### PR TITLE
Add options to deploy command to specify access information in commandline

### DIFF
--- a/bin/fun.js
+++ b/bin/fun.js
@@ -27,11 +27,11 @@ program.command('validate')
 
 program.command('deploy')
   .description('Deploy a project to AliCloud')
-  .option('-k, --accessKeyId [access key id]', '')
-  .option('-s, --accessKeySecret [access key id]', '')
-  .option('-i, --accountId [account id]', '')
-  .option('-r, --defaultRegion [region]', '')
-  .option('-t, --timeout [timeout]', '')
+  .option('-k, --accessKeyId [access key id]')
+  .option('-s, --accessKeySecret [access key id]')
+  .option('-i, --accountId [account id]')
+  .option('-r, --defaultRegion [region]')
+  .option('-t, --timeout [timeout]')
   .action((stage, options)=> {
     if (typeof stage === 'object') {
       options = stage;

--- a/bin/fun.js
+++ b/bin/fun.js
@@ -33,6 +33,10 @@ program.command('deploy')
   .option('-r, --defaultRegion [region]', '')
   .option('-t, --timeout [timeout]', '')
   .action((stage, options)=> {
+    if (typeof stage === 'object') {
+      options = stage;
+      stage = undefined;
+    }
     require('../lib/commands/deploy')(stage, options).catch(handle);
   });
 

--- a/bin/fun.js
+++ b/bin/fun.js
@@ -27,8 +27,13 @@ program.command('validate')
 
 program.command('deploy')
   .description('Deploy a project to AliCloud')
-  .action((stage)=> {
-    require('../lib/commands/deploy')(stage).catch(handle);
+  .option('-k, --accessKeyId [access key id]', '')
+  .option('-s, --accessKeySecret [access key id]', '')
+  .option('-i, --accountId [account id]', '')
+  .option('-r, --defaultRegion [region]', '')
+  .option('-t, --timeout [timeout]', '')
+  .action((stage, options)=> {
+    require('../lib/commands/deploy')(stage, options).catch(handle);
   });
 
 program.command('build')

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -12,7 +12,7 @@ async function detectTplPath() {
     .find(async (p) => (await exists(p)));
 }
 
-async function deploy(stage, tplPath) {
+async function deploy(stage, options, tplPath) {
 
   if (!tplPath) {
     tplPath = await detectTplPath();
@@ -23,7 +23,7 @@ async function deploy(stage, tplPath) {
     console.log('The folder must contains template.[yml|yaml] or faas.[yml|yaml] .');
     process.exit(-1);
   } else if (path.basename(tplPath).startsWith('template')) {
-    await require('../deploy/deploy-by-tpl')(tplPath);
+    await require('../deploy/deploy-by-tpl')(tplPath, options);
   } else if (path.basename(tplPath).startsWith('faas')) {
     await require('../deploy/deploy-by-faas')(stage);
   } else {

--- a/lib/deploy/deploy-by-tpl.js
+++ b/lib/deploy/deploy-by-tpl.js
@@ -91,13 +91,11 @@ async function deployFunctions(serviceName, serviceDefinition) {
   }
 }
 
-async function deployPolicy(serviceName, roleName, policy, curCount) {
+async function deployPolicy(serviceName, roleName, policy, curCount, profile) {
   if (typeof policy === 'string') {
     await attachPolicyToRole(policy, roleName);
     return curCount;
   } 
-
-  const profile = await getProfile();
 
   const policyName = `AliyunFcGeneratedServicePolicy-${profile.defaultRegion}-${serviceName}${curCount}`;
   
@@ -107,20 +105,20 @@ async function deployPolicy(serviceName, roleName, policy, curCount) {
   
 }
 
-async function deployPolicies(serviceName, roleName, policies) {
+async function deployPolicies(serviceName, roleName, policies, profile) {
 
   let nextCount = 1;
 
   if (Array.isArray(policies)) {
     for (let policy of policies) {
-      nextCount = await deployPolicy(serviceName, roleName, policy, nextCount);
+      nextCount = await deployPolicy(serviceName, roleName, policy, nextCount, profile);
     }
   } else {
-    nextCount = await deployPolicy(serviceName, roleName, policies, nextCount);
+    nextCount = await deployPolicy(serviceName, roleName, policies, nextCount, profile);
   }
 }
 
-async function deployFcService(serviceName, serviceDefinition) {
+async function deployFcService(serviceName, serviceDefinition, profile) {
   const properties = (serviceDefinition.Properties || {});
   const roleArn = properties.Role;
   const internetAccess = 'InternetAccess' in properties ? properties.InternetAccess : null;
@@ -129,8 +127,6 @@ async function deployFcService(serviceName, serviceDefinition) {
   const logConfig = properties.LogConfig || {};
   let roleName;
   let createRoleIfNotExist;
-
-  const profile = await getProfile();
 
   if ( roleArn ) {
     roleName = extractFcRole(roleArn);
@@ -383,8 +379,23 @@ async function deployApigateway(name, { apiDefinition, template, tplPath }) {
 
 }
 
-async function deploy(tplPath) {
+async function validateOptions (options) {
+  return options.accessKeyID !== undefined && options.accessKeySecret !== undefined && options.accessKeySecret !== undefined;
+}
 
+async function buildProfileFromOptions (options) {
+  const isValid = await validateOptions(options);
+  if (!isValid) {return undefined;}
+  return {
+    accessKeyID: options.accessKeyID,
+    accessKeySecret: options.accessKeySecret,
+    accountId: options.accountId,
+    defaultRegion: options.defaultRegion,
+    timeout: options.timeout
+  };
+}
+
+async function deploy(tplPath, options) {
   const { valid, ajv } = await validate(tplPath);
 
   if (!valid) {
@@ -393,13 +404,14 @@ async function deploy(tplPath) {
   }
 
   const tpl = await getTpl(tplPath);
+  const profile = await buildProfileFromOptions(options) || await getProfile();
 
   await deployLogs(tpl.Resources);
 
   for (const [name, resource] of Object.entries(tpl.Resources)) {
     if (resource.Type === 'Aliyun::Serverless::Service') {
       console.log(`Waiting for service ${name} to be deployed...`);
-      await deployFcService(name, resource);
+      await deployFcService(name, resource, profile);
       console.log(green(`service ${name} deploy success\n` ));
     } else if (resource.Type === 'Aliyun::Serverless::Api') {
       console.log(`Waiting for api gateway ${name} to be deployed...`);

--- a/lib/deploy/deploy-by-tpl.js
+++ b/lib/deploy/deploy-by-tpl.js
@@ -380,14 +380,14 @@ async function deployApigateway(name, { apiDefinition, template, tplPath }) {
 }
 
 async function validateOptions (options) {
-  return options.accessKeyID !== undefined && options.accessKeySecret !== undefined && options.accessKeySecret !== undefined;
+  return options.accessKeyId !== undefined && options.accessKeySecret !== undefined && options.accountId !== undefined && options.defaultRegion !== undefined;
 }
 
 async function buildProfileFromOptions (options) {
   const isValid = await validateOptions(options);
   if (!isValid) {return undefined;}
   return {
-    accessKeyID: options.accessKeyID,
+    accessKeyId: options.accessKeyId,
     accessKeySecret: options.accessKeySecret,
     accountId: options.accountId,
     defaultRegion: options.defaultRegion,

--- a/test/deploy/deploy-by-tpl.test.js
+++ b/test/deploy/deploy-by-tpl.test.js
@@ -32,10 +32,11 @@ describe('deploy', () => {
   });
 
   async function deploy(example) {
+    const options = {};
     await proxyquire('../../lib/deploy/deploy-by-tpl', {
       './deploy-support': deploySupport,
       '../ram': ram
-    })(`./examples/${example}/template.yml`);
+    })(`./examples/${example}/template.yml`, options);
 
     // await proxyquire('../../lib/deploy/deploy-support', {
       


### PR DESCRIPTION
Hi, developers,

I’d like to deploy test and production environments at the same time on a CI service. But it does not work well because `fun` only supports one set of environment variables.

So I add options to `fun deploy` to specify access keys.

# In short
* Deploy by using `fun` on a CI service
* Deploy to test environment  at the same time to perform integration tests
* Need to specify 2 access keys