### PR TITLE
add fun import API

### DIFF
--- a/lib/import/constants.js
+++ b/lib/import/constants.js
@@ -1,16 +1,10 @@
 'use strict';
 
-const TEMPLATE_HEADER = {
-  ROSTemplateFormatVersion: '2015-09-01',
-  Transform: 'Aliyun::Serverless-2018-04-03',
-  Resources: {}
-};
-
 const SERVICE_TYPE = 'Aliyun::Serverless::Service';
 const CUSTOM_DOMAIN_TYPE = 'Aliyun::Serverless::CustomDomain';
 const FUNCTION_TYPE = 'Aliyun::Serverless::Function';
 
 
 module.exports = {
-  TEMPLATE_HEADER, SERVICE_TYPE, CUSTOM_DOMAIN_TYPE, FUNCTION_TYPE
+  SERVICE_TYPE, CUSTOM_DOMAIN_TYPE, FUNCTION_TYPE
 };

--- a/lib/import/constants.js
+++ b/lib/import/constants.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const TEMPLATE_HEADER = {
+  ROSTemplateFormatVersion: '2015-09-01',
+  Transform: 'Aliyun::Serverless-2018-04-03',
+  Resources: {}
+};
+
+const SERVICE_TYPE = 'Aliyun::Serverless::Service';
+const CUSTOM_DOMAIN_TYPE = 'Aliyun::Serverless::CustomDomain';
+const FUNCTION_TYPE = 'Aliyun::Serverless::Function';
+
+
+module.exports = {
+  TEMPLATE_HEADER, SERVICE_TYPE, CUSTOM_DOMAIN_TYPE, FUNCTION_TYPE
+};

--- a/lib/import/custom-domain-parser.js
+++ b/lib/import/custom-domain-parser.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { doProp } = require('./utils');
+const { CUSTOM_DOMAIN_TYPE } = require('./constants');
+
+function isNotEmptyCertConfigConfig(certConfig) {
+  return certConfig && certConfig.certName;
+}
+
+function parseCustomDomainResource(customDomainMeta) {
+  const customDomainResource = {
+    Type: CUSTOM_DOMAIN_TYPE,
+    Properties: {}
+  };
+  const properties = customDomainResource.Properties;
+  doProp(properties, 'Protocol', customDomainMeta.protocol);
+  doProp(properties, 'RouteConfig', {
+    Routes: {}
+  });
+  for (const route of customDomainMeta.routeConfig.routes) {
+    properties.RouteConfig.Routes[route.path] = {
+      ServiceName: route.serviceName,
+      FunctionName: route.functionName
+    }
+  }
+  const certConfig = customDomainMeta.certConfig;
+  if (isNotEmptyCertConfigConfig(certConfig)) {
+    doProp(properties, 'CertConfig', {
+      CertName: certConfig.certName,
+      PrivateKey: certConfig.privateKey,
+      Certificate: certConfig.certificate
+    });
+  }
+
+  return customDomainResource;
+}
+
+module.exports = {
+  parseCustomDomainResource
+};

--- a/lib/import/custom-domain-parser.js
+++ b/lib/import/custom-domain-parser.js
@@ -3,8 +3,8 @@
 const { doProp } = require('./utils');
 const { CUSTOM_DOMAIN_TYPE } = require('./constants');
 
-function isNotEmptyCertConfigConfig(certConfig) {
-  return certConfig && certConfig.certName;
+function isCertConfigConfigNotEmpty(certConfig) {
+  return !!(certConfig && certConfig.certName);
 }
 
 function parseCustomDomainResource(customDomainMeta) {
@@ -21,10 +21,10 @@ function parseCustomDomainResource(customDomainMeta) {
     properties.RouteConfig.Routes[route.path] = {
       ServiceName: route.serviceName,
       FunctionName: route.functionName
-    }
+    };
   }
   const certConfig = customDomainMeta.certConfig;
-  if (isNotEmptyCertConfigConfig(certConfig)) {
+  if (isCertConfigConfigNotEmpty(certConfig)) {
     doProp(properties, 'CertConfig', {
       CertName: certConfig.certName,
       PrivateKey: certConfig.privateKey,

--- a/lib/import/custom-domain.js
+++ b/lib/import/custom-domain.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const { getFcClient } = require('../client');
-const { TEMPLATE_HEADER } = require('./constants');
-const { getTemplateFile, checkResource, outputTemplateFile } = require('./utils');
+const { getTemplateFile, checkResource, outputTemplateFile, getTemplateHeader } = require('./utils');
 const { parseCustomDomainResource } = require('./custom-domain-parser');
 const path = require('path');
 const debug = require('debug')('fun:import:custom-domain');
@@ -20,13 +19,13 @@ async function listCustomDomainMetas() {
   return data.customDomains;
 }
 
-function checkCustomDomain(customDomainMetas, content, existsSkip) {
+function checkCustomDomain(customDomainMetas, content, skipIfExists) {
   for (const customDomainMeta of customDomainMetas) {
     try {
       checkResource(customDomainMeta.customDomain, content);
       customDomainMeta.exists = false;
     } catch (error) {
-      if (!existsSkip) {
+      if (!skipIfExists) {
         throw error;
       }
       customDomainMeta.exists = true;
@@ -34,7 +33,7 @@ function checkCustomDomain(customDomainMetas, content, existsSkip) {
   }
 }
 
-async function importCustomDomain(domainName, outputDir = '.', existsSkip = true) {
+async function importCustomDomain(domainName, outputDir = '.', skipIfExists = true) {
   console.log('\nImport custom domain resources: ');
   let customDomainMetas = [];
   if (domainName) {
@@ -59,13 +58,13 @@ async function importCustomDomain(domainName, outputDir = '.', existsSkip = true
     content = templateFile.content;
     templateFilePath = templateFile.templateFilePath;
   } else {
-    content = { ...TEMPLATE_HEADER };
+    content = getTemplateHeader();
     templateFilePath = path.resolve(fullOutputDir, 'template.yml');
   }
 
-  checkCustomDomain(customDomainMetas, content, existsSkip);
+  checkCustomDomain(customDomainMetas, content, skipIfExists);
   for (const customDomainMeta of customDomainMetas) {
-    const customDomain = customDomainMeta.customDomain
+    const customDomain = customDomainMeta.customDomain;
     if (customDomainMeta.exists) {
       console.log(`${yellow('skip')} ${customDomain} - ${grey('Custom Domain')}`);
     } else {

--- a/lib/import/custom-domain.js
+++ b/lib/import/custom-domain.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const { getFcClient } = require('../client');
+const { TEMPLATE_HEADER } = require('./constants');
+const { getTemplateFile, checkResource, outputTemplateFile } = require('./utils');
+const { parseCustomDomainResource } = require('./custom-domain-parser');
+const path = require('path');
+const debug = require('debug')('fun:import:custom-domain');
+const { green, grey, yellow } = require('colors');
+
+async function getCustomDomainMeta(domainName) {
+  const fc = await getFcClient();
+  const { data } = await fc.getCustomDomain(domainName);
+  return data;
+}
+
+async function listCustomDomainMetas() {
+  const fc = await getFcClient();
+  const { data } = await fc.listCustomDomains();
+  return data.customDomains;
+}
+
+function checkCustomDomain(customDomainMetas, content, existsSkip) {
+  for (const customDomainMeta of customDomainMetas) {
+    try {
+      checkResource(customDomainMeta.customDomain, content);
+      customDomainMeta.exists = false;
+    } catch (error) {
+      if (!existsSkip) {
+        throw error;
+      }
+      customDomainMeta.exists = true;
+    }
+  }
+}
+
+async function importCustomDomain(domainName, outputDir = '.', existsSkip = true) {
+  console.log('\nImport custom domain resources: ');
+  let customDomainMetas = [];
+  if (domainName) {
+    const customDomainMeta = await getCustomDomainMeta(domainName);
+    customDomainMetas.push(customDomainMeta);
+  } else {
+    customDomainMetas = await listCustomDomainMetas(domainName);
+  }
+  if (customDomainMetas.length === 0) {
+    console.log(yellow('No custom domain name resources found.\n'));
+    return;
+  }
+  const fullOutputDir = path.resolve(process.cwd(), outputDir);
+  debug('Output Dir: %s', fullOutputDir);
+  const templateFile = getTemplateFile(fullOutputDir);
+  debug('Custom domain metadata: %s', customDomainMetas);
+
+  let content;
+  let templateFilePath;
+
+  if (templateFile) {
+    content = templateFile.content;
+    templateFilePath = templateFile.templateFilePath;
+  } else {
+    content = { ...TEMPLATE_HEADER };
+    templateFilePath = path.resolve(fullOutputDir, 'template.yml');
+  }
+
+  checkCustomDomain(customDomainMetas, content, existsSkip);
+  for (const customDomainMeta of customDomainMetas) {
+    const customDomain = customDomainMeta.customDomain
+    if (customDomainMeta.exists) {
+      console.log(`${yellow('skip')} ${customDomain} - ${grey('Custom Domain')}`);
+    } else {
+      content.Resources[customDomain] = parseCustomDomainResource(customDomainMeta);
+      console.log(`${green('✔')} ${customDomain} - ${grey('Custom Domain')}`);
+    }
+  }
+  
+  outputTemplateFile(templateFilePath, content);
+  console.log('Custom domain import finished\n');
+}
+
+module.exports = {
+  importCustomDomain
+};

--- a/lib/import/function-parser.js
+++ b/lib/import/function-parser.js
@@ -10,9 +10,9 @@ function parseFunctionResource(functionMeta) {
   };
   const properties = functionResource.Properties;
   doProp(properties, 'Description', functionMeta.description);
-  doProp(properties, 'initializer', functionMeta.initializer);
+  doProp(properties, 'Initializer', functionMeta.initializer);
   if (functionMeta.initializer) {
-    doProp(properties, 'initializationTimeout', functionMeta.initializationTimeout);
+    doProp(properties, 'InitializationTimeout', functionMeta.initializationTimeout);
   }
   doProp(properties, 'Handler', functionMeta.handler);
   doProp(properties, 'Runtime', functionMeta.runtime);

--- a/lib/import/function-parser.js
+++ b/lib/import/function-parser.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { doProp } = require('./utils');
+const { FUNCTION_TYPE } = require('./constants');
+
+function parseFunctionResource(functionMeta) {
+  const functionResource = {
+    Type: FUNCTION_TYPE,
+    Properties: {}
+  };
+  const properties = functionResource.Properties;
+  doProp(properties, 'Description', functionMeta.description);
+  doProp(properties, 'initializer', functionMeta.initializer);
+  if (functionMeta.initializer) {
+    doProp(properties, 'initializationTimeout', functionMeta.initializationTimeout);
+  }
+  doProp(properties, 'Handler', functionMeta.handler);
+  doProp(properties, 'Runtime', functionMeta.runtime);
+  doProp(properties, 'Timeout', functionMeta.timeout);
+  doProp(properties, 'MemorySize', functionMeta.memorySize);
+  doProp(properties, 'EnvironmentVariables', functionMeta.environmentVariables);
+
+  return functionResource;
+}
+
+module.exports = {
+  parseFunctionResource
+};

--- a/lib/import/function.js
+++ b/lib/import/function.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { getFcClient } = require('../client');
+const { TEMPLATE_HEADER, SERVICE_TYPE } = require('./constants');
+const { getTemplateFile, checkResource, outputTemplateFile } = require('./utils');
+const { getFunctionResource, getServiceResource } = require('./service');
+const path = require('path');
+const debug = require('debug')('fun:import:function');
+const { green, red } = require('colors');
+
+async function getFuncitonMeta(serviceName, functionName) {
+  const fc = await getFcClient();
+  const { data } = await fc.getFunction(serviceName, functionName);
+  return data;
+}
+
+function existsService(serviceName, content) {
+  if (!content.Resources) {
+    throw new Error(red('The template file format in the current directory is incorrect.'));
+  }
+  const service = content.Resources[serviceName];
+  if (service && service.Type === SERVICE_TYPE) {
+    if (service.Type === SERVICE_TYPE) {
+      return true;
+    }
+    throw new Error(red(`The resource that needs to be imported already exists: ${serviceName}, type: ${service.Type}.`));
+  }
+  return false;
+}
+
+function checkFunction(serviceName, functionName, content) {
+  const service = content.Resources[serviceName];
+  if (service[functionName]) {
+    throw new Error(red(`The resource that needs to be imported already exists: ${serviceName}/${functionName}.`));
+  }
+}
+
+async function importFunction(serviceName, functionName, outputDir = '.', recursive = true, onlyConfig = false) {
+  console.log('\nImport function resources:');
+  const fullOutputDir = path.resolve(process.cwd(), outputDir);
+  debug('Output Dir: %s', fullOutputDir);
+  const templateFile = getTemplateFile(fullOutputDir);
+  const functionMeta = await getFuncitonMeta(serviceName, functionName);
+  debug('Function metadata: %s', functionMeta);
+
+  let content;
+  let serviceResource;
+  let templateFilePath;
+
+  serviceResource = await getServiceResource(serviceName, fullOutputDir, false, onlyConfig);
+
+  if (templateFile) {
+    content = templateFile.content;
+    templateFilePath = templateFile.templateFilePath;
+
+    if (existsService(serviceName, content)) {
+      checkFunction(serviceName, functionName, content);
+      content.Resources[serviceName] = { ...content.Resources[serviceName], serviceResource };
+      serviceResource = content.Resources[serviceName];
+    } else {
+      checkResource();
+    }
+  } else {
+    content = { ...TEMPLATE_HEADER };
+    templateFilePath = path.resolve(fullOutputDir, 'template.yml');
+  }
+
+  const functionResource = await getFunctionResource(serviceName, functionMeta, fullOutputDir, recursive, onlyConfig);
+  serviceResource[functionName] = functionResource;
+  content.Resources[serviceName] = serviceResource;
+  outputTemplateFile(templateFilePath, content);
+  console.log('Function import finished\n');
+}
+
+module.exports = {
+  importFunction
+};

--- a/lib/import/function.js
+++ b/lib/import/function.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const { getFcClient } = require('../client');
-const { TEMPLATE_HEADER, SERVICE_TYPE } = require('./constants');
-const { getTemplateFile, checkResource, outputTemplateFile } = require('./utils');
-const { getFunctionResource, getServiceResource } = require('./service');
+const { SERVICE_TYPE } = require('./constants');
+const { getTemplateFile, checkResource, outputTemplateFile, getTemplateHeader } = require('./utils');
+const { getFunctionResource, getServiceResource, getServiceMeta } = require('./service');
 const path = require('path');
 const debug = require('debug')('fun:import:function');
-const { green, red } = require('colors');
+const { red } = require('colors');
 
 async function getFuncitonMeta(serviceName, functionName) {
   const fc = await getFcClient();
@@ -47,7 +47,8 @@ async function importFunction(serviceName, functionName, outputDir = '.', recurs
   let serviceResource;
   let templateFilePath;
 
-  serviceResource = await getServiceResource(serviceName, fullOutputDir, false, onlyConfig);
+  const serviceMeta = await getServiceMeta(serviceName);
+  serviceResource = await getServiceResource(serviceMeta, fullOutputDir, false, onlyConfig);
 
   if (templateFile) {
     content = templateFile.content;
@@ -55,13 +56,13 @@ async function importFunction(serviceName, functionName, outputDir = '.', recurs
 
     if (existsService(serviceName, content)) {
       checkFunction(serviceName, functionName, content);
-      content.Resources[serviceName] = { ...content.Resources[serviceName], serviceResource };
+      Object.assign(content.Resources[serviceName], serviceResource);
       serviceResource = content.Resources[serviceName];
     } else {
-      checkResource();
+      checkResource(serviceName, content);
     }
   } else {
-    content = { ...TEMPLATE_HEADER };
+    content = getTemplateHeader();
     templateFilePath = path.resolve(fullOutputDir, 'template.yml');
   }
 

--- a/lib/import/service-parser.js
+++ b/lib/import/service-parser.js
@@ -3,16 +3,16 @@
 const { doProp } = require('./utils');
 const { SERVICE_TYPE } = require('./constants');
 
-function isNotEmptyVpcConfig(vpcConfig) {
-  return vpcConfig && vpcConfig.vpcId;
+function isVpcConfigNotEmpty(vpcConfig) {
+  return !!(vpcConfig && vpcConfig.vpcId);
 }
 
-function isNotEmptyNasConfig(nasConfig) {
-  return nasConfig && nasConfig.mountPoints && nasConfig.mountPoints.length > 0;
+function isNasConfigNotEmpty(nasConfig) {
+  return !!(nasConfig && nasConfig.mountPoints && nasConfig.mountPoints.length > 0);
 }
 
-function isNotEmptyLogConfig(logConfig) {
-  return logConfig && logConfig.project;
+function isLogConfigNotEmpty(logConfig) {
+  return !!(logConfig && logConfig.project);
 }
 
 function parseServiceResource(serviceMeta) {
@@ -24,7 +24,7 @@ function parseServiceResource(serviceMeta) {
   doProp(properties, 'Description', serviceMeta.description);
   doProp(properties, 'Role', serviceMeta.role);
   const logConfig = serviceMeta.logConfig;
-  if (isNotEmptyLogConfig(logConfig)) {
+  if (isLogConfigNotEmpty(logConfig)) {
     doProp(properties, 'LogConfig', {
       Project: logConfig.project,
       Logstore: logConfig.logstore
@@ -32,7 +32,7 @@ function parseServiceResource(serviceMeta) {
   }
 
   const vpcConfig = serviceMeta.vpcConfig;
-  if (isNotEmptyVpcConfig(vpcConfig)) {
+  if (isVpcConfigNotEmpty(vpcConfig)) {
     doProp(properties, 'VpcConfig', {
       VpcId: vpcConfig.vpcId,
       VSwitchIds: vpcConfig.vSwitchIds,
@@ -41,7 +41,7 @@ function parseServiceResource(serviceMeta) {
   }
 
   const nasConfig = serviceMeta.nasConfig;
-  if (isNotEmptyNasConfig(nasConfig)) {
+  if (isNasConfigNotEmpty(nasConfig)) {
     doProp(properties, 'NasConfig', {
       UserId: nasConfig.userId,
       GroupId: nasConfig.groupId,

--- a/lib/import/service-parser.js
+++ b/lib/import/service-parser.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const { doProp } = require('./utils');
+const { SERVICE_TYPE } = require('./constants');
+
+function isNotEmptyVpcConfig(vpcConfig) {
+  return vpcConfig && vpcConfig.vpcId;
+}
+
+function isNotEmptyNasConfig(nasConfig) {
+  return nasConfig && nasConfig.mountPoints && nasConfig.mountPoints.length > 0;
+}
+
+function isNotEmptyLogConfig(logConfig) {
+  return logConfig && logConfig.project;
+}
+
+function parseServiceResource(serviceMeta) {
+  const serviceResource = {
+    Type: SERVICE_TYPE,
+    Properties: {}
+  };
+  const properties = serviceResource.Properties;
+  doProp(properties, 'Description', serviceMeta.description);
+  doProp(properties, 'Role', serviceMeta.role);
+  const logConfig = serviceMeta.logConfig;
+  if (isNotEmptyLogConfig(logConfig)) {
+    doProp(properties, 'LogConfig', {
+      Project: logConfig.project,
+      Logstore: logConfig.logstore
+    });
+  }
+
+  const vpcConfig = serviceMeta.vpcConfig;
+  if (isNotEmptyVpcConfig(vpcConfig)) {
+    doProp(properties, 'VpcConfig', {
+      VpcId: vpcConfig.vpcId,
+      VSwitchIds: vpcConfig.vSwitchIds,
+      SecurityGroupId: vpcConfig.securityGroupId
+    });
+  }
+
+  const nasConfig = serviceMeta.nasConfig;
+  if (isNotEmptyNasConfig(nasConfig)) {
+    doProp(properties, 'NasConfig', {
+      UserId: nasConfig.userId,
+      GroupId: nasConfig.groupId,
+      MountPoints: nasConfig.mountPoints.map(p => ({ ServerAddr: p.serverAddr, MountDir: p.mountDir }))
+    });
+  }
+  properties.InternetAccess = serviceMeta.internetAccess;
+
+  return serviceResource;
+}
+
+module.exports = {
+  parseServiceResource
+};

--- a/lib/import/service.js
+++ b/lib/import/service.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const { TEMPLATE_HEADER } = require('./constants');
+const { getFcClient } = require('../client');
+const {
+  getTemplateFile,
+  makeSurePathExists,
+  getCodeUri,
+  checkResource,
+  outputTemplateFile,
+  createProgressBar } = require('./utils');
+const { parseServiceResource } = require('./service-parser');
+const { parseFunctionResource } = require('./function-parser');
+const { parseTriggerResource } = require('./trigger-parser');
+const httpx = require('httpx');
+const path = require('path');
+const unzipper = require('unzipper');
+const debug = require('debug')('fun:import:service');
+const { green, grey } = require('colors');
+
+async function getServiceMeta(serviceName) {
+  const fc = await getFcClient();
+  const { data } = await fc.getService(serviceName);
+  return data;
+}
+
+async function getFunctionMetas(serviceName) {
+  const fc = await getFcClient();
+  const { data } = await fc.listFunctions(serviceName);
+  return data.functions;
+}
+
+async function getTriggerMetas(serviceName, functionName) {
+  const fc = await getFcClient();
+  const { data } = await fc.listTriggers(serviceName, functionName);
+  return data.triggers;
+}
+
+async function getFunctionResource(serviceName, functionMeta, fullOutputDir, recursive, onlyConfig) {
+  const functionResource = parseFunctionResource(functionMeta);
+  const functionName = functionMeta.functionName;
+  if (!onlyConfig) {
+    await outputFunctionCode(serviceName, functionName, fullOutputDir);
+    functionResource.Properties.CodeUri = getCodeUri(serviceName, functionName);
+  }
+
+  if (recursive) {
+    const triggerMetas = await getTriggerMetas(serviceName, functionName);
+    if (triggerMetas && triggerMetas.length > 0) {
+      functionResource.Events = {};
+      for (const triggerMeta of triggerMetas) {
+        debug('Trigger metadata: %s', triggerMeta);
+        functionResource.Events[triggerMeta.triggerName] = parseTriggerResource(triggerMeta);
+        console.log(`        ${green('✔')} ${triggerMeta.triggerName} - ${grey('Trigger')}`);
+      }
+    }
+  }
+  return functionResource;
+}
+
+async function outputFunctionCode(serviceName, functionName, fullOutputDir) {
+  const fc = await getFcClient();
+  const { data } = await fc.getFunctionCode(serviceName, functionName);
+  const response = await httpx.request(data.url);
+  var len = parseInt(response.headers['content-length'], 10);
+  const bar = createProgressBar(`${green(':loading')} ${functionName} downloading :bar :rate/bps :percent :etas`, { total: len });
+  response.on('data', (chunk) => {
+    bar.tick(chunk.length);
+  });
+  response.on('end', () => {
+    console.log(`    ${green('✔')} ${functionName} - ${grey('Function')}`);
+  });
+  const fullTargetCodeDir = path.join(fullOutputDir, serviceName, functionName);
+  makeSurePathExists(fullTargetCodeDir);
+  return new Promise((resolve, reject) => {
+    response.pipe(unzipper.Extract({ path: fullTargetCodeDir })).on('error', reject).on('finish', resolve);
+  });
+
+}
+
+async function getServiceResource(serviceName, fullOutputDir, recursive, onlyConfig, override) {
+  const serviceMeta = await getServiceMeta(serviceName);
+  debug('Service metadata: %s', serviceMeta);
+  const serviceResource = parseServiceResource(serviceMeta);
+  console.log(`${green('✔')} ${serviceName} - ${grey('Service')}`);
+
+  if (recursive) {
+    const functionMetas = await getFunctionMetas(serviceName);
+    if (functionMetas && functionMetas.length > 0) {
+      for (const functionMeta of functionMetas) {
+        debug('Function metadata: %s', functionMeta);
+        const functionName = functionMeta.functionName;
+        const functionResource = await getFunctionResource(serviceName, functionMeta, fullOutputDir, recursive, onlyConfig);
+        serviceResource[functionName] = functionResource;
+      }
+    }
+  }
+  return serviceResource;
+}
+
+async function importService(serviceName, outputDir = '.', recursive = true, onlyConfig = false) {
+  console.log('\nImport service resources: ');
+  const fullOutputDir = path.resolve(process.cwd(), outputDir);
+  debug('Output Dir: %s', fullOutputDir);
+  const templateFile = getTemplateFile(fullOutputDir);
+
+  let content;
+  let templateFilePath;
+
+  if (templateFile) {
+    content = templateFile.content;
+    templateFilePath = templateFile.templateFilePath;
+    checkResource(serviceName, content);
+  } else {
+    content = { ...TEMPLATE_HEADER };
+    templateFilePath = path.resolve(fullOutputDir, 'template.yml');
+  }
+
+  const serviceResource = await getServiceResource(serviceName, fullOutputDir, recursive, onlyConfig);
+  content.Resources[serviceName] = serviceResource;
+  outputTemplateFile(templateFilePath, content);
+  console.log('Service import finished\n')
+}
+
+module.exports = {
+  getFunctionResource, outputFunctionCode, getServiceResource, importService
+};

--- a/lib/import/service.js
+++ b/lib/import/service.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { TEMPLATE_HEADER } = require('./constants');
 const { getFcClient } = require('../client');
 const {
   getTemplateFile,
@@ -8,6 +7,7 @@ const {
   getCodeUri,
   checkResource,
   outputTemplateFile,
+  getTemplateHeader,
   createProgressBar } = require('./utils');
 const { parseServiceResource } = require('./service-parser');
 const { parseFunctionResource } = require('./function-parser');
@@ -16,13 +16,20 @@ const httpx = require('httpx');
 const path = require('path');
 const unzipper = require('unzipper');
 const debug = require('debug')('fun:import:service');
-const { green, grey } = require('colors');
+const { green, grey, yellow } = require('colors');
 
 async function getServiceMeta(serviceName) {
   const fc = await getFcClient();
   const { data } = await fc.getService(serviceName);
   return data;
 }
+
+async function listServiceMetas() {
+  const fc = await getFcClient();
+  const { data } = await fc.listServices();
+  return data.services;
+}
+
 
 async function getFunctionMetas(serviceName) {
   const fc = await getFcClient();
@@ -42,6 +49,8 @@ async function getFunctionResource(serviceName, functionMeta, fullOutputDir, rec
   if (!onlyConfig) {
     await outputFunctionCode(serviceName, functionName, fullOutputDir);
     functionResource.Properties.CodeUri = getCodeUri(serviceName, functionName);
+  } else {
+    console.log(`    ${green('✔')} ${functionName} - ${grey('Function')}`);
   }
 
   if (recursive) {
@@ -78,9 +87,9 @@ async function outputFunctionCode(serviceName, functionName, fullOutputDir) {
 
 }
 
-async function getServiceResource(serviceName, fullOutputDir, recursive, onlyConfig, override) {
-  const serviceMeta = await getServiceMeta(serviceName);
+async function getServiceResource(serviceMeta, fullOutputDir, recursive, onlyConfig) {
   debug('Service metadata: %s', serviceMeta);
+  const serviceName = serviceMeta.serviceName;
   const serviceResource = parseServiceResource(serviceMeta);
   console.log(`${green('✔')} ${serviceName} - ${grey('Service')}`);
 
@@ -98,10 +107,36 @@ async function getServiceResource(serviceName, fullOutputDir, recursive, onlyCon
   return serviceResource;
 }
 
-async function importService(serviceName, outputDir = '.', recursive = true, onlyConfig = false) {
+function checkService(serviceMetas, content, skipIfExists) {
+  for (const serviceMeta of serviceMetas) {
+    try {
+      checkResource(serviceMeta.serviceName, content);
+      serviceMeta.exists = false;
+    } catch (error) {
+      if (!skipIfExists) {
+        throw error;
+      }
+      serviceMeta.exists = true;
+    }
+  }
+}
+
+async function importService(serviceName, outputDir = '.', recursive = true, onlyConfig = false, skipIfExists = true) {
   console.log('\nImport service resources: ');
+  let serviceMetas = [];
+  if (serviceName) {
+    const serviceMeta = await getServiceMeta(serviceName);
+    serviceMetas.push(serviceMeta);
+  } else {
+    serviceMetas = await listServiceMetas();
+  }
+  if (serviceMetas.length === 0) {
+    console.log(yellow('No service resources found.\n'));
+    return;
+  }
   const fullOutputDir = path.resolve(process.cwd(), outputDir);
   debug('Output Dir: %s', fullOutputDir);
+  debug('Custom domain metadata: %s', serviceMetas);
   const templateFile = getTemplateFile(fullOutputDir);
 
   let content;
@@ -112,16 +147,24 @@ async function importService(serviceName, outputDir = '.', recursive = true, onl
     templateFilePath = templateFile.templateFilePath;
     checkResource(serviceName, content);
   } else {
-    content = { ...TEMPLATE_HEADER };
+    content = getTemplateHeader();
     templateFilePath = path.resolve(fullOutputDir, 'template.yml');
   }
 
-  const serviceResource = await getServiceResource(serviceName, fullOutputDir, recursive, onlyConfig);
-  content.Resources[serviceName] = serviceResource;
+  checkService(serviceMetas, content, skipIfExists);
+  for (const serviceMeta of serviceMetas) {
+    const serviceName = serviceMeta.serviceName;
+    if (serviceMeta.exists) {
+      console.log(`${yellow('skip')} ${serviceName} - ${grey('Service')}`);
+    } else {
+      content.Resources[serviceName] = await getServiceResource(serviceMeta, fullOutputDir, recursive, onlyConfig);
+    }
+  }
+
   outputTemplateFile(templateFilePath, content);
-  console.log('Service import finished\n')
+  console.log('Service import finished\n');
 }
 
 module.exports = {
-  getFunctionResource, outputFunctionCode, getServiceResource, importService
+  getFunctionResource, outputFunctionCode, getServiceResource, importService, getServiceMeta
 };

--- a/lib/import/trigger-parser.js
+++ b/lib/import/trigger-parser.js
@@ -13,7 +13,7 @@ function doParseOSSTriggerConfig(triggerResource, triggerConfig) {
         Prefix: filter.key.prefix,
         Suffix: filter.key.suffix
       }
-    }
+    };
   }
 }
 
@@ -29,11 +29,11 @@ function doParseLogTriggerConfig(triggerResource, triggerConfig) {
   const properties = triggerResource.Properties;
   properties.SourceConfig = {
     Logstore: triggerConfig.sourceConfig.logstore
-  }
+  };
   properties.JobConfig = {
     MaxRetryTime: triggerConfig.jobConfig.maxRetryTime,
     TriggerInterval: triggerConfig.jobConfig.triggerInterval
-  }
+  };
 }
 
 function doParseMNSTopicTriggerConfig(triggerResource, triggerConfig) {
@@ -77,7 +77,7 @@ function doParseCDNTriggerConfig(triggerResource, triggerConfig) {
   doProp(properties, 'EventName', triggerConfig.eventName);
   doProp(properties, 'EventVersion', triggerConfig.eventVersion);
   doProp(properties, 'Notes', triggerConfig.notes);
-  const filter = serviceMeta.filter;
+  const filter = triggerResource.filter;
   if (filter) {
     properties.Filter = {
       Domain: filter.domain
@@ -90,7 +90,7 @@ function parseTriggerResource(triggerMeta) {
   const triggerResource = {
     Type: '',
     Properties: {}
-  }
+  };
   const properties = triggerResource.Properties;
   doProp(properties, 'InvocationRole', triggerMeta.invocationRole);
   doProp(properties, 'SourceArn', triggerMeta.sourceArn);
@@ -114,7 +114,7 @@ function parseTriggerResource(triggerMeta) {
   } else {
     throw new Error(`Trigger type is not supported: ${triggerType}.`);
   }
-  return triggerResource
+  return triggerResource;
 }
 
 module.exports = {

--- a/lib/import/trigger-parser.js
+++ b/lib/import/trigger-parser.js
@@ -1,0 +1,122 @@
+'use strict';
+const { doProp } = require('./utils');
+
+function doParseOSSTriggerConfig(triggerResource, triggerConfig) {
+  triggerResource.Type = 'OSS';
+  const properties = triggerResource.Properties;
+  doProp(properties, 'Events', triggerConfig.events);
+  doProp(properties, 'BucketName', triggerConfig.bucketName);
+  const filter = triggerConfig.filter;
+  if (filter) {
+    properties.Filter = {
+      Key: {
+        Prefix: filter.key.prefix,
+        Suffix: filter.key.suffix
+      }
+    }
+  }
+}
+
+function doParseHttpTriggerConfig(triggerResource, triggerConfig) {
+  triggerResource.Type = 'HTTP';
+  const properties = triggerResource.Properties;
+  doProp(properties, 'AuthType', triggerConfig.authType);
+  doProp(properties, 'Methods', triggerConfig.methods);
+}
+
+function doParseLogTriggerConfig(triggerResource, triggerConfig) {
+  triggerResource.Type = 'Log';
+  const properties = triggerResource.Properties;
+  properties.SourceConfig = {
+    Logstore: triggerConfig.sourceConfig.logstore
+  }
+  properties.JobConfig = {
+    MaxRetryTime: triggerConfig.jobConfig.maxRetryTime,
+    TriggerInterval: triggerConfig.jobConfig.triggerInterval
+  }
+}
+
+function doParseMNSTopicTriggerConfig(triggerResource, triggerConfig) {
+  triggerResource.Type = 'MNSTopic';
+  const properties = triggerResource.Properties;
+  doProp(properties, 'TopicName', triggerConfig.topicName);
+  doProp(properties, 'Region', triggerConfig.region);
+  doProp(properties, 'NotifyContentFormat', triggerConfig.notifyContentFormat);
+  doProp(properties, 'NotifyStrategy', triggerConfig.notifyStrategy);
+  doProp(properties, 'FilterTag', triggerConfig.filterTag);
+}
+
+function doParseTableStoreTriggerConfig(triggerResource, triggerConfig) {
+  triggerResource.Type = 'TableStore';
+  const properties = triggerResource.Properties;
+  doProp(properties, 'InstanceName', triggerConfig.instanceName);
+  doProp(properties, 'TableName', triggerConfig.tableName);
+}
+
+function doParseRDSTriggerConfig(triggerResource, triggerConfig) {
+  triggerResource.Type = 'RDS';
+  const properties = triggerResource.Properties;
+  doProp(properties, 'InstanceId', triggerConfig.instanceId);
+  doProp(properties, 'SubscriptionObjects', triggerConfig.subscriptionObjects);
+  doProp(properties, 'Retry', triggerConfig.retry);
+  doProp(properties, 'Concurrency', triggerConfig.concurrency);
+  doProp(properties, 'EventFormat', triggerConfig.eventFormat);
+}
+
+function doParseTimerTriggerConfig(triggerResource, triggerConfig) {
+  triggerResource.Type = 'Timer';
+  const properties = triggerResource.Properties;
+  doProp(properties, 'Payload', triggerConfig.payload);
+  doProp(properties, 'CronExpression', triggerConfig.cronExpression);
+  doProp(properties, 'Enable', triggerConfig.enable);
+}
+
+function doParseCDNTriggerConfig(triggerResource, triggerConfig) {
+  triggerResource.Type = 'CDN';
+  const properties = triggerResource.Properties;
+  doProp(properties, 'EventName', triggerConfig.eventName);
+  doProp(properties, 'EventVersion', triggerConfig.eventVersion);
+  doProp(properties, 'Notes', triggerConfig.notes);
+  const filter = serviceMeta.filter;
+  if (filter) {
+    properties.Filter = {
+      Domain: filter.domain
+    };
+  }
+}
+
+function parseTriggerResource(triggerMeta) {
+  const triggerType = triggerMeta.triggerType;
+  const triggerResource = {
+    Type: '',
+    Properties: {}
+  }
+  const properties = triggerResource.Properties;
+  doProp(properties, 'InvocationRole', triggerMeta.invocationRole);
+  doProp(properties, 'SourceArn', triggerMeta.sourceArn);
+  doProp(properties, 'Qualifier', triggerMeta.qualifier);
+  if (triggerType === 'oss') {
+    doParseOSSTriggerConfig(triggerResource, triggerMeta.triggerConfig);
+  } else if (triggerType === 'log') {
+    doParseLogTriggerConfig(triggerResource, triggerMeta.triggerConfig);
+  } else if (triggerType === 'timer') {
+    doParseTimerTriggerConfig(triggerResource, triggerMeta.triggerConfig);
+  } else if (triggerType === 'http') {
+    doParseHttpTriggerConfig(triggerResource, triggerMeta.triggerConfig);
+  } else if (triggerType === 'tablestore') {
+    doParseTableStoreTriggerConfig(triggerResource, triggerMeta.triggerConfig);
+  } else if (triggerType === 'cdn_events') {
+    doParseCDNTriggerConfig(triggerResource, triggerMeta.triggerConfig);
+  } else if (triggerType === 'rds') {
+    doParseRDSTriggerConfig(triggerResource, triggerMeta.triggerConfig);
+  } else if (triggerType === 'mns_topic') {
+    doParseMNSTopicTriggerConfig(triggerResource, triggerMeta.triggerConfig);
+  } else {
+    throw new Error(`Trigger type is not supported: ${triggerType}.`);
+  }
+  return triggerResource
+}
+
+module.exports = {
+  parseTriggerResource
+};

--- a/lib/import/utils.js
+++ b/lib/import/utils.js
@@ -1,0 +1,99 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { green, white, red } = require('colors');
+const ProgressBar = require('progress');
+const { CUSTOM_DOMAIN_TYPE, SERVICE_TYPE } = require('./constants');
+
+function makeSurePathExists(p) {
+  if (fs.existsSync(p)) {
+    return true;
+  }
+  if (makeSurePathExists(path.dirname(p))) {
+    fs.mkdirSync(p);
+    return true;
+  }
+
+}
+
+function getTemplateFile(fullOutputDir) {
+  const doGetTemplateFile = fileName => {
+    const templateFilePath = path.resolve(fullOutputDir, fileName);
+    if (fs.existsSync(templateFilePath)) {
+      return {
+        templateFilePath,
+        content: yaml.safeLoad(fs.readFileSync(templateFilePath, 'utf8'))
+      }
+    }
+  };
+  const result = doGetTemplateFile('template.yml');
+  if (result) {
+    return result;
+  }
+  return doGetTemplateFile('template.yaml');
+}
+
+function doProp(target, propertyName, value) {
+  if (!target) {
+    return;
+  }
+  if (value) {
+    target[propertyName] = value;
+  }
+}
+
+function getCodeUri(serviceName, functionName) {
+  return `./${serviceName}/${functionName}`
+}
+
+function createProgressBar(format, options) {
+  const opts = {
+    complete: green('█'),
+    incomplete: white('█'),
+    width: 20,
+    clear: true,
+    ...options
+  }
+  const bar = new ProgressBar(format, opts);
+  const old = bar.tick;
+  const loadingChars = ['⣴', '⣆', '⢻', '⢪', '⢫'];
+  bar.tick = (len, tokens) => {
+    const newTokens = {
+      loading: loadingChars[parseInt(Math.random() * 5)],
+      ...tokens
+    }
+    old.call(bar, len, newTokens);
+  }
+  return bar;
+}
+
+function checkResource(resourceName, content) {
+  if (!content.Resources) {
+    throw new Error(red('The template file format in the current directory is incorrect.'));
+  }
+  const resource = content.Resources[resourceName]
+  if (resource) {
+    if (resource.Type === SERVICE_TYPE) {
+      throw new Error(red(`The service that needs to be imported already exists: ${resourceName}.`));
+    }
+    if (resource.Type === CUSTOM_DOMAIN_TYPE) {
+      throw new Error(red(`The custom domain that needs to be imported already exists: ${resourceName}.`));
+    }
+    throw new Error(red(`The resource that needs to be imported already exists: ${resourceName}, type: ${resource.Type}.`));
+  }
+}
+
+function outputTemplateFile(templateFilePath, content) {
+  fs.writeFileSync(templateFilePath, yaml.safeDump(content));
+}
+
+module.exports = {
+  getTemplateFile,
+  makeSurePathExists,
+  getCodeUri,
+  createProgressBar,
+  checkResource,
+  doProp,
+  outputTemplateFile
+};

--- a/lib/import/utils.js
+++ b/lib/import/utils.js
@@ -24,7 +24,7 @@ function getTemplateFile(fullOutputDir) {
       return {
         templateFilePath,
         content: yaml.safeLoad(fs.readFileSync(templateFilePath, 'utf8'))
-      }
+      };
     }
   };
   const result = doGetTemplateFile('template.yml');
@@ -44,27 +44,25 @@ function doProp(target, propertyName, value) {
 }
 
 function getCodeUri(serviceName, functionName) {
-  return `./${serviceName}/${functionName}`
+  return `./${serviceName}/${functionName}`;
 }
 
 function createProgressBar(format, options) {
-  const opts = {
+  const opts = Object.assign({
     complete: green('█'),
     incomplete: white('█'),
     width: 20,
-    clear: true,
-    ...options
-  }
+    clear: true
+  }, options);
   const bar = new ProgressBar(format, opts);
   const old = bar.tick;
   const loadingChars = ['⣴', '⣆', '⢻', '⢪', '⢫'];
   bar.tick = (len, tokens) => {
-    const newTokens = {
-      loading: loadingChars[parseInt(Math.random() * 5)],
-      ...tokens
-    }
+    const newTokens = Object.assign({
+      loading: loadingChars[parseInt(Math.random() * 5)]
+    }, tokens);
     old.call(bar, len, newTokens);
-  }
+  };
   return bar;
 }
 
@@ -72,7 +70,7 @@ function checkResource(resourceName, content) {
   if (!content.Resources) {
     throw new Error(red('The template file format in the current directory is incorrect.'));
   }
-  const resource = content.Resources[resourceName]
+  const resource = content.Resources[resourceName];
   if (resource) {
     if (resource.Type === SERVICE_TYPE) {
       throw new Error(red(`The service that needs to be imported already exists: ${resourceName}.`));
@@ -88,6 +86,14 @@ function outputTemplateFile(templateFilePath, content) {
   fs.writeFileSync(templateFilePath, yaml.safeDump(content));
 }
 
+function getTemplateHeader() {
+  return {
+    ROSTemplateFormatVersion: '2015-09-01',
+    Transform: 'Aliyun::Serverless-2018-04-03',
+    Resources: {}
+  };
+}
+
 module.exports = {
   getTemplateFile,
   makeSurePathExists,
@@ -95,5 +101,6 @@ module.exports = {
   createProgressBar,
   checkResource,
   doProp,
-  outputTemplateFile
+  outputTemplateFile,
+  getTemplateHeader
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,7 +152,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -352,7 +352,7 @@
     },
     "array-from": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/array-from/download/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
@@ -553,10 +553,24 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.44",
+      "resolved": "https://registry.npm.taobao.org/big-integer/download/big-integer-1.6.44.tgz",
+      "integrity": "sha1-TumuX1g5/BGt4zj+oha0UTRUpTk="
+    },
     "bignumber.js": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
       "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npm.taobao.org/binary/download/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
     },
     "bit-mask": {
       "version": "1.0.2",
@@ -574,6 +588,11 @@
       "requires": {
         "readable-stream": "^2.0.5"
       }
+    },
+    "bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npm.taobao.org/bluebird/download/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -746,6 +765,16 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
     },
+    "buffer-indexof-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npm.taobao.org/buffer-indexof-polyfill/download/buffer-indexof-polyfill-1.0.1.tgz",
+      "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8="
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npm.taobao.org/buffers/download/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+    },
     "bufferview": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bufferview/-/bufferview-1.0.1.tgz",
@@ -879,6 +908,14 @@
       "requires": {
         "bit-mask": "^1.0.1",
         "readdir-enhanced": "^1.4.0"
+      }
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npm.taobao.org/chainsaw/download/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -1524,6 +1561,14 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
       "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "http://registry.npm.taobao.org/duplexer2/download/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -2280,7 +2325,7 @@
     },
     "git-ignore-parser": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/git-ignore-parser/-/git-ignore-parser-0.0.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/git-ignore-parser/download/git-ignore-parser-0.0.2.tgz",
       "integrity": "sha1-fykXBKrv9mlvmHePzLJ2AbtzOTI="
     },
     "glob": {
@@ -3220,6 +3265,11 @@
         "immediate": "~3.0.5"
       }
     },
+    "listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npm.taobao.org/listenercount/download/listenercount-1.0.1.tgz",
+      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
+    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -4056,6 +4106,12 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
+        "progress": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/progress/download/progress-2.0.0.tgz",
+          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -4138,6 +4194,12 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
+        "progress": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/progress/download/progress-2.0.0.tgz",
+          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -4192,10 +4254,9 @@
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/progress/download/progress-2.0.3.tgz",
+      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg="
     },
     "promise-retry": {
       "version": "1.1.1",
@@ -4650,6 +4711,11 @@
           }
         }
       }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npm.taobao.org/setimmediate/download/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.1.0",
@@ -5208,6 +5274,11 @@
         }
       }
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npm.taobao.org/traverse/download/traverse-0.3.9.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftraverse%2Fdownload%2Ftraverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+    },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
@@ -5485,6 +5556,62 @@
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
+        }
+      }
+    },
+    "unzipper": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npm.taobao.org/unzipper/download/unzipper-0.10.1.tgz",
+      "integrity": "sha1-jB8In8t/Sy0FguWxWeodes40IhU=",
+      "requires": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      },
+      "dependencies": {
+        "fstream": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npm.taobao.org/fstream/download/fstream-1.0.12.tgz",
+          "integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
+          }
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npm.taobao.org/process-nextick-args/download/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.6.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-2.3.6.tgz",
+          "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "node-watch": "^0.6.0",
     "os-locale": "^2.1.0",
     "os-name": "^3.1.0",
+    "progress": "^2.0.3",
     "promise-retry": "^1.1.1",
     "raw-body": "^2.3.3",
     "require-from-string": "^2.0.2",
@@ -80,6 +81,7 @@
     "single-line-log": "^1.1.2",
     "tablestore": "^4.3.2",
     "universal-analytics": "^0.4.20",
+    "unzipper": "^0.10.1",
     "update-notifier": "^3.0.0",
     "urlencode": "^1.1.0"
   },

--- a/test/import/custom-domain.js
+++ b/test/import/custom-domain.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const customDomain1 = {
+  customDomain: 'foo.com',
+  protocol: 'http',
+  routeConfig: {
+    routes: [
+      { path: '/path1', serviceName: 'service1', functionName: 'function1' },
+      { path: '/path2', serviceName: 'service2', functionName: 'function2' },
+      { path: '/path3', serviceName: 'service3', functionName: 'function3' }
+    ]
+  },
+  certConfig: {
+    certName: 'certName',
+    privateKey: 'privateKey',
+    certificate: 'certificate'
+  }
+};
+
+const customDomain2 = {
+  customDomain: 'bar.com',
+  protocol: 'http',
+  routeConfig: {
+    routes: [
+      { path: '/path1', serviceName: 'service1', functionName: 'function1' },
+      { path: '/path2', serviceName: 'service2', functionName: 'function2' },
+      { path: '/path3', serviceName: 'service3', functionName: 'function3' }
+    ]
+  }
+};
+
+const customDomainResource1 = {
+  'Type': 'Aliyun::Serverless::CustomDomain',
+  'Properties': {
+    'Protocol': 'http',
+    'RouteConfig': {
+      'Routes': {
+        '/path1': {
+          'ServiceName': 'service1',
+          'FunctionName': 'function1'
+        },
+        '/path2': {
+          'ServiceName': 'service2',
+          'FunctionName': 'function2'
+        },
+        '/path3': {
+          'ServiceName': 'service3',
+          'FunctionName': 'function3'
+        }
+      }
+    },
+    'CertConfig': {
+      'CertName': 'certName',
+      'PrivateKey': 'privateKey',
+      'Certificate': 'certificate'
+    }
+  }
+};
+
+const customDomainResource2 = {
+  'Type': 'Aliyun::Serverless::CustomDomain',
+  'Properties': {
+    'Protocol': 'http',
+    'RouteConfig': {
+      'Routes': {
+        '/path1': {
+          'ServiceName': 'service1',
+          'FunctionName': 'function1'
+        },
+        '/path2': {
+          'ServiceName': 'service2',
+          'FunctionName': 'function2'
+        },
+        '/path3': {
+          'ServiceName': 'service3',
+          'FunctionName': 'function3'
+        }
+      }
+    }
+  }
+};
+
+module.exports = { customDomain1, customDomain2, customDomainResource1, customDomainResource2 };

--- a/test/import/custom-domain.test.js
+++ b/test/import/custom-domain.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const { customDomain1, customDomain2, customDomainResource1, customDomainResource2 } = require('./custom-domain');
+const { getTemplateHeader } = require('../../lib/import/utils');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+const sandbox = sinon.createSandbox();
+const listCustomDomains = sandbox.stub();
+const getCustomDomain = sandbox.stub();
+
+
+const client = {
+  getFcClient: () => {
+    return {
+      listCustomDomains,
+      getCustomDomain
+    };
+  }
+};
+
+const utils = {
+  outputTemplateFile: sandbox.stub()
+};
+
+const path = {
+  resolve: sandbox.stub()
+};
+
+const customDomainStub = proxyquire('../../lib/import/custom-domain', {
+  '../client': client,
+  './utils': utils,
+  'path': path
+});
+
+describe('import custom-domain', () => {
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it('import all custom domain', async () => {
+    const response = {
+      data: {
+        customDomains: [ customDomain1, customDomain2 ]
+      }
+    };
+    listCustomDomains.returns(response);
+    path.resolve.returns('.');
+
+    await customDomainStub.importCustomDomain();
+    sandbox.assert.calledWith(utils.outputTemplateFile, '.', Object.assign(getTemplateHeader(), {
+      Resources: {
+        [customDomain1.customDomain]: customDomainResource1,
+        [customDomain2.customDomain]: customDomainResource2
+      }
+    }));
+  });
+
+  it('import custom domain with custom domain name', async () => {
+    const response = {
+      data: customDomain1
+    };
+    getCustomDomain.returns(response);
+    path.resolve.returns('.');
+
+    await customDomainStub.importCustomDomain('foo.com');
+    sandbox.assert.calledWith(utils.outputTemplateFile, '.', Object.assign(getTemplateHeader(), {
+      Resources: {
+        [customDomain1.customDomain]: customDomainResource1
+      }
+    }));
+  });
+});

--- a/test/import/function.js
+++ b/test/import/function.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const {
+  ossResource,
+  httpResource,
+  logResource,
+  mnsTopicResource,
+  cdnEventsResource,
+  rdsResource,
+  tablestoreResource,
+  timerResource
+} = require('./trigger');
+
+const func1 = {
+  functionName: 'func1',
+  description: 'description',
+  initializer: 'initializer',
+  initializationTimeout: 60,
+  handler: 'index.handler',
+  runtime: 'nodejs8',
+  memorySize: 512,
+  environmentVariables: {
+    foo: 'bar'
+  }
+};
+
+const func2 = {
+  functionName: 'func2',
+  description: 'description',
+  initializer: 'initializer',
+  initializationTimeout: 60,
+  handler: 'index.handler',
+  runtime: 'nodejs8',
+  memorySize: 512
+};
+
+const func3 = {
+  functionName: 'func3',
+  handler: 'index.handler',
+  runtime: 'nodejs8',
+  memorySize: 512
+};
+
+const funcResource1 = {
+  'Type': 'Aliyun::Serverless::Function',
+  'Properties': {
+    'Description': 'description',
+    'Initializer': 'initializer',
+    'InitializationTimeout': 60,
+    'Handler': 'index.handler',
+    'Runtime': 'nodejs8',
+    'MemorySize': 512,
+    'EnvironmentVariables': {
+      'foo': 'bar'
+    },
+    'CodeUri': './service/func1'
+  },
+  'Events': {
+    'oss': ossResource,
+    'http': httpResource,
+    'log': logResource,
+    'mns_topic': mnsTopicResource,
+    'cdn_events': cdnEventsResource,
+    'rds': rdsResource,
+    'tablestore': tablestoreResource,
+    'timer': timerResource
+  }
+};
+
+
+const funcResource2 = {
+  'Type': 'Aliyun::Serverless::Function',
+  'Properties': {
+    'Description': 'description',
+    'Initializer': 'initializer',
+    'InitializationTimeout': 60,
+    'Handler': 'index.handler',
+    'Runtime': 'nodejs8',
+    'MemorySize': 512,
+    'CodeUri': './service/func2'
+  }
+};
+
+const funcResource3 = {
+  'Type': 'Aliyun::Serverless::Function',
+  'Properties': {
+    'Handler': 'index.handler',
+    'Runtime': 'nodejs8',
+    'MemorySize': 512,
+    'CodeUri': './service/func3'
+  }
+};
+
+module.exports = { func1, func2, func3, funcResource1, funcResource2, funcResource3 };

--- a/test/import/function.test.js
+++ b/test/import/function.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const { serviceResouce } = require('./service');
+const { func1, func2, funcResource1, funcResource2 } = require('./function');
+const { getTemplateHeader } = require('../../lib/import/utils');
+const expect = require('expect.js');
+
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+const sandbox = sinon.createSandbox();
+const getFunction = sandbox.stub();
+
+const client = {
+  getFcClient: () => {
+    return {
+      getFunction
+    };
+  }
+};
+
+const utils = {
+  outputTemplateFile: sandbox.stub(),
+  getTemplateFile: sandbox.stub()
+};
+
+const service = {
+  getFunctionResource: sandbox.stub(),
+  getServiceResource: sandbox.stub(),
+  getServiceMeta: sandbox.stub()
+};
+
+const path = {
+  resolve: sandbox.stub()
+};
+
+const functionStub = proxyquire('../../lib/import/function', {
+  '../client': client,
+  './utils': utils,
+  './service': service,
+  'path': path
+});
+
+describe('import function', () => {
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it('import simple function', async () => {
+    const response = {
+      data: func1
+    };
+    service.getServiceResource.returns(serviceResouce());
+    service.getFunctionResource.returns(funcResource1);
+    getFunction.returns(response);
+    path.resolve.returns('.');
+
+    await functionStub.importFunction('service', func1.functionName, '.', false);
+    sandbox.assert.calledWith(utils.outputTemplateFile, '.', Object.assign(getTemplateHeader(), {
+      Resources: {
+        service: Object.assign(serviceResouce(), {
+          [func1.functionName]: funcResource1
+        })
+      }
+    }));
+  });
+
+  it('import function with template file exists', async () => {
+    const response = {
+      data: func1
+    };
+    utils.getTemplateFile.returns({
+      templateFilePath: '.',
+      content: Object.assign(getTemplateHeader(), {
+        Resources: {
+          service: Object.assign(serviceResouce(), {
+            [func2.functionName]: funcResource2
+          })
+        }
+      })
+    });
+    service.getServiceMeta.returns({});
+    service.getServiceResource.returns(serviceResouce());
+    service.getFunctionResource.returns(funcResource1);
+    getFunction.returns(response);
+    path.resolve.returns('.');
+
+    await functionStub.importFunction('service', func1.functionName, '.');
+    sandbox.assert.calledWith(utils.outputTemplateFile, '.', Object.assign(getTemplateHeader(), {
+      Resources: {
+        service: Object.assign(serviceResouce(), {
+          [func1.functionName]: funcResource1,
+          [func2.functionName]: funcResource2
+        })
+      }
+    }));
+  });
+
+  it('import function with function exists', async () => {
+    const response = {
+      data: func1
+    };
+    utils.getTemplateFile.returns({
+      templateFilePath: '.',
+      content: Object.assign(getTemplateHeader(), {
+        Resources: {
+          service: Object.assign(serviceResouce(), {
+            [func1.functionName]: funcResource2
+          })
+        }
+      })
+    });
+    service.getServiceMeta.returns({});
+    service.getServiceResource.returns(serviceResouce());
+    service.getFunctionResource.returns(funcResource1);
+    getFunction.returns(response);
+    path.resolve.returns('.');
+    try {
+      await functionStub.importFunction('service', func1.functionName, '.');
+    } catch (error) {
+      return;
+    }
+    expect().fail('expect throw Error.');
+
+  });
+
+  it('import function with resource exists', async () => {
+    const response = {
+      data: func1
+    };
+    utils.getTemplateFile.returns({
+      templateFilePath: '.',
+      content: Object.assign(getTemplateHeader(), {
+        Resources: {
+          service: {
+            Type: 'xxx'
+          }
+        }
+      })
+    });
+    service.getServiceResource.returns(serviceResouce());
+    service.getFunctionResource.returns(funcResource1);
+    getFunction.returns(response);
+    path.resolve.returns('.');
+    try {
+      await functionStub.importFunction('service', func1.functionName, '.');
+    } catch (error) {
+      return;
+    }
+    expect().fail('expect throw Error.');
+
+  });
+
+});

--- a/test/import/service.js
+++ b/test/import/service.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const service = () => ({
+  serviceName: 'service',
+  description: 'description',
+  role: 'role',
+  logConfig: {
+    project: 'project',
+    logstore: 'logstore'
+  },
+  vpcConfig: {
+    vpcId: 'vpcId',
+    vSwitchIds: ['vSwitchIds'],
+    securityGroupId: 'securityGroupId'
+  },
+  nasConfig: {
+    userId: -1,
+    groupId: -1,
+    mountPoints: [{ serverAddr: 'serverAddr', mountDir: 'mountDir' }]
+  },
+  internetAccess: true
+});
+
+const serviceResouce = () => ({
+  'Type': 'Aliyun::Serverless::Service',
+  'Properties': {
+    'Description': 'description',
+    'Role': 'role',
+    'LogConfig': {
+      'Project': 'project',
+      'Logstore': 'logstore'
+    },
+    'VpcConfig': {
+      'VpcId': 'vpcId',
+      'VSwitchIds': [
+        'vSwitchIds'
+      ],
+      'SecurityGroupId': 'securityGroupId'
+    },
+    'NasConfig': {
+      'UserId': -1,
+      'GroupId': -1,
+      'MountPoints': [
+        {
+          'ServerAddr': 'serverAddr',
+          'MountDir': 'mountDir'
+        }
+      ]
+    },
+    'InternetAccess': true
+  }
+});
+
+module.exports = { service, serviceResouce };

--- a/test/import/service.test.js
+++ b/test/import/service.test.js
@@ -1,0 +1,185 @@
+'use strict';
+
+const { service, serviceResouce } = require('./service');
+const { func1, func2, func3, funcResource1, funcResource2, funcResource3 } = require('./function');
+const { getTemplateHeader } = require('../../lib/import/utils');
+const { 
+  oss,
+  http,
+  log,
+  mnsTopic,
+  cdnEvents,
+  rds,
+  tablestore,
+  timer
+} = require('./trigger');
+
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const expect = require('expect.js');
+
+const sandbox = sinon.createSandbox();
+const getService = sandbox.stub();
+const listServices = sandbox.stub();
+const listFunctions = sandbox.stub();
+const listTriggers = sandbox.stub();
+const getFunctionCode = sandbox.stub();
+
+const client = {
+  getFcClient: () => {
+    return {
+      getService,
+      listServices,
+      listFunctions,
+      listTriggers,
+      getFunctionCode
+    };
+  }
+};
+
+const utils = {
+  outputTemplateFile: sandbox.stub(),
+  getTemplateFile: sandbox.stub()
+};
+
+const path = {
+  resolve: sandbox.stub()
+};
+
+const httpx = {
+  request: sandbox.stub()
+};
+
+const serviceStub = proxyquire('../../lib/import/service', {
+  '../client': client,
+  './utils': utils,
+  'path': path,
+  'httpx': httpx
+});
+
+describe('import service', () => {
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it('import simple service', async () => {
+    const response = {
+      data: service()
+    };
+    getService.returns(response);
+    listFunctions.returns({
+      data: {
+        functions: [ func1, func2, func3 ]
+      }
+    });
+    path.resolve.returns('.');
+
+    await serviceStub.importService(service().serviceName, '.', false);
+    sandbox.assert.calledWith(utils.outputTemplateFile, '.', Object.assign(getTemplateHeader(), {
+      Resources: {
+        [service().serviceName]: serviceResouce()
+      }
+    }));
+  });
+
+  it('import all services', async () => {
+    const response = {
+      data: {
+        services: [ service() ]
+      }
+    };
+    listServices.returns(response);
+    listFunctions.returns({
+      data: { functions: [] }
+    });
+  
+    path.resolve.returns('.');
+
+    await serviceStub.importService();
+    sandbox.assert.calledWith(utils.outputTemplateFile, '.', Object.assign(getTemplateHeader(), {
+      Resources: {
+        [service().serviceName]: serviceResouce()
+      }
+    }));
+  });
+
+  it('import service and function', async () => {
+    const response = {
+      data: service()
+    };
+    getService.returns(response);
+    getFunctionCode.returns({ data: {}});
+    listFunctions.returns({
+      data: {
+        functions: [ func1, func2, func3 ]
+      }
+    });
+    listTriggers.withArgs(service().serviceName, func1.functionName).returns({
+      data: {
+        triggers: [
+          oss,
+          http,
+          log,
+          mnsTopic,
+          cdnEvents,
+          rds,
+          tablestore,
+          timer
+        ]
+      }
+    });
+    listTriggers.returns({
+      data: {
+        triggers: []
+      }
+    });
+    path.resolve.returns('.');
+
+    const on = (event, listener) => {
+      if (event === 'finish') {
+        listener();
+      } else if (event === 'end') {
+        listener();
+      }
+      return { on };
+    };
+
+    httpx.request.returns({
+      headers: {},
+      on,
+      pipe: arg => ( { on })
+    });
+
+    await serviceStub.importService(service().serviceName);
+    sandbox.assert.calledWith(utils.outputTemplateFile, '.', Object.assign(getTemplateHeader(), {
+      Resources: {
+        [service().serviceName]: Object.assign(serviceResouce(), {
+          [func1.functionName]: funcResource1,
+          [func2.functionName]: funcResource2,
+          [func3.functionName]: funcResource3
+        })
+      }
+    }));
+  });
+
+  it('import service with service exists', async () => {
+    utils.getTemplateFile.returns({
+      templateFilePath: '.',
+      content: Object.assign(getTemplateHeader(), {
+        Resources: {
+          service: service()
+        }
+      })
+    });
+    path.resolve.returns('.');
+    try {
+      await serviceStub.importServie(service().serviceName);
+    } catch (error) {
+      return;
+    }
+    expect().fail('expect throw Error.');
+
+  });
+
+});

--- a/test/import/trigger.js
+++ b/test/import/trigger.js
@@ -1,0 +1,194 @@
+'use strict';
+
+const oss = {
+  triggerType: 'oss',
+  triggerName: 'oss',
+  invocationRole: 'invocationRole',
+  sourceArn: 'sourceArn',
+  qualifier: 'qualifier',
+  triggerConfig: {
+    events: ['put'],
+    bucketName: 'bucketName',
+    filter: {
+      key: {
+        prefix: 'prefix',
+        suffix: 'suffix'
+      }
+    }
+  }
+};
+
+const http = {
+  triggerType: 'http',
+  triggerName: 'http',
+  triggerConfig: {
+    authType: 'function',
+    methods: ['get', 'post']
+  }
+};
+
+const log = {
+  triggerType: 'log',
+  triggerName: 'log',
+  triggerConfig: {
+    sourceConfig: {
+      logstore: 'logstore'
+    },
+    jobConfig: {
+      maxRetryTime: 2,
+      triggerInterval: 60
+    }
+  }
+};
+
+const mnsTopic = {
+  triggerType: 'mns_topic',
+  triggerName: 'mns_topic',
+  triggerConfig: {
+    region: 'region',
+    notifyContentFormat: 'notifyContentFormat',
+    notifyStrategy: 'notifyStrategy',
+    filterTag: 'filterTag'
+  }
+};
+
+const cdnEvents = {
+  triggerType: 'cdn_events',
+  triggerName: 'cdn_events',
+  triggerConfig: {
+    eventName: 'eventName',
+    eventVersion: 'eventVersion',
+    enable: true,
+    notes: 'notes',
+    filter: {
+      domain: 'domain'
+    }
+  }
+};
+
+const tablestore = {
+  triggerType: 'tablestore',
+  triggerName: 'tablestore',
+  triggerConfig: {
+    instanceName: 'instanceName',
+    tableName: 'tableName'
+  }
+};
+
+const rds = {
+  triggerType: 'rds',
+  triggerName: 'rds',
+  triggerConfig: {
+    instanceId: 'instanceId',
+    subscriptionObjects: 'subscriptionObjects',
+    retry: 3,
+    concurrency: 'concurrency',
+    eventFormat: 'eventFormat'
+  }
+};
+
+const timer = {
+  triggerType: 'timer',
+  triggerName: 'timer',
+  triggerConfig: {
+    payload: 'payload',
+    cronExpression: 'cronExpression',
+    enable: true
+  }
+};
+
+const ossResource = {
+  'Type': 'OSS',
+  'Properties': {
+    'InvocationRole': 'invocationRole',
+    'SourceArn': 'sourceArn',
+    'Qualifier': 'qualifier',
+    'Events': [
+      'put'
+    ],
+    'BucketName': 'bucketName',
+    'Filter': {
+      'Key': {
+        'Prefix': 'prefix',
+        'Suffix': 'suffix'
+      }
+    }
+  }
+};
+
+const httpResource = {
+  'Type': 'HTTP',
+  'Properties': {
+    'AuthType': 'function',
+    'Methods': [
+      'get',
+      'post'
+    ]
+  }
+};
+
+const logResource = {
+  'Type': 'Log',
+  'Properties': {
+    'SourceConfig': {
+      'Logstore': 'logstore'
+    },
+    'JobConfig': {
+      'MaxRetryTime': 2,
+      'TriggerInterval': 60
+    }
+  }
+};
+
+const mnsTopicResource = {
+  'Type': 'MNSTopic',
+  'Properties': {
+    'Region': 'region',
+    'NotifyContentFormat': 'notifyContentFormat',
+    'NotifyStrategy': 'notifyStrategy',
+    'FilterTag': 'filterTag'
+  }
+};
+
+const tablestoreResource = {
+  'Type': 'TableStore',
+  'Properties': {
+    'InstanceName': 'instanceName',
+    'TableName': 'tableName'
+  }
+};
+
+const rdsResource = {
+  'Type': 'RDS',
+  'Properties': {
+    'InstanceId': 'instanceId',
+    'SubscriptionObjects': 'subscriptionObjects',
+    'Retry': 3,
+    'Concurrency': 'concurrency',
+    'EventFormat': 'eventFormat'
+  }
+};
+
+const timerResource = {
+  'Type': 'Timer',
+  'Properties': {
+    'Payload': 'payload',
+    'CronExpression': 'cronExpression',
+    'Enable': true
+  }
+};
+
+const cdnEventsResource = {
+  'Type': 'CDN',
+  'Properties': {
+    'EventName': 'eventName',
+    'EventVersion': 'eventVersion',
+    'Notes': 'notes'
+  }
+};
+
+
+module.exports = { 
+  oss, http, log, mnsTopic, cdnEvents, rds, tablestore, timer,
+  ossResource, httpResource, logResource, mnsTopicResource, cdnEventsResource, rdsResource, tablestoreResource, timerResource
+};


### PR DESCRIPTION
目前支持一下三种资源导入：
1. 服务资源
```javascript
async function importService(serviceName, outputDir = '.', recursive = true, onlyConfig = false, existsSkip = true) 
```
2. 函数资源
```javascrpt
async function importFunction(serviceName, functionName, outputDir = '.', recursive = true, onlyConfig = false) 
```
3. 自定义域名
```javascript
async function importCustomDomain(domainName, outputDir = '.', existsSkip = true) 
```
说明：

1. 对于服务和自定义域名来说，当传服务名称或者域名，怎么导入全部服务或者自定义域名
2. 对于服务和自定义域名，一次可以导入一个或者多个，则有参数 skipIfExists，skipIfExists 为 true，资源存在跳过，为 false，则直接抛异常