### PR TITLE
loose format check

### DIFF
--- a/examples/cdn-trigger/template.yml
+++ b/examples/cdn-trigger/template.yml
@@ -1,5 +1,4 @@
 ROSTemplateFormatVersion: '2015-09-01'
-Transform: 'Aliyun::Serverless-2018-04-03'
 Resources:
   cdn-test-service:
     Type: 'Aliyun::Serverless::Service'

--- a/lib/import/utils.js
+++ b/lib/import/utils.js
@@ -21,9 +21,31 @@ function getTemplateFile(fullOutputDir) {
   const doGetTemplateFile = fileName => {
     const templateFilePath = path.resolve(fullOutputDir, fileName);
     if (fs.existsSync(templateFilePath)) {
+      const defautContent = getTemplateHeader();
+      let content = yaml.safeLoad(fs.readFileSync(templateFilePath, 'utf8'));
+      if (content) {
+        if (content.ROSTemplateFormatVersion === undefined) {
+          throw new Error(red('The template file format in the current directory is incorrect.'));
+        }
+        content.Resources = defautContent.Resources;
+        content.ROSTemplateFormatVersion = content.ROSTemplateFormatVersion || defautContent.ROSTemplateFormatVersion;
+        if (typeof content.Transform === 'string') {
+          if (content.Transform !== defautContent.Transform) {
+            content.Transform = [ content.Transform, defautContent.Transform ];
+          }
+        } else if (Array.isArray(content.Transform)) {
+          if (!content.Transform.includes(defautContent.Transform)) {
+            content.Transform.push(defautContent.Transform);
+          }
+        } else {
+          content.Transform = defautContent.Transform;
+        }
+      } else {
+        content = defautContent;
+      }
       return {
         templateFilePath,
-        content: yaml.safeLoad(fs.readFileSync(templateFilePath, 'utf8'))
+        content
       };
     }
   };
@@ -67,9 +89,6 @@ function createProgressBar(format, options) {
 }
 
 function checkResource(resourceName, content) {
-  if (!content.Resources) {
-    throw new Error(red('The template file format in the current directory is incorrect.'));
-  }
   const resource = content.Resources[resourceName];
   if (resource) {
     if (resource.Type === SERVICE_TYPE) {

--- a/test/import/utils.test.js
+++ b/test/import/utils.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const expect = require('expect.js');
+
+const sandbox = sinon.createSandbox();
+
+const fs = {
+  existsSync: sandbox.stub(),
+  readFileSync: sandbox.stub()
+};
+
+const utilsStub = proxyquire('../../lib/import/utils', {
+  'fs': fs
+});
+
+describe('import utils', () => {
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it('test getTemplateFile with the content empty', () => {
+    fs.existsSync.returns(true);
+    fs.readFileSync.returns(null);
+
+    const { content } = utilsStub.getTemplateFile('foo');
+    expect(content).to.be.eql(utilsStub.getTemplateHeader());
+  });
+
+  it('test getTemplateFile with the content invalid', () => {
+    fs.existsSync.returns(true);
+    fs.readFileSync.returns(JSON.stringify({ foo: 'bar' }));
+    try {
+      utilsStub.getTemplateFile('foo');
+    } catch (error) {
+      return;
+    }
+    expect().fail('expect throw Error.');
+  });
+
+  it('test getTemplateFile with the Transform empty', () => {
+    const baseContent = utilsStub.getTemplateHeader();
+    delete baseContent.Transform;
+
+    fs.existsSync.returns(true);
+    fs.readFileSync.returns(JSON.stringify(baseContent));
+
+    const { content } = utilsStub.getTemplateFile('foo');
+    expect(content).to.be.eql(utilsStub.getTemplateHeader());
+  });
+
+  it('test getTemplateFile with the Transform single value and not equal to fun default', () => {
+    const baseContent = utilsStub.getTemplateHeader();
+    baseContent.Transform = 'foo';
+
+    fs.existsSync.returns(true);
+    fs.readFileSync.returns(JSON.stringify(baseContent));
+
+    const { content } = utilsStub.getTemplateFile('foo');
+    expect(content).to.be.eql(Object.assign(utilsStub.getTemplateHeader(), { Transform: [ 'foo', utilsStub.getTemplateHeader().Transform ] }));
+  });
+
+  it('test getTemplateFile with the Transform array value and not contain fun default', () => {
+    const baseContent = utilsStub.getTemplateHeader();
+    baseContent.Transform = [ 'foo' ];
+
+    fs.existsSync.returns(true);
+    fs.readFileSync.returns(JSON.stringify(baseContent));
+
+    const { content } = utilsStub.getTemplateFile('foo');
+    expect(content).to.be.eql(Object.assign(utilsStub.getTemplateHeader(), { Transform: [ 'foo', utilsStub.getTemplateHeader().Transform ] }));
+  });
+
+  it('test getTemplateFile with the Transform array value and contain fun default', () => {
+    const baseContent = utilsStub.getTemplateHeader();
+    baseContent.Transform = [ 'foo', baseContent.Transform ];
+
+    fs.existsSync.returns(true);
+    fs.readFileSync.returns(JSON.stringify(baseContent));
+
+    const { content } = utilsStub.getTemplateFile('foo');
+    expect(content).to.be.eql(Object.assign(utilsStub.getTemplateHeader(), { Transform: [ 'foo', utilsStub.getTemplateHeader().Transform ] }));
+  });
+
+  it('test getTemplateFile with the Resources empty', () => {
+    const baseContent = utilsStub.getTemplateHeader();
+    delete baseContent.Resources;
+    fs.existsSync.returns(true);
+    fs.readFileSync.returns(JSON.stringify(baseContent));
+
+    const { content } = utilsStub.getTemplateFile('foo');
+    expect(content).to.be.eql(utilsStub.getTemplateHeader());
+  });
+
+});


### PR DESCRIPTION
通过  fun import api 导入资源的时候，如果工作目录下存在 template.[yml|yaml] 文件，则导入的资源会与本地存在的资源尝试合并，以前的检查规则比较简单，通过判断 Resources 是否为空，为空报错，有值才会尝试合并，现在做了一下优化：
1. 当 template.[yml|yaml] 文件内容为空时，自动生成 fun 的头部文件内容，如下：
```yaml
ROSTemplateFormatVersion: '2015-09-01'
Transform: 'Aliyun::Serverless-2018-04-03'
```
2. 当 template.[yml|yaml] 文件能容不为空时，分一下几种情况：
    1. `ROSTemplateFormatVersion` 属性 
        1. 存在，继续执行导后面入逻辑
        2. 不存在，终止执行后面导入逻辑
    2. `Transform ` 属性
        1. 存在，Aliyun::Serverless-2018-04-03 合并追加到 `Transform ` 属性值中，如果有多个值则为数组类型，单个值则为字符串类型
        2. 不存在，则加上该属性

Transform 表示法：
```yaml
# 单值情况
Transform: 'foo'
# 多值情况
Transform: ['foo', 'bar']
```
