### PR TITLE
replace ping

### DIFF
--- a/lib/docker-opts.js
+++ b/lib/docker-opts.js
@@ -11,9 +11,10 @@ const { addEnv } = require('./install/env');
 const _ = require('lodash');
 
 const { red } = require('colors');
-
-const ping = require('ping');
+const net = require('net');
 const getVisitor = require('../lib/visitor').getVisitor;
+
+let isFromChinaMotherlandCache;
 
 const runtimeImageMap = {
   'nodejs6': 'nodejs6',
@@ -28,35 +29,52 @@ function resolveDockerEnv(envs = {}) {
   return _.map(addEnv(envs || {}), (v, k) => `${k}=${v}`);
 }
 
-async function doImageRepoEventTag(el) {
+async function doImageRegisterEventTag(el) {
   const visitor = await getVisitor();
   visitor.event({
-    ec: 'imageRepo',
+    ec: 'imageRegistry',
     ea: 'resolve',
     el 
   }).send();
 }
 
-async function doResolveDockerImageRepo(isDockerhubRegistry) {
-  await doImageRepoEventTag('start');
+async function doResolveDockerRegistry(isDockerhubRegistry) {
+  await doImageRegisterEventTag('start');
   if (isDockerhubRegistry) {
-    await doImageRepoEventTag('DockerhubRegistry');
+    await doImageRegisterEventTag('dockerhubRegistry');
     return '';
   }
-  await doImageRepoEventTag('AliyunRegistry');
+  await doImageRegisterEventTag('aliyunRegistry');
   return 'registry.cn-beijing.aliyuncs.com';
 }
 
-async function resolveDockerImageRepo() {
+function isFromChinaMotherland() {
+  if (isFromChinaMotherlandCache !== undefined) {
+    return Promise.resolve(isFromChinaMotherlandCache);
+  }
+  return new Promise((resolve, reject) => {
+    const s = new net.Socket();
+    const doResolve = (isInside) => {
+      isFromChinaMotherlandCache = isInside;
+      resolve(isFromChinaMotherlandCache);
+      s.destroy();
+    };
+
+    s.connect(443, 'google.com', () => doResolve(false));
+    s.on('error', () => doResolve(true));
+    s.setTimeout(1000, () => doResolve(true));
+  });
+}
+
+async function resolveDockerRegistry() {
   try {
-    const { alive, host } = await ping.promise.probe('google.com', { timeout: 10 });
-    if (!alive && host !== 'unknown') {
-      return doResolveDockerImageRepo(false);
+    if (await isFromChinaMotherland()) {
+      return doResolveDockerRegistry(false);
     }
   } catch (error) {
-    return doResolveDockerImageRepo(true);
+    return doResolveDockerRegistry(true);
   }
-  return doResolveDockerImageRepo(true);
+  return doResolveDockerRegistry(true);
 }
 
 async function resolveRuntimeToDockerImage(runtime, isBuild) {
@@ -69,9 +87,9 @@ async function resolveRuntimeToDockerImage(runtime, isBuild) {
       imageName = `aliyunfc/runtime-${name}:1.5.6`;
     }
 
-    const dockerImageRepo = await resolveDockerImageRepo();
-    if (dockerImageRepo) {
-      imageName = `${dockerImageRepo}/${imageName}`;
+    const dockerImageRegistry = await resolveDockerRegistry();
+    if (dockerImageRegistry) {
+      imageName = `${dockerImageRegistry}/${imageName}`;
     }
 
     debug('imageName: ' + imageName);
@@ -213,5 +231,6 @@ module.exports = {
   generateLocalInvokeOpts, resolveRuntimeToDockerImage, 
   generateInstallOpts, generateLocalStartRunOpts,
   resolveMockScript, resolveDockerEnv, transformPathForVirtualBox,
-  resolveDockerImageRepo, transformMountsForToolbox, transformSourcePathOfMount
+  resolveDockerRegistry, transformMountsForToolbox, transformSourcePathOfMount,
+  isFromChinaMotherland
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,7 +152,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -347,12 +347,12 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-from": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/array-from/download/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
@@ -2356,7 +2356,7 @@
     },
     "git-ignore-parser": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/git-ignore-parser/-/git-ignore-parser-0.0.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/git-ignore-parser/download/git-ignore-parser-0.0.2.tgz",
       "integrity": "sha1-fykXBKrv9mlvmHePzLJ2AbtzOTI="
     },
     "glob": {
@@ -3386,7 +3386,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -4047,15 +4047,6 @@
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
-    "ping": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npm.taobao.org/ping/download/ping-0.2.2.tgz",
-      "integrity": "sha1-GA+3UIwdx0eThJvONcgHP5llvOI=",
-      "requires": {
-        "q": "1.x",
-        "underscore": "^1.8.3"
-      }
-    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -4412,11 +4403,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
       "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "http://registry.npm.taobao.org/q/download/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.5.2",
@@ -5489,11 +5475,6 @@
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "http://registry.npm.taobao.org/underscore/download/underscore-1.9.1.tgz",
-      "integrity": "sha1-BtzjSg5op7q8KbNluOdLiSUgOWE="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "node-watch": "^0.6.0",
     "os-locale": "^2.1.0",
     "os-name": "^3.1.0",
-    "ping": "^0.2.2",
     "progress": "^2.0.3",
     "promise-retry": "^1.1.1",
     "raw-body": "^2.3.3",

--- a/test/docker-opts.test.js
+++ b/test/docker-opts.test.js
@@ -10,16 +10,41 @@ const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 const proxyquire = require('proxyquire');
 
-describe('test resolveRuntimeToDockerImage', () => {
+class Socket {
+  connect(part, host, callback) {
+  }
 
-  const pingProbe = sandbox.stub();
+  on(event, callback) {
+  }
+
+  setTimeout(timeout, callback) {
+  }
+}
+
+class OnErrorSocket extends Socket {
+  on(event, callback) {
+    callback();
+  }
+}
+
+class TimeoutSocket extends Socket {
+  setTimeout(timeout, callback) {
+    callback();
+  }
+}
+
+class ConnectSocket extends Socket {
+  connect(part, host, callback) {
+    callback();
+  }
+}
+
+describe('test resolveRuntimeToDockerImage', () => {
 
   beforeEach(() => {
     dockerOpts = proxyquire('../lib/docker-opts', {
-      'ping': {
-        promise: {
-          probe: pingProbe
-        }
+      net: {
+        Socket: ConnectSocket
       }
     });
   });
@@ -29,7 +54,6 @@ describe('test resolveRuntimeToDockerImage', () => {
   });
 
   it('test find not python image', async () => {
-    pingProbe.returns({ alive: true, host: 'google.com' });
     for (let runtime of ['nodejs6', 'nodejs8', 'python2.7', 'java8', 'php7.2']) {
       const imageName = await dockerOpts.resolveRuntimeToDockerImage(runtime);
       expect(imageName).to.contain(`aliyunfc/runtime-${runtime}:`);
@@ -37,52 +61,43 @@ describe('test resolveRuntimeToDockerImage', () => {
   });
 
   it('test find python 3 image', async () => {
-    pingProbe.returns({ alive: true, host: 'google.com' });
     const imageName = await dockerOpts.resolveRuntimeToDockerImage('python3');
     expect(imageName).to.contain(`aliyunfc/runtime-python3.6:`);
   });
 });
 
-describe('test resolveDockerImageRepo', () => {
-  const pingProbe = sandbox.stub();
+describe('test resolveDockerRegistry', () => {
 
-  beforeEach(() => {
+  it('test domestic users resolver docker registry', async () => {
     dockerOpts = proxyquire('../lib/docker-opts', {
-      'ping': {
-        promise: {
-          probe: pingProbe
-        }
+      net: {
+        Socket: OnErrorSocket
       }
     });
+    const dockerRegistry = await dockerOpts.resolveDockerRegistry();
+    expect(dockerRegistry).to.be.eql('registry.cn-beijing.aliyuncs.com');
   });
 
-  afterEach(() => {
-    sandbox.restore();
+  it('test foreign users resolver docker registry', async () => {
+    dockerOpts = proxyquire('../lib/docker-opts', {
+      net: {
+        Socket: ConnectSocket
+      }
+    });
+    const dockerRegistry = await dockerOpts.resolveDockerRegistry();
+    expect(dockerRegistry).to.be('');
   });
 
-  it('test domestic users resolver docker image repo', async () => {
-    pingProbe.returns({ alive: false, host: 'google.com' });
-    const dockerImageRepo = await dockerOpts.resolveDockerImageRepo();
-    expect(dockerImageRepo).to.be.eql('registry.cn-beijing.aliyuncs.com');
+  it('test resolver docker registry with network timeout', async () => {
+    dockerOpts = proxyquire('../lib/docker-opts', {
+      net: {
+        Socket: TimeoutSocket
+      }
+    });
+    const dockerRegistry = await dockerOpts.resolveDockerRegistry();
+    expect(dockerRegistry).to.be.eql('registry.cn-beijing.aliyuncs.com');
   });
 
-  it('test foreign users resolver docker image repo', async () => {
-    pingProbe.returns({ alive: true, host: 'google.com' });
-    const dockerImageRepo = await dockerOpts.resolveDockerImageRepo();
-    expect(dockerImageRepo).to.be('');
-  });
-
-  it('test resolver docker image repo with network not work', async () => {
-    pingProbe.returns({ alive: false, host: 'unknown' });
-    const dockerImageRepo = await dockerOpts.resolveDockerImageRepo();
-    expect(dockerImageRepo).to.be.eql('');
-  });
-
-  it('test resolver docker image repo with error throw', async () => {
-    pingProbe.throws();
-    const dockerImageRepo = await dockerOpts.resolveDockerImageRepo();
-    expect(dockerImageRepo).to.be.eql('');
-  });
 });
 
 describe('test generateLocalInvokeOpts', () => {
@@ -96,10 +111,8 @@ describe('test generateLocalInvokeOpts', () => {
 
     dockerOpts = proxyquire('../lib/docker-opts', {
       'dockerode': DockerCli,
-      'ping': {
-        promise: {
-          probe: pingProbe
-        }
+      net: {
+        Socket: ConnectSocket
       }
     });
 

--- a/test/local/invoke.test.js
+++ b/test/local/invoke.test.js
@@ -8,6 +8,7 @@ const assert = sinon.assert;
 let Invoke = require('../../lib/local/invoke');
 
 const docker = require('../../lib/docker');
+const dockerOpts = require('../../lib/docker-opts');
 
 const proxyquire = require('proxyquire');
 
@@ -23,9 +24,11 @@ describe('test invoke construct and init', async () => {
 
     sandbox.stub(docker, 'resolveCodeUriToMount').resolves(codeMount);
     sandbox.stub(docker, 'pullImageIfNeed').resolves({});
+    sandbox.stub(dockerOpts, 'resolveRuntimeToDockerImage').resolves('aliyunfc/runtime-python3.6:1.5.6');
 
     Invoke = proxyquire('../../lib/local/invoke', {
-      '../docker': docker
+      '../docker': docker,
+      '../docker-opts': dockerOpts
     });
   });
 


### PR DESCRIPTION
检查网络环境加速 docker 镜像下载的改进点：
1. 直接基于 tcp 来替换 ping 方式
2. 将网络状态保持到 cache 中，避免一条 fun 命令多次检查网络状态
3. 将超时时间设置为 1 秒，就算 tcp 超时，也不会有太大影响