### PR TITLE
fix import file ended error

### DIFF
--- a/lib/import/service.js
+++ b/lib/import/service.js
@@ -12,7 +12,7 @@ const {
 const { parseServiceResource } = require('./service-parser');
 const { parseFunctionResource } = require('./function-parser');
 const { parseTriggerResource } = require('./trigger-parser');
-const httpx = require('httpx');
+const https = require('https');
 const path = require('path');
 const unzipper = require('unzipper');
 const debug = require('debug')('fun:import:service');
@@ -70,19 +70,21 @@ async function getFunctionResource(serviceName, functionMeta, fullOutputDir, rec
 async function outputFunctionCode(serviceName, functionName, fullOutputDir) {
   const fc = await getFcClient();
   const { data } = await fc.getFunctionCode(serviceName, functionName);
-  const response = await httpx.request(data.url);
-  var len = parseInt(response.headers['content-length'], 10);
-  const bar = createProgressBar(`${green(':loading')} ${functionName} downloading :bar :rate/bps :percent :etas`, { total: len });
-  response.on('data', (chunk) => {
-    bar.tick(chunk.length);
-  });
-  response.on('end', () => {
-    console.log(`    ${green('✔')} ${functionName} - ${grey('Function')}`);
-  });
-  const fullTargetCodeDir = path.join(fullOutputDir, serviceName, functionName);
-  makeSurePathExists(fullTargetCodeDir);
   return new Promise((resolve, reject) => {
-    response.pipe(unzipper.Extract({ path: fullTargetCodeDir })).on('error', reject).on('finish', resolve);
+    https.get(data.url, response => {
+      var len = parseInt(response.headers['content-length'], 10);    
+      const bar = createProgressBar(`${green(':loading')} ${functionName} downloading :bar :rate/bps :percent :etas`, { total: len });
+      response.on('data', (chunk) => {
+        bar.tick(chunk.length);
+      });
+      response.on('end', () => {
+        console.log(`    ${green('✔')} ${functionName} - ${grey('Function')}`);
+      });
+      const fullTargetCodeDir = path.join(fullOutputDir, serviceName, functionName);
+      makeSurePathExists(fullTargetCodeDir);
+      response.pipe(unzipper.Extract({ path: fullTargetCodeDir })).on('error', reject).on('finish', resolve);
+    });
+    
   });
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -264,12 +264,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
-    },
     "archiver": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.0.0.tgz",
@@ -459,6 +453,33 @@
         "chalk": "^1.1.0",
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "babel-runtime": {
@@ -906,19 +927,6 @@
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "requires": {
         "traverse": ">=0.3.0 <0.4"
-      }
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
       }
     },
     "chardet": {
@@ -1721,6 +1729,48 @@
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
           }
         },
         "debug": {
@@ -5229,12 +5279,6 @@
         "superagent": "^3.8.3"
       }
     },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
     "symbol-observable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -5263,6 +5307,31 @@
             "co": "^4.6.0",
             "json-stable-stringify": "^1.0.1"
           }
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },

--- a/test/import/service.test.js
+++ b/test/import/service.test.js
@@ -46,15 +46,13 @@ const path = {
   resolve: sandbox.stub()
 };
 
-const httpx = {
-  request: sandbox.stub()
-};
+const https = {};
 
 const serviceStub = proxyquire('../../lib/import/service', {
   '../client': client,
   './utils': utils,
   'path': path,
-  'httpx': httpx
+  'https': https
 });
 
 describe('import service', () => {
@@ -145,7 +143,7 @@ describe('import service', () => {
       return { on };
     };
 
-    httpx.request.returns({
+    https.get = (url, callback) => callback({
       headers: {},
       on,
       pipe: arg => ( { on })


### PR DESCRIPTION
通过 fun import api 进行导入时，某些函数代码包在导入过程中会出现 FILE_ENDED 错误，解决方式是使用 nodejs 内置的 https 库代替 httpx 库来下载代码