### PR TITLE
optimize init in git

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -20,10 +20,13 @@ async function init(context) {
     context.location = await promptForTemplate(Object.keys(context.templates));
   }
   const {repoDir, clean} = await determineRepoDir(context);
-  await buildContext(repoDir, context);
-  render(context);
-  if (clean) {
-    cleanTemplate(repoDir);
+  try {
+    await buildContext(repoDir, context);
+    render(context);
+  } finally {
+    if (clean) {
+      cleanTemplate(repoDir);
+    }
   }
 
 }

--- a/lib/import/service.js
+++ b/lib/import/service.js
@@ -3,7 +3,6 @@
 const { getFcClient } = require('../client');
 const {
   getTemplateFile,
-  makeSurePathExists,
   getCodeUri,
   checkResource,
   outputTemplateFile,
@@ -12,7 +11,7 @@ const {
 const { parseServiceResource } = require('./service-parser');
 const { parseFunctionResource } = require('./function-parser');
 const { parseTriggerResource } = require('./trigger-parser');
-const https = require('https');
+const httpx = require('httpx');
 const path = require('path');
 const unzipper = require('unzipper');
 const debug = require('debug')('fun:import:service');
@@ -70,21 +69,21 @@ async function getFunctionResource(serviceName, functionMeta, fullOutputDir, rec
 async function outputFunctionCode(serviceName, functionName, fullOutputDir) {
   const fc = await getFcClient();
   const { data } = await fc.getFunctionCode(serviceName, functionName);
+  const response = await httpx.request(data.url, { timeout: 36000000, method: 'GET' }); // 10 hours
+  const len = parseInt(response.headers['content-length'], 10);    
+  const bar = createProgressBar(`${green(':loading')} ${functionName} downloading :bar :rate/bps :percent :etas`, { total: len });
+  response.on('data', (chunk) => {
+    bar.tick(chunk.length);
+  });
+  response.on('end', () => {
+    console.log(`    ${green('✔')} ${functionName} - ${grey('Function')}`);
+  });
+  const fullTargetCodeDir = path.join(fullOutputDir, serviceName, functionName);
   return new Promise((resolve, reject) => {
-    https.get(data.url, response => {
-      var len = parseInt(response.headers['content-length'], 10);    
-      const bar = createProgressBar(`${green(':loading')} ${functionName} downloading :bar :rate/bps :percent :etas`, { total: len });
-      response.on('data', (chunk) => {
-        bar.tick(chunk.length);
-      });
-      response.on('end', () => {
-        console.log(`    ${green('✔')} ${functionName} - ${grey('Function')}`);
-      });
-      const fullTargetCodeDir = path.join(fullOutputDir, serviceName, functionName);
-      makeSurePathExists(fullTargetCodeDir);
-      response.pipe(unzipper.Extract({ path: fullTargetCodeDir })).on('error', reject).on('finish', resolve);
-    });
-    
+    response.pipe(unzipper.Extract({ path: fullTargetCodeDir })).on('error', err => {
+      bar.interrupt(err);
+      reject(err);
+    }).on('finish', resolve);
   });
 
 }

--- a/lib/import/utils.js
+++ b/lib/import/utils.js
@@ -6,17 +6,6 @@ const { green, white, red } = require('colors');
 const ProgressBar = require('progress');
 const { CUSTOM_DOMAIN_TYPE, SERVICE_TYPE } = require('./constants');
 
-function makeSurePathExists(p) {
-  if (fs.existsSync(p)) {
-    return true;
-  }
-  if (makeSurePathExists(path.dirname(p))) {
-    fs.mkdirSync(p);
-    return true;
-  }
-
-}
-
 function getTemplateFile(fullOutputDir) {
   const doGetTemplateFile = fileName => {
     const templateFilePath = path.resolve(fullOutputDir, fileName);
@@ -115,7 +104,6 @@ function getTemplateHeader() {
 
 module.exports = {
   getTemplateFile,
-  makeSurePathExists,
   getCodeUri,
   createProgressBar,
   checkResource,

--- a/lib/init/context.js
+++ b/lib/init/context.js
@@ -2,11 +2,10 @@
 'use strict';
 
 const { getConfig } = require('./config');
-const { makeSurePathExists } = require('./vcs');
 const { promptForConfig, promptForExistingPath } = require('./prompt');
 const templateSettings = require('lodash/templateSettings');
 const { renderContent } = require('./renderer');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 
 const debug = require('debug')('fun:context');
@@ -62,7 +61,7 @@ async function buildContext(repoDir, context) {
   context.templateDir = templateDir;
   const renderedDir = renderContent(templateDir, context);
   const fullTargetDir = path.resolve(context.outputDir, renderedDir);
-  makeSurePathExists(path.resolve(context.outputDir));
+  await fs.ensureDir(path.resolve(context.outputDir));
   debug(`Generating project to ${ fullTargetDir }...`);
   await promptForExistingPath(fullTargetDir, `You've created ${fullTargetDir} before. Is it okay to override it?`);
 

--- a/lib/init/vcs.js
+++ b/lib/init/vcs.js
@@ -1,11 +1,14 @@
 'use strict';
-const { promptForExistingPath } = require('./prompt');
 const commandExists = require('command-exists');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const debug = require('debug')('fun:vcs');
 const uuid = require('uuid');
+const httpx = require('httpx');
+const { createProgressBar } = require('../import/utils');
+const { green, yellow } = require('colors');
+const unzipper = require('unzipper');
 
 function identifyRepo(repoUrl) {
   debug('identify repo...');
@@ -19,7 +22,7 @@ function identifyRepo(repoUrl) {
   } else {
     if (repoUrl.indexOf('git') !== -1) {
       return { repoType: 'git', repoUrl: repoUrl };
-    } else if (repoUrl.indexOf('bitbucket')) {
+    } else if (repoUrl.indexOf('bitbucket') !== -1) {
       return { repoType: 'hg', repoUrl: repoUrl };
     }
   }
@@ -31,17 +34,6 @@ function isVCSInstalled(repoType) {
   return commandExists.sync(repoType);
 }
 
-function makeSurePathExists(p) {
-  if (fs.existsSync(p)) {
-    return true;
-  }
-  if (makeSurePathExists(path.dirname(p))) {
-    fs.mkdirSync(p);
-    return true;
-  }
-
-}
-
 function cloneArguments(repoType, repoUrl, outputDir) {
   switch (repoType) {
   case 'git':
@@ -51,18 +43,71 @@ function cloneArguments(repoType, repoUrl, outputDir) {
   }
 }
 
+function getRepoZipUrl(repoUrl) {
+  if (repoUrl.includes('github')) {
+    const parts = repoUrl.split('/');
+    const repo = parts.pop().replace('.git', '');
+    const group = parts.pop();
+    return `https://codeload.github.com/${group}/${repo}/zip/master`;
+  }
+  throw new Error('Only support repo zip file from github.');
+}
+
+function cloneRepo(repoType, repoUrl, outputDir, repoDir, checkout) {
+  console.log('start cloning...');
+  spawnSync(repoType, cloneArguments(repoType, repoUrl, outputDir), { cmd: repoDir, stdio: 'inherit' });
+  console.log('finish clone.');
+
+  if (checkout) {
+    debug('checkout is %s', checkout);
+    spawnSync(repoType, ['checkout', checkout], { cmd: repoDir, stdio: 'inherit' });
+  }
+}
+
+async function downloadRepoZip(repoType, repoUrl, repoDir, outputDir, checkout) {
+  if (checkout) {
+    console.warn(`Need to install ${repoType} to support checkout.`);
+  }
+  debug('start downloading...');
+  // https://github.com/JacksonTian/httpx/blob/master/lib/index.js#L36-L44
+  const response = await httpx.request(getRepoZipUrl(repoUrl), { timeout: 36000000, method: 'GET' }); // 10 hours
+  const len = parseInt(response.headers['content-length'], 10);
+  let bar;
+  if (len) {
+    bar = createProgressBar(`${green(':loading')} downloading :bar :rate/bps :percent :etas`, { total: len });
+  }
+  response.on('data', (chunk) => {
+    if (bar) {
+      bar.tick(chunk.length);
+    }
+  });
+  response.on('end', () => {
+    debug('finish download.');
+  });
+  
+  return new Promise((resolve, reject) => response.pipe(unzipper.Extract({ path: outputDir })).on('error', err => {
+    if (bar) {
+      bar.interrupt(err);
+    }
+    reject(err);
+  }).on('finish', () => {
+    const sourcePath = path.join(repoDir, repoUrl.split('/').pop().replace('.git', '') + '-master');
+    const cachePath = path.join(repoDir, '..', `.fun-init-cache-${uuid.v1()}`);
+    fs.moveSync(sourcePath, cachePath);
+    fs.moveSync(cachePath, repoDir, { overwrite: true });
+    resolve();
+  }));
+
+}
+
 async function clone(repoUrl, cloneToDir = '.', checkout) {
   debug('clone to dir: %s', cloneToDir);
   cloneToDir = path.resolve(cloneToDir);
-  makeSurePathExists(cloneToDir);
+  await fs.ensureDir(cloneToDir);
 
   const repo = identifyRepo(repoUrl);
   const repoType = repo.repoType;
   repoUrl = repo.repoUrl;
-
-  if (!isVCSInstalled(repoType)) {
-    throw new Error(`${repoType} is not installed.`);
-  }
 
   debug('repo type is: %s', repoType);
   debug('repo url is: %s', repoUrl);  
@@ -70,20 +115,21 @@ async function clone(repoUrl, cloneToDir = '.', checkout) {
   const outputDir = '.fun-init-cache-' + uuid.v1();
   let repoDir = path.join(cloneToDir, outputDir);
 
-  repoUrl = repoUrl.replace(/'^\/+|\/+$/g, '');
+  repoUrl = repoUrl.replace(/\/+$/g, '');
 
   debug('repoDir is %s', repoDir);
-  await promptForExistingPath(repoDir, `You've downloaded ${repoDir} before. Is it okay to delete and re-download it?`, true);
-  console.log('start cloning...');
-  spawnSync(repoType, cloneArguments(repoType, repoUrl, outputDir), { cmd: repoDir, stdio: 'inherit' });
-  console.log('finish cloning.');
-
-  if (checkout) {
-    debug('checkout is %s', checkout);
-    spawnSync(repoType, ['checkout', checkout], { cmd: repoDir, stdio: 'inherit' });
+  if (isVCSInstalled(repoType)) {
+    cloneRepo(repoType, repoUrl, outputDir, repoDir, checkout);
+  } else {
+    if (repoType === 'git') {
+      console.warn(yellow('git command is not installled, try to download template by HTTP.'));
+      await downloadRepoZip(repo, repoUrl, repoDir, outputDir, checkout);
+    } else {
+      throw new Error(`${repoType} is not installed.`);
+    }
   }
 
   return repoDir;
 }
 
-module.exports = { clone, makeSurePathExists };
+module.exports = { clone };

--- a/test/import/service.test.js
+++ b/test/import/service.test.js
@@ -46,13 +46,15 @@ const path = {
   resolve: sandbox.stub()
 };
 
-const https = {};
+const httpx = {
+  request: sandbox.stub()
+};
 
 const serviceStub = proxyquire('../../lib/import/service', {
   '../client': client,
   './utils': utils,
   'path': path,
-  'https': https
+  'httpx': httpx
 });
 
 describe('import service', () => {
@@ -143,7 +145,7 @@ describe('import service', () => {
       return { on };
     };
 
-    https.get = (url, callback) => callback({
+    httpx.request.returns({
       headers: {},
       on,
       pipe: arg => ( { on })

--- a/test/init/context.test.js
+++ b/test/init/context.test.js
@@ -6,7 +6,8 @@ const expect = require('expect.js');
 
 const sandbox = sinon.createSandbox();
 const fs = {
-  readdirSync: sandbox.stub()
+  readdirSync: sandbox.stub(),
+  ensureDir: sandbox.stub()
 };
 const config = {
   getConfig: sandbox.stub()
@@ -14,10 +15,6 @@ const config = {
 
 const renderer = {
   renderContent: sandbox.stub()
-};
-
-const vcs = {
-  makeSurePathExists: sandbox.stub()
 };
 
 const prompt = {
@@ -29,8 +26,7 @@ const contextStub = proxyquire('../../lib/init/context', {
   './config': config,
   './renderer': renderer,
   './prompt': prompt,
-  './vcs': vcs,
-  'fs': fs
+  'fs-extra': fs
 });
 
 describe('context', () => {


### PR DESCRIPTION
针对 Fun init 模板存 github 情况做如下优化：
1. 当发现用户没有安装 git 命令行工具，打印相关提示信息
2. 尝试从 github 上下载 repo master 分支对应的 zip 文件，解压渲染

备注：除了 github 以外的其他自建 git 的中心仓库不做处理，主要考虑有两点：
1. repo 的 zip url 地址没有统一的规范，很难考虑周全
2. 这种情况非常非常少

遇到一个 Transfer-Encoding 为 chunked 的情况，这样会取不到 content-length 响应头，详情如下：
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding