### PR TITLE
sunfeiyu/fun invoke

### DIFF
--- a/bin/fun-invoke.js
+++ b/bin/fun-invoke.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/* eslint-disable quotes */
+
+'use strict';
+
+const program = require('commander');
+const getVisitor = require('../lib/visitor').getVisitor;
+const notifier = require('../lib/update-notifier');
+
+program
+  .name('fun invoke')
+  .description('remote invoke function.')
+  .option('-e, --event [event]', `event data (strings) passed to the function during invocation,
+           which is empty sting by default if this option is not specified`, '')
+  .option('-f, --event-file <path>', `a file containing event data passed to the function during invoke.`)
+  .option('-s, --event-stdin', 'read by standard input, support pipeline.')
+  .option('-t, --invocation-type <invocationType>', `invocation type: optional value "Async"|"Sync", default value "Sync"`, 'Sync')
+
+  .parse(process.argv);
+
+if (program.args.length > 1) {
+  console.error();
+  console.error("  error: unexpected argument '%s'", program.args[1]);
+  program.help();
+}
+
+notifier.notify();
+
+getVisitor().then(visitor => {
+  visitor.pageview('/fun/invoke').send();
+
+  require('../lib/commands/invoke')(program.args[0], program)
+    .then(() => {
+      visitor.event({
+        ec: 'invoke',
+        ea: 'invoke',
+        el: 'success',
+        dp: '/fun/invoke'
+      }).send();
+    })
+    .catch(error => {
+      visitor.event({
+        ec: 'invoke',
+        ea: 'invoke',
+        el: 'error',
+        dp: '/fun/invoke'
+      }).send();
+
+      require('../lib/exception-handler')(error);
+    });
+});

--- a/bin/fun-invoke.js
+++ b/bin/fun-invoke.js
@@ -10,11 +10,11 @@ const notifier = require('../lib/update-notifier');
 
 program
   .name('fun invoke')
-  .description('remote invoke function.')
+  .description('invoke deployed function.')
   .option('-e, --event [event]', `event data (strings) passed to the function during invocation,
            which is empty sting by default if this option is not specified`, '')
   .option('-f, --event-file <path>', `a file containing event data passed to the function during invoke.`)
-  .option('-s, --event-stdin', 'read by standard input, support pipeline.')
+  .option('-s, --event-stdin', 'read from standard input, to support script pipeline.')
   .option('-t, --invocation-type <invocationType>', `invocation type: optional value "Async"|"Sync", default value "Sync"`, 'Sync')
 
   .parse(process.argv);

--- a/bin/fun-invoke.js
+++ b/bin/fun-invoke.js
@@ -15,7 +15,7 @@ program
            which is empty sting by default if this option is not specified`, '')
   .option('-f, --event-file <path>', `a file containing event data passed to the function during invoke.`)
   .option('-s, --event-stdin', 'read from standard input, to support script pipeline.')
-  .option('-t, --invocation-type <invocationType>', `invocation type: optional value "Async"|"Sync", default value "Sync"`, 'Sync')
+  .option('-t, --invocation-type <invocationType>', `invocation type: optional value "async"|"sync", default value "sync"`, 'sync')
 
   .parse(process.argv);
 

--- a/bin/fun-local-invoke.js
+++ b/bin/fun-local-invoke.js
@@ -40,7 +40,7 @@ notifier.notify();
 getVisitor().then(visitor => {
   visitor.pageview('/fun/local/invoke').send();
 
-  require('../lib/commands/local/invoke')(program.args[0], program)
+  require('../lib/commands/local/invoke').invoke(program.args[0], program)
     .then(() => {
       visitor.event({
         ec: 'local invoke',

--- a/bin/fun.js
+++ b/bin/fun.js
@@ -25,7 +25,8 @@ test serverless applications locally, and deploy them to the Alibaba Cloud.`)
   .command('edge', 'run your serverless application at edge')
   .command('validate', 'validate a fun template')
   .command('deploy', 'deploy a fun application')
-  .command('nas', 'operate NAS file system');
+  .command('nas', 'operate NAS file system')
+  .command('invoke', 'remote invoke function');
 // set default verbose value for subcommand.
 process.env.FUN_VERBOSE = 0;
 

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -93,23 +93,34 @@ async function detectHttpTrigger(serviceName, functionName) {
 
   if (_.isEmpty(triggers)) { return; }
 
-  const httpTrigger = triggers.find(t => t.triggerType === 'http' || t.triggerType === 'https');
+  const httpTrigger = triggers.filter(t => t.triggerType === 'http' || t.triggerType === 'https');
 
   if (_.isEmpty(httpTrigger)) { return; }
 
   const profile = await getProfile();
 
+  const triggerNames = httpTrigger.map(p => p.triggerName).join(',');
+
+  console.warn(red(`\n  function(name: ${functionName}) with http trigger(name: ${triggerNames}) can only be invoked with http trigger URL.`));
+
+  httpTrigger.forEach(trigger => {
+
+    displayTriggerInfo(trigger, profile.accountId, profile.defaultRegion, serviceName, functionName);
+  });
+
+  throw new Error();
+}
+
+function displayTriggerInfo(httpTrigger, accountId, region, serviceName, functionName) {
+
   const methods = httpTrigger.triggerConfig['methods'];
   const qualifier = httpTrigger.qualifier ? `.${httpTrigger.qualifier}` : '';
 
-  const accountId = profile.accountId;
-  const region = profile.defaultRegion;
-
-  throw new Error(`\n  function(name: ${functionName}) with http trigger(name: ${httpTrigger.triggerName}) can only be invoked with http trigger URL.
-
+  console.warn(`
   methods: ${yellow(methods)}
   url: ` + yellow(`https://${accountId}.${region}.fc.aliyuncs.com/2016-08-15/proxy/${serviceName}${qualifier}/${functionName}/`));
 }
+
 
 async function invoke(invokeName, options) {
 

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -93,7 +93,6 @@ async function detectHttpTrigger(serviceName, functionName) {
 
   if (_.isEmpty(triggers)) { return; }
 
-
   const httpTrigger = triggers.find(t => t.triggerType === 'http' || t.triggerType === 'https');
 
   if (_.isEmpty(httpTrigger)) { return; }

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -1,21 +1,19 @@
 'use strict';
 
+const fc = require('../fc');
 const path = require('path');
+const validate = require('../../lib/commands/validate');
+const getProfile = require('../../lib/profile').getProfile;
 
 const { detectTplPath, getTpl } = require('../tpl');
-
-const fc = require('../fc');
+const { getTriggerMetas } = require('../../lib/import/service');
 const { promptForFunctionSelection } = require('../init/prompt');
 const { parseInvokeName } = require('./local/invoke');
-
 const { findFunctionsInTpl } = require('../definition');
-
 const { getEvent } = require('../utils/file');
-
-const validate = require('../../lib/commands/validate');
+const { red, yellow } = require('colors');
 
 const _ = require('lodash');
-const { red } = require('colors');
 
 const invokeTypeSupport = ['async', 'sync'];
 
@@ -89,6 +87,30 @@ async function eventPriority(options) {
   return options.event;
 }
 
+async function detectHttpTrigger(serviceName, functionName) {
+
+  const triggers = await getTriggerMetas(serviceName, functionName);
+
+  if (_.isEmpty(triggers)) { return; }
+
+
+  const httpTrigger = triggers.find(t => t.triggerType === 'http' || t.triggerType === 'https');
+
+  if (_.isEmpty(httpTrigger)) { return; }
+
+  const profile = await getProfile();
+
+  const methods = httpTrigger.triggerConfig['methods'];
+
+  const accountId = profile.accountId;
+  const region = profile.defaultRegion;
+
+  throw new Error(`\n  function(name: ${functionName}) with http trigger(name: ${httpTrigger.triggerName}) can only be invoked with http trigger URL.
+
+  methods: ${yellow(methods)}
+  url: ` + yellow(`https://${accountId}.${region}.fc.aliyuncs.com/2016-08-15/proxy/${serviceName}/${functionName}/`));
+}
+
 async function invoke(invokeName, options) {
 
   const { serviceName, functionName } = await certainInvokeName(invokeName);
@@ -103,6 +125,8 @@ async function invoke(invokeName, options) {
   }
 
   const event = await eventPriority(options);
+
+  await detectHttpTrigger(serviceName, functionName);
 
   await fc.invokeFunction({serviceName, functionName, event, invocationType: _.upperFirst(upperCase)});
 }

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -101,12 +101,16 @@ async function detectHttpTrigger(serviceName, functionName) {
 
   const triggerNames = httpTrigger.map(p => p.triggerName).join(',');
 
-  console.warn(red(`\n  function(name: ${functionName}) with http trigger(name: ${triggerNames}) can only be invoked with http trigger URL.`));
+  console.warn(red(`\n  Currently fun invoke does not support functions with HTTP trigger`));
+
+  console.warn(`\n  function(name: ${functionName}) with http trigger(name: ${triggerNames}) can only be invoked with http trigger URL.`);
 
   httpTrigger.forEach(trigger => {
 
     displayTriggerInfo(trigger, profile.accountId, profile.defaultRegion, serviceName, functionName);
   });
+
+  console.log(`\n  users can make remote calls through console, postman or fcli command line tools.`);
 
   throw new Error();
 }
@@ -118,7 +122,7 @@ function displayTriggerInfo(httpTrigger, accountId, region, serviceName, functio
 
   console.warn(`
   methods: ${yellow(methods)}
-  url: ` + yellow(`https://${accountId}.${region}.fc.aliyuncs.com/2016-08-15/proxy/${serviceName}${qualifier}/${functionName}/`));
+  entry point: ` + yellow(`https://${accountId}.${region}.fc.aliyuncs.com/2016-08-15/proxy/${serviceName}${qualifier}/${functionName}/`));
 }
 
 

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -2,16 +2,20 @@
 
 const path = require('path');
 
+const { detectTplPath, getTpl } = require('../tpl');
+
 const fc = require('../fc');
-const { promptForInvokeFunctionSelection } = require('../init/prompt');
+const { promptForFunctionSelection } = require('../init/prompt');
 const { parseInvokeName } = require('./local/invoke');
+
+const { findFunctionInTpl, findFunctionsInTpl } = require('../definition');
 
 const { getEvent } = require('../utils/file');
 
 const _ = require('lodash');
 const { red } = require('colors');
 
-async function certainInvokeName(invokeName) {
+async function certainInvokeName(tpl, invokeName) {
 
   const [parsedServiceName, parsedFunctionName] = parseInvokeName(invokeName);
 
@@ -22,7 +26,10 @@ async function certainInvokeName(invokeName) {
 
   if (!parsedServiceName) {
 
-    const functions = await fc.getFunctionsByFunctionName(parsedFunctionName);
+    const functions = findFunctionsInTpl(tpl, (functionName, functionRes) => {
+
+      return functionName === parsedFunctionName;
+    });
 
     if (functions.length === 0) {
       
@@ -36,8 +43,14 @@ async function certainInvokeName(invokeName) {
       };
     } else {
 
-      return await promptForInvokeFunctionSelection(functions);
+      return await promptForFunctionSelection(functions);
     }
+  }
+
+  const {functionRes} = findFunctionInTpl(parsedServiceName, parsedFunctionName, tpl);
+
+  if (!functionRes) {
+    throw new Error(red(`function '${parsedFunctionName}' does not exist in service '${parsedServiceName}'.`));
   }
 
   return {
@@ -76,13 +89,18 @@ const invokeTypeMapping = {
 
 async function invoke(invokeName, options) {
 
+  const tplPath = await detectTplPath();
+
+  const tpl = await getTpl(tplPath);
+
+  const { serviceName, functionName } = await certainInvokeName(tpl, invokeName);
+
   const invocationType = options.invocationType;
+
   if (!_.includes(invokeTypeSupport, invocationType)) {
 
     throw new Error(red(`error: unexpected argument：${invocationType}`));
   }
-
-  const { serviceName, functionName } = await certainInvokeName(invokeName);
 
   const event = await eventPriority(options);
 

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -8,14 +8,14 @@ const fc = require('../fc');
 const { promptForFunctionSelection } = require('../init/prompt');
 const { parseInvokeName } = require('./local/invoke');
 
-const { findFunctionInTpl, findFunctionsInTpl } = require('../definition');
+const { findFunctionsInTpl } = require('../definition');
 
 const { getEvent } = require('../utils/file');
 
 const _ = require('lodash');
 const { red } = require('colors');
 
-async function certainInvokeName(tpl, invokeName) {
+async function certainInvokeName(invokeName) {
 
   const [parsedServiceName, parsedFunctionName] = parseInvokeName(invokeName);
 
@@ -25,6 +25,10 @@ async function certainInvokeName(tpl, invokeName) {
   }
 
   if (!parsedServiceName) {
+
+    const tplPath = await detectTplPath();
+
+    const tpl = await getTpl(tplPath);
 
     const functions = findFunctionsInTpl(tpl, (functionName, functionRes) => {
 
@@ -45,12 +49,6 @@ async function certainInvokeName(tpl, invokeName) {
 
       return await promptForFunctionSelection(functions);
     }
-  }
-
-  const {functionRes} = findFunctionInTpl(parsedServiceName, parsedFunctionName, tpl);
-
-  if (!functionRes) {
-    throw new Error(red(`function '${parsedFunctionName}' does not exist in service '${parsedServiceName}'.`));
   }
 
   return {
@@ -89,11 +87,7 @@ const invokeTypeMapping = {
 
 async function invoke(invokeName, options) {
 
-  const tplPath = await detectTplPath();
-
-  const tpl = await getTpl(tplPath);
-
-  const { serviceName, functionName } = await certainInvokeName(tpl, invokeName);
+  const { serviceName, functionName } = await certainInvokeName(invokeName);
 
   const invocationType = options.invocationType;
 

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -100,6 +100,7 @@ async function detectHttpTrigger(serviceName, functionName) {
   const profile = await getProfile();
 
   const methods = httpTrigger.triggerConfig['methods'];
+  const qualifier = httpTrigger.qualifier ? `.${httpTrigger.qualifier}` : '';
 
   const accountId = profile.accountId;
   const region = profile.defaultRegion;
@@ -107,7 +108,7 @@ async function detectHttpTrigger(serviceName, functionName) {
   throw new Error(`\n  function(name: ${functionName}) with http trigger(name: ${httpTrigger.triggerName}) can only be invoked with http trigger URL.
 
   methods: ${yellow(methods)}
-  url: ` + yellow(`https://${accountId}.${region}.fc.aliyuncs.com/2016-08-15/proxy/${serviceName}/${functionName}/`));
+  url: ` + yellow(`https://${accountId}.${region}.fc.aliyuncs.com/2016-08-15/proxy/${serviceName}${qualifier}/${functionName}/`));
 }
 
 async function invoke(invokeName, options) {

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -60,16 +60,16 @@ async function certainInvokeName(invokeName) {
 
   const [parsedServiceName, parsedFunctionName] = parseInvokeName(invokeName);
 
-  if (!parsedServiceName && !parsedFunctionName) {
+  if (!parsedFunctionName) {
 
-    throw new Error('unexpect parameter /');
+    throw new Error(`invalid invokeName '${invokeName}'.`);
   }
 
   if (!parsedServiceName) {
 
     return await findFunctionInCurrentDirectory(parsedFunctionName);
   }
-
+  
   return {
     serviceName: parsedServiceName,
     functionName: parsedFunctionName

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -65,10 +65,19 @@ async function eventPriority(options) {
   return options.event;
 }
 
+const invokeTypeSupport = ['Async', 'Sync', 'async', 'sync'];
+
+const invokeTypeMapping = {
+  'Async': 'Async',
+  'async': 'Async',
+  'Sync': 'Sync',
+  'sync': 'Sync'
+};
+
 async function invoke(invokeName, options) {
 
   const invocationType = options.invocationType;
-  if (!_.includes(['Async', 'Sync'], invocationType)) {
+  if (!_.includes(invokeTypeSupport, invocationType)) {
 
     throw new Error(red(`error: unexpected argument：${invocationType}`));
   }
@@ -77,7 +86,7 @@ async function invoke(invokeName, options) {
 
   const event = await eventPriority(options);
 
-  await fc.invokeFunction({serviceName, functionName, event, invocationType});
+  await fc.invokeFunction({serviceName, functionName, event, invocationType: invokeTypeMapping[invocationType]});
 }
 
 module.exports = invoke;

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const debug = require('debug')('fun:local');
+
+const fc = require('../fc');
+const { promptForInvokeFunctionSelection } = require('../init/prompt');
+
+const readline = require('readline');
+const getStdin = require('get-stdin');
+
+const getVisitor = require('../visitor').getVisitor;
+
+const _ = require('lodash');
+const { red } = require('colors');
+
+function parseInvokeName(invokeName) {
+
+  let serviceName = null;
+  let functionName = null;
+
+  let index = invokeName.indexOf('/');
+
+  if (index < 0) {
+    functionName = invokeName;
+  } else {
+    serviceName = invokeName.substring(0, index);
+    functionName = invokeName.substring(index + 1);
+  }
+
+  debug(`invoke service: ${serviceName}`);
+
+  debug(`invoke function: ${functionName}`);
+
+  return [serviceName, functionName];
+}
+
+/**
+ * Get event content from a file. It reads event from stdin if the file is "-".
+ *
+ * @param file the file from which to read the event content, or "-" to read from stdin.
+ * @returns {Promise<String>}
+ */
+async function getEvent(eventFile) {
+  let event = await getStdin(); // read from pipes
+
+  if (event && eventFile) {
+    throw new Error(red('-e or stdin only one can be provided'));
+  }
+
+  if (!eventFile) { return event; }
+
+  return new Promise((resolve, reject) => {
+
+    let input;
+
+    if (eventFile === '-') { // read from stdin
+      console.log(`Reading event data from stdin, which can be ended with Enter then Ctrl+D
+  (you can also pass it from file with -e)`);
+      input = process.stdin;
+    } else {
+      input = fs.createReadStream(eventFile, {
+        encoding: 'utf-8'
+      });
+    }
+    const rl = readline.createInterface({
+      input
+    });
+    
+    event = '';
+    rl.on('line', (line) => {
+      event += line;
+    });
+    rl.on('close', () => {
+      getVisitor().then(visitor => {
+        visitor.event({
+          ec: 'invoke',
+          ea: 'getEvent',
+          el: 'success',
+          dp: '/fun/invoke'
+        }).send();
+  
+        resolve(event);
+      });
+    });
+    
+    rl.on('SIGINT', function () {
+      
+      getVisitor().then(visitor => {
+        visitor.event({
+          ec: 'invoke',
+          ea: 'getEvent',
+          el: 'cancel',
+          dp: '/fun/invoke'
+        }).send();
+  
+        // Keep the behavior consistent with system.
+        reject(new Error('^C'));
+      });
+    });
+  });
+}
+
+async function certainInvokeName(invokeName) {
+
+  const [parsedServiceName, parsedFunctionName] = parseInvokeName(invokeName);
+
+  if (!parsedServiceName && !parsedFunctionName) {
+
+    throw new Error('unexpect parameter /');
+  }
+
+  if (!parsedServiceName) {
+
+    const functions = await fc.getFunctionsByFunctionName(parsedFunctionName);
+
+    if (functions.length === 0) {
+      
+      throw new Error(`don't exit function: ${parsedFunctionName}`);
+
+    } else if (functions.length === 1) {
+      
+      return {
+        serviceName: _.first(functions).serviceName,
+        functionName: _.first(functions).functionName
+      };
+    } else {
+
+      return await promptForInvokeFunctionSelection(functions);
+    }
+  }
+
+  return {
+    serviceName: parsedServiceName,
+    functionName: parsedFunctionName
+  };
+}
+
+async function eventPriority(options) {
+
+  if (options.eventStdin) {
+
+    return await getEvent('-');
+  }
+
+  if (options.eventFile) {
+
+    const eventFile = options.eventFile;
+
+    let filePath = path.isAbsolute(eventFile)? eventFile : path.join(process.cwd(), eventFile);
+
+    return await getEvent(filePath);
+  }
+
+  return options.event;
+}
+
+async function invoke(invokeName, options) {
+
+  const invocationType = options.invocationType;
+  if (!_.includes(['Async', 'Sync'], invocationType)) {
+
+    throw new Error(red(`error: unexpected argument：${invocationType}`));
+  }
+
+  const { serviceName, functionName } = await certainInvokeName(invokeName);
+
+  const event = await eventPriority(options);
+
+  await fc.funInvokeFunction({serviceName, functionName, event, invocationType});
+}
+
+module.exports = invoke;

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -1,106 +1,15 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
-const debug = require('debug')('fun:local');
 
 const fc = require('../fc');
 const { promptForInvokeFunctionSelection } = require('../init/prompt');
+const { parseInvokeName } = require('./local/invoke');
 
-const readline = require('readline');
-const getStdin = require('get-stdin');
-
-const getVisitor = require('../visitor').getVisitor;
+const { getEvent } = require('../utils/file');
 
 const _ = require('lodash');
 const { red } = require('colors');
-
-function parseInvokeName(invokeName) {
-
-  let serviceName = null;
-  let functionName = null;
-
-  let index = invokeName.indexOf('/');
-
-  if (index < 0) {
-    functionName = invokeName;
-  } else {
-    serviceName = invokeName.substring(0, index);
-    functionName = invokeName.substring(index + 1);
-  }
-
-  debug(`invoke service: ${serviceName}`);
-
-  debug(`invoke function: ${functionName}`);
-
-  return [serviceName, functionName];
-}
-
-/**
- * Get event content from a file. It reads event from stdin if the file is "-".
- *
- * @param file the file from which to read the event content, or "-" to read from stdin.
- * @returns {Promise<String>}
- */
-async function getEvent(eventFile) {
-  let event = await getStdin(); // read from pipes
-
-  if (event && eventFile) {
-    throw new Error(red('-e or stdin only one can be provided'));
-  }
-
-  if (!eventFile) { return event; }
-
-  return new Promise((resolve, reject) => {
-
-    let input;
-
-    if (eventFile === '-') { // read from stdin
-      console.log(`Reading event data from stdin, which can be ended with Enter then Ctrl+D
-  (you can also pass it from file with -e)`);
-      input = process.stdin;
-    } else {
-      input = fs.createReadStream(eventFile, {
-        encoding: 'utf-8'
-      });
-    }
-    const rl = readline.createInterface({
-      input
-    });
-    
-    event = '';
-    rl.on('line', (line) => {
-      event += line;
-    });
-    rl.on('close', () => {
-      getVisitor().then(visitor => {
-        visitor.event({
-          ec: 'invoke',
-          ea: 'getEvent',
-          el: 'success',
-          dp: '/fun/invoke'
-        }).send();
-  
-        resolve(event);
-      });
-    });
-    
-    rl.on('SIGINT', function () {
-      
-      getVisitor().then(visitor => {
-        visitor.event({
-          ec: 'invoke',
-          ea: 'getEvent',
-          el: 'cancel',
-          dp: '/fun/invoke'
-        }).send();
-  
-        // Keep the behavior consistent with system.
-        reject(new Error('^C'));
-      });
-    });
-  });
-}
 
 async function certainInvokeName(invokeName) {
 
@@ -141,7 +50,7 @@ async function eventPriority(options) {
 
   if (options.eventStdin) {
 
-    return await getEvent('-');
+    return await getEvent('-', 'fun invoke', '/fun/invoke');
   }
 
   if (options.eventFile) {
@@ -150,7 +59,7 @@ async function eventPriority(options) {
 
     let filePath = path.isAbsolute(eventFile)? eventFile : path.join(process.cwd(), eventFile);
 
-    return await getEvent(filePath);
+    return await getEvent(filePath, 'fun invoke', '/fun/invoke');
   }
 
   return options.event;
@@ -168,7 +77,7 @@ async function invoke(invokeName, options) {
 
   const event = await eventPriority(options);
 
-  await fc.funInvokeFunction({serviceName, functionName, event, invocationType});
+  await fc.invokeFunction({serviceName, functionName, event, invocationType});
 }
 
 module.exports = invoke;

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -19,8 +19,6 @@ const { red } = require('colors');
 
 const invokeTypeSupport = ['async', 'sync'];
 
-
-
 async function findFunctionInCurrentDirectory(invokeFunctionName) {
 
   const tplPath = await detectTplPath();
@@ -69,7 +67,7 @@ async function certainInvokeName(invokeName) {
 
     return await findFunctionInCurrentDirectory(parsedFunctionName);
   }
-  
+
   return {
     serviceName: parsedServiceName,
     functionName: parsedFunctionName

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -12,8 +12,49 @@ const { findFunctionsInTpl } = require('../definition');
 
 const { getEvent } = require('../utils/file');
 
+const validate = require('../../lib/commands/validate');
+
 const _ = require('lodash');
 const { red } = require('colors');
+
+const invokeTypeSupport = ['async', 'sync'];
+
+
+
+async function findFunctionInCurrentDirectory(invokeFunctionName) {
+
+  const tplPath = await detectTplPath();
+
+  if (!tplPath) {
+
+    throw new Error(red('Current folder not a fun project\nThe folder must contains template.[yml|yaml] or faas.[yml|yaml] .'));
+  }
+
+  await validate(tplPath);
+
+  const tpl = await getTpl(tplPath);
+
+  const functions = findFunctionsInTpl(tpl, (functionName, functionRes) => {
+
+    return functionName === invokeFunctionName;
+  });
+
+  if (functions.length === 0) {
+    
+    throw new Error(`don't exit function: ${invokeFunctionName}`);
+
+  } else if (functions.length === 1) {
+    
+    return {
+      serviceName: _.first(functions).serviceName,
+      functionName: _.first(functions).functionName
+    };
+  } else {
+
+    return await promptForFunctionSelection(functions);
+  }
+}
+
 
 async function certainInvokeName(invokeName) {
 
@@ -26,29 +67,7 @@ async function certainInvokeName(invokeName) {
 
   if (!parsedServiceName) {
 
-    const tplPath = await detectTplPath();
-
-    const tpl = await getTpl(tplPath);
-
-    const functions = findFunctionsInTpl(tpl, (functionName, functionRes) => {
-
-      return functionName === parsedFunctionName;
-    });
-
-    if (functions.length === 0) {
-      
-      throw new Error(`don't exit function: ${parsedFunctionName}`);
-
-    } else if (functions.length === 1) {
-      
-      return {
-        serviceName: _.first(functions).serviceName,
-        functionName: _.first(functions).functionName
-      };
-    } else {
-
-      return await promptForFunctionSelection(functions);
-    }
+    return await findFunctionInCurrentDirectory(parsedFunctionName);
   }
 
   return {
@@ -66,24 +85,11 @@ async function eventPriority(options) {
 
   if (options.eventFile) {
 
-    const eventFile = options.eventFile;
-
-    let filePath = path.isAbsolute(eventFile)? eventFile : path.join(process.cwd(), eventFile);
-
-    return await getEvent(filePath, 'fun invoke', '/fun/invoke');
+    return await getEvent(path.resolve(options.eventFile), 'fun invoke', '/fun/invoke');
   }
 
   return options.event;
 }
-
-const invokeTypeSupport = ['Async', 'Sync', 'async', 'sync'];
-
-const invokeTypeMapping = {
-  'Async': 'Async',
-  'async': 'Async',
-  'Sync': 'Sync',
-  'sync': 'Sync'
-};
 
 async function invoke(invokeName, options) {
 
@@ -91,14 +97,16 @@ async function invoke(invokeName, options) {
 
   const invocationType = options.invocationType;
 
-  if (!_.includes(invokeTypeSupport, invocationType)) {
+  const upperCase = _.lowerCase(invocationType);
+
+  if (!_.includes(invokeTypeSupport, upperCase)) {
 
     throw new Error(red(`error: unexpected argument：${invocationType}`));
   }
 
   const event = await eventPriority(options);
 
-  await fc.invokeFunction({serviceName, functionName, event, invocationType: invokeTypeMapping[invocationType]});
+  await fc.invokeFunction({serviceName, functionName, event, invocationType: _.upperFirst(upperCase)});
 }
 
 module.exports = invoke;

--- a/lib/commands/local/invoke.js
+++ b/lib/commands/local/invoke.js
@@ -1,19 +1,16 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('fun:local');
 
 const validate = require('../../validate/validate');
-const readline = require('readline');
-const getStdin = require('get-stdin');
+
 const definition = require('../../definition');
 const fc = require('../../fc');
 const { getDebugPort, getDebugIde } = require('../../debug');
-const getVisitor = require('../../visitor').getVisitor;
 
 const { detectTplPath, getTpl } = require('../../tpl');
-
+const { getEvent } = require('../../utils/file');
 const { red, yellow } = require('colors');
 
 function parseInvokeName(invokeName) {
@@ -72,72 +69,6 @@ async function localInvoke(invokeName, tpl, debugPort, event, debugIde, tplPath)
   await localInvoke.invoke(event);
 }
 
-/**
- * Get event content from a file. It reads event from stdin if the file is "-".
- *
- * @param file the file from which to read the event content, or "-" to read from stdin.
- * @returns {Promise<String>}
- */
-async function getEvent(eventFile) {
-  let event = await getStdin(); // read from pipes
-  if (event && eventFile) {
-    throw new Error(red('-e or stdin only one can be provided'));
-  }
-
-  if (!eventFile) { return event; }
-
-  return new Promise((resolve, reject) => {
-
-    let input;
-
-    if (eventFile === '-') { // read from stdin
-      console.log(`Reading event data from stdin, which can be ended with Enter then Ctrl+D
-  (you can also pass it from file with -e)`);
-      input = process.stdin;
-    } else {
-      input = fs.createReadStream(eventFile, {
-        encoding: 'utf-8'
-      });
-    }
-    const rl = readline.createInterface({
-      input,
-      output: process.stdout
-    });
-    
-    event = '';
-    rl.on('line', (line) => {
-      event += line;
-    });
-    rl.on('close', () => {
-      getVisitor().then(visitor => {
-        visitor.event({
-          ec: 'local invoke',
-          ea: 'getEvent',
-          el: 'success',
-          dp: '/fun/local/invoke'
-        }).send();
-  
-        resolve(event);
-      });
-    });
-    
-    rl.on('SIGINT', function () {
-      
-      getVisitor().then(visitor => {
-        visitor.event({
-          ec: 'local invoke',
-          ea: 'getEvent',
-          el: 'cancel',
-          dp: '/fun/local/invoke'
-        }).send();
-  
-        // Keep the behavior consistent with system.
-        reject(new Error('^C'));
-      });
-    });
-  });
-}
-
 async function invoke(invokeName, options) {
 
   const tplPath = await detectTplPath();
@@ -164,4 +95,4 @@ async function invoke(invokeName, options) {
   }
 }
 
-module.exports = invoke;
+module.exports = { invoke, parseInvokeName };

--- a/lib/definition.js
+++ b/lib/definition.js
@@ -216,20 +216,20 @@ function findServiceByServiceName (resources, name) {
   return {};
 }
 
-function findAllFunctionsByFunctionName(resources, funcName) {
+function findAllFunctionsByFunctionName(resources, functionName) {
 
   let functions = [];
 
   for (let { serviceName, serviceRes } of findServices(resources)) {
     debug('servicename: ' + serviceName);
-    const functionRes = findFunctionInService(funcName, serviceRes);
+    const functionRes = findFunctionInService(functionName, serviceRes);
 
     if (functionRes) {
 
       functions.push({
         serviceName,
         serviceRes,
-        funcName,
+        functionName,
         functionRes
       });
     }
@@ -257,13 +257,11 @@ async function matchingFuntionUnderServiceBySourceName(resources, sourceName) {
 
   } else if (functions.length > 1) {
 
-    const choiseSourceName = await promptForFunctionSelection(functions);
-
-    const array = _.split(choiseSourceName, '/');
+    const { serviceName, functionName } = await promptForFunctionSelection(functions);
 
     const selectionFunction = functions.find(funcObj => {
 
-      return funcObj.serviceName === _.first(array) && funcObj.funcName === _.last(array);
+      return funcObj.serviceName === serviceName && funcObj.functionName === functionName;
     });
 
     // delete unmatch functions under a serviceRes
@@ -281,7 +279,7 @@ async function matchingFuntionUnderServiceBySourceName(resources, sourceName) {
   serviceRes = deleteUnmatchFunctionsUnderServiceRes({
     serviceName,
     serviceRes,
-    funcName: sourceName
+    functionName: sourceName
   });
 
   return {
@@ -294,21 +292,21 @@ async function matchingFuntionUnderServiceBySourceName(resources, sourceName) {
 function deleteUnmatchFunctionsUnderServiceRes({
   serviceName,
   serviceRes,
-  funcName
+  functionName
 }) {
 
   const functionNamesInService = findFunctions(serviceRes).map(funRes => {
     return funRes.functionName;
   });
 
-  if (!_.includes(functionNamesInService, funcName)) {
+  if (!_.includes(functionNamesInService, functionName)) {
 
-    throw new Error(`could not found service/function：` + green(`${serviceName}`) + `/` + red(`${funcName}`));
+    throw new Error(`could not found service/function：` + green(`${serviceName}`) + `/` + red(`${functionName}`));
   }
 
-  for (let { functionName } of findFunctions(serviceRes)) {
+  for (let functions of findFunctions(serviceRes)) {
 
-    if (functionName !== funcName) {
+    if (functions.functionName !== functionName) {
 
       serviceRes = _.omit(serviceRes, functionName);
     }
@@ -326,7 +324,7 @@ function findServiceByCertainServiceAndFunctionName(resources, certainServiceNam
       serviceRes = deleteUnmatchFunctionsUnderServiceRes({
         serviceName,
         serviceRes,
-        funcName: certainFunctionName
+        functionName: certainFunctionName
       });
 
       return {

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -13,6 +13,7 @@ const { addEnv, resolveLibPathsFromLdConf } = require('./install/env');
 const funignore = require('./package/ignore');
 const _ = require('lodash');
 const definition = require('./definition');
+const { getFunctionMetas, listServiceMetas } = require('./import/service');
 
 const promiseRetry = require('./retry');
 
@@ -499,6 +500,70 @@ async function makeFcUtilsFunctionNasDirChecker(role, vpcConfig, nasConfig) {
   return functionName;
 }
 
+
+async function funInvokeFunction({
+  serviceName,
+  functionName,
+  event,
+  invocationType
+}) {
+
+  var rs;
+  const fc = await getFcClient();
+
+  if (invocationType === 'Sync') {
+
+    rs = await fc.invokeFunction(serviceName, functionName, event, {
+      'X-Fc-Log-Type': 'Tail',
+      'X-Fc-Invocation-Type': invocationType
+    });
+
+    const log = rs.headers['x-fc-log-result'];
+
+    if (log) {
+
+      console.log(yellow('========= FC invoke Logs begin ========='));
+      const decodedLog = Buffer.from(log, 'base64');
+      console.log(decodedLog.toString());
+      console.log(yellow('========= FC invoke Logs end ========='));
+
+      console.log(green('\nFC Invoke Result:') + JSON.stringify(rs.data, null, 4));
+    }
+  } else {
+
+    rs = await fc.invokeFunction(serviceName, functionName, event, {
+      'X-Fc-Invocation-Type': invocationType
+    });
+
+    console.log(green('✔ ') + `${serviceName}/${functionName} async invoke success.`);
+  }
+
+  return rs;
+}
+
+async function getFunctionsByFunctionName(functionName) {
+  const functions = [];
+
+  const listServices = await listServiceMetas();
+
+  for (const service of listServices) {
+
+    const listFunctions = await getFunctionMetas(service.serviceName);
+
+    for (const func of listFunctions) {
+
+      if (func.functionName === functionName) {
+
+        functions.push({
+          serviceName: service.serviceName,
+          functionName
+        });
+      }
+    }
+  }
+  return functions;
+}
+
 module.exports = {
   invokeFcUtilsFunction,
   makeFcUtilsFunctionNasDirChecker,
@@ -507,5 +572,6 @@ module.exports = {
   makeFunction,
   getFunCodeAsBase64,
   detectLibrary,
-  getFcUtilsFunctionCode
+  getFcUtilsFunctionCode,
+  funInvokeFunction
 };

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -501,7 +501,7 @@ async function makeFcUtilsFunctionNasDirChecker(role, vpcConfig, nasConfig) {
 }
 
 
-async function funInvokeFunction({
+async function invokeFunction({
   serviceName,
   functionName,
   event,
@@ -573,5 +573,6 @@ module.exports = {
   getFunCodeAsBase64,
   detectLibrary,
   getFcUtilsFunctionCode,
-  funInvokeFunction
+  getFunctionsByFunctionName,
+  invokeFunction
 };

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -526,7 +526,8 @@ async function invokeFunction({
       console.log(decodedLog.toString());
       console.log(yellow('========= FC invoke Logs end ========='));
 
-      console.log(green('\nFC Invoke Result:') + JSON.stringify(rs.data, null, 4));
+      console.log(green('\nFC Invoke Result:'));
+      console.log(rs.data);
     }
   } else {
 

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -13,7 +13,6 @@ const { addEnv, resolveLibPathsFromLdConf } = require('./install/env');
 const funignore = require('./package/ignore');
 const _ = require('lodash');
 const definition = require('./definition');
-const { getFunctionMetas, listServiceMetas } = require('./import/service');
 
 const promiseRetry = require('./retry');
 
@@ -541,29 +540,6 @@ async function invokeFunction({
   return rs;
 }
 
-async function getFunctionsByFunctionName(functionName) {
-  const functions = [];
-
-  const listServices = await listServiceMetas();
-
-  for (const service of listServices) {
-
-    const listFunctions = await getFunctionMetas(service.serviceName);
-
-    for (const func of listFunctions) {
-
-      if (func.functionName === functionName) {
-
-        functions.push({
-          serviceName: service.serviceName,
-          functionName
-        });
-      }
-    }
-  }
-  return functions;
-}
-
 module.exports = {
   invokeFcUtilsFunction,
   makeFcUtilsFunctionNasDirChecker,
@@ -573,6 +549,5 @@ module.exports = {
   getFunCodeAsBase64,
   detectLibrary,
   getFcUtilsFunctionCode,
-  getFunctionsByFunctionName,
   invokeFunction
 };

--- a/lib/import/service.js
+++ b/lib/import/service.js
@@ -173,5 +173,6 @@ module.exports = {
   getServiceResource, 
   importService,
   getServiceMeta,
-  listServiceMetas
+  listServiceMetas,
+  getTriggerMetas
 };

--- a/lib/import/service.js
+++ b/lib/import/service.js
@@ -168,5 +168,10 @@ async function importService(serviceName, outputDir = '.', recursive = true, onl
 }
 
 module.exports = {
-  getFunctionResource, outputFunctionCode, getServiceResource, importService, getServiceMeta
+  getFunctionResource,
+  outputFunctionCode,
+  getServiceResource, 
+  importService,
+  getServiceMeta,
+  listServiceMetas
 };

--- a/lib/init/prompt.js
+++ b/lib/init/prompt.js
@@ -82,12 +82,11 @@ async function promptForTemplate(templates) {
   });
 }
 
-
 async function promptForFunctionSelection(functions) {
 
   const choicesFuntions = functions.map(func => {
       
-    return func.serviceName + '/' + func.funcName;
+    return func.serviceName + '/' + func.functionName;
   });
 
   return inquirer.prompt([
@@ -98,28 +97,8 @@ async function promptForFunctionSelection(functions) {
       choices: choicesFuntions
     }
   ]).then(answers => {
-    return answers.function;
-  });
-}
 
-
-async function promptForInvokeFunctionSelection(functions) {
-
-  const choicesFuntions = functions.map(func => {
-      
-    return func.serviceName + '/' + func.functionName;
-  });
-
-  return inquirer.prompt([
-    {
-      type: 'list',
-      message: 'Select a invoke function?',
-      name: 'invokeFunction',
-      choices: choicesFuntions
-    }
-  ]).then(answers => {
-
-    const splitFunc = _.split(answers.invokeFunction, '/');
+    const splitFunc = _.split(answers.function, '/');
 
     return {
       serviceName: _.first(splitFunc),
@@ -128,10 +107,9 @@ async function promptForInvokeFunctionSelection(functions) {
   });
 }
 
-module.exports = { 
+module.exports = {
   promptForConfig, 
   promptForExistingPath, 
   promptForTemplate, 
-  promptForFunctionSelection, 
-  promptForInvokeFunctionSelection
+  promptForFunctionSelection
 };

--- a/lib/init/prompt.js
+++ b/lib/init/prompt.js
@@ -6,6 +6,8 @@ const { isEmpty, isArray } = require('lodash/lang');
 const { sync } = require('rimraf');
 const debug = require('debug')('fun:prompt');
 
+const _ = require('lodash');
+
 inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
 
 async function promptForConfig(context) {
@@ -100,4 +102,36 @@ async function promptForFunctionSelection(functions) {
   });
 }
 
-module.exports = { promptForConfig, promptForExistingPath, promptForTemplate, promptForFunctionSelection };
+
+async function promptForInvokeFunctionSelection(functions) {
+
+  const choicesFuntions = functions.map(func => {
+      
+    return func.serviceName + '/' + func.functionName;
+  });
+
+  return inquirer.prompt([
+    {
+      type: 'list',
+      message: 'Select a invoke function?',
+      name: 'invokeFunction',
+      choices: choicesFuntions
+    }
+  ]).then(answers => {
+
+    const splitFunc = _.split(answers.invokeFunction, '/');
+
+    return {
+      serviceName: _.first(splitFunc),
+      functionName: _.last(splitFunc)
+    };
+  });
+}
+
+module.exports = { 
+  promptForConfig, 
+  promptForExistingPath, 
+  promptForTemplate, 
+  promptForFunctionSelection, 
+  promptForInvokeFunctionSelection
+};

--- a/lib/tpl.js
+++ b/lib/tpl.js
@@ -12,9 +12,16 @@ const exists = util.promisify(fs.exists);
 const readFile = util.promisify(fs.readFile);
 
 async function detectTplPath() {
-  return ['template.yml', 'template.yaml', 'faas.yml', 'faas.yaml']
-    .map((f) => path.join(process.cwd(), f))
-    .find(async (p) => (await exists(p)));
+
+  const tplPath = ['template.yml', 'template.yaml', 'faas.yml', 'faas.yaml']
+    .map((f) => path.join(process.cwd(), f));
+
+  for (const path of tplPath) {
+    if (await exists(path)) {
+      return path;
+    }
+  }
+  return null;
 }
 
 async function getTpl(tplPath) {

--- a/lib/utils/file.js
+++ b/lib/utils/file.js
@@ -2,6 +2,11 @@
 
 const fs = require('fs-extra');
 const readline = require('readline');
+const getStdin = require('get-stdin');
+
+const { red } = require('colors');
+
+const getVisitor = require('../../visitor').getVisitor;
 
 function readLines(fileName) {
   return new Promise((resolve, reject) => {
@@ -14,4 +19,71 @@ function readLines(fileName) {
   });
 }
 
-module.exports = { readLines };
+/**
+ * Get event content from a file. It reads event from stdin if the file is "-".
+ *
+ * @param file the file from which to read the event content, or "-" to read from stdin.
+ * @returns {Promise<String>}
+ */
+async function getEvent(eventFile, ec = 'local invoke', dp = '/fun/local/invoke') {
+  let event = await getStdin(); // read from pipes
+
+  if (event && eventFile) {
+    throw new Error(red('-e or stdin only one can be provided'));
+  }
+
+  if (!eventFile) { return event; }
+
+  return new Promise((resolve, reject) => {
+
+    let input;
+
+    if (eventFile === '-') { // read from stdin
+      console.log(`Reading event data from stdin, which can be ended with Enter then Ctrl+D
+  (you can also pass it from file with -e)`);
+      input = process.stdin;
+    } else {
+      input = fs.createReadStream(eventFile, {
+        encoding: 'utf-8'
+      });
+    }
+    const rl = readline.createInterface({
+      input
+    });
+    
+    event = '';
+    rl.on('line', (line) => {
+      event += line;
+    });
+    rl.on('close', () => {
+      getVisitor().then(visitor => {
+        visitor.event({
+          ec,
+          ea: 'getEvent',
+          el: 'success',
+          dp
+        }).send();
+  
+        resolve(event);
+      });
+    });
+    
+    rl.on('SIGINT', function () {
+      
+      getVisitor().then(visitor => {
+        visitor.event({
+          ec,
+          ea: 'getEvent',
+          el: 'cancel',
+          dp
+        }).send();
+  
+        // Keep the behavior consistent with system.
+        reject(new Error('^C'));
+      });
+    });
+  });
+}
+
+
+module.exports = { readLines, getEvent };

--- a/lib/utils/file.js
+++ b/lib/utils/file.js
@@ -6,7 +6,7 @@ const getStdin = require('get-stdin');
 
 const { red } = require('colors');
 
-const getVisitor = require('../../visitor').getVisitor;
+const getVisitor = require('../visitor').getVisitor;
 
 function readLines(fileName) {
   return new Promise((resolve, reject) => {

--- a/lib/utils/file.js
+++ b/lib/utils/file.js
@@ -48,7 +48,8 @@ async function getEvent(eventFile, ec = 'local invoke', dp = '/fun/local/invoke'
       });
     }
     const rl = readline.createInterface({
-      input
+      input,
+      output: process.stdout
     });
     
     event = '';

--- a/test/definition.test.js
+++ b/test/definition.test.js
@@ -89,7 +89,7 @@ describe('test findFunctionByServiceAndFunctionName', () => {
     expect(serviceRes).to.eql(definition.deleteUnmatchFunctionsUnderServiceRes({
       serviceName: 'localdemo',
       serviceRes: tplWithDuplicatedFunctionsInService.Resources.localdemo,
-      funcName: 'nodejs6'
+      functionName: 'nodejs6'
     }));
   });
 
@@ -124,7 +124,10 @@ describe('test matching function', () => {
 
     Object.keys(prompt).forEach(m => {
       if (m === 'promptForFunctionSelection') {
-        sandbox.stub(prompt, m).resolves('localdemo/python3');
+        sandbox.stub(prompt, m).resolves({
+          serviceName: 'localdemo',
+          functionName: 'python3'
+        });
       } else {
         sandbox.stub(prompt, m).resolves({});
       }

--- a/test/deploy/deploy-by-tpl.test.js
+++ b/test/deploy/deploy-by-tpl.test.js
@@ -16,7 +16,7 @@ const trigger = require('../../lib/trigger');
 const fc = require('../../lib/fc');
 const prompt = require('../../lib/init/prompt');
 
-const { tpl } = require('../tpl-mock-data');
+const { tpl, tplWithDuplicatedFunction } = require('../tpl-mock-data');
 
 describe('deploy service role ', () => {
   let restoreProcess;
@@ -1146,13 +1146,16 @@ describe('custom domain', () => {
 
 
 
-describe('test partical deploy', () => {
+describe.only('test partical deploy', () => {
   
   beforeEach(() => {
 
     Object.keys(prompt).forEach(m => {
       if (m === 'promptForSameFunction') {
-        sandbox.stub(prompt, m).resolves('localdemo/python3');
+        sandbox.stub(prompt, m).resolves({
+          serviceName: 'localdemo',
+          functionName: 'python3'
+        });
       } else {
         sandbox.stub(prompt, m).resolves({});
       }
@@ -1185,5 +1188,13 @@ describe('test partical deploy', () => {
     
     expect(serviceName).to.be('localdemo');
     expect(serviceRes).to.be(tpl.Resources.localdemo);
+  });
+
+  it('more than one function', async () => {
+
+    const {serviceName, serviceRes} = await partialDeployment('localdemo/python3', tplWithDuplicatedFunction);
+    
+    expect(serviceName).to.be('localdemo');
+    expect(serviceRes).to.be(tplWithDuplicatedFunction.Resources.localdemo);
   });
 });

--- a/test/deploy/deploy-by-tpl.test.js
+++ b/test/deploy/deploy-by-tpl.test.js
@@ -1146,7 +1146,7 @@ describe('custom domain', () => {
 
 
 
-describe.only('test partical deploy', () => {
+describe('test partical deploy', () => {
   
   beforeEach(() => {
 

--- a/test/fc.test.js
+++ b/test/fc.test.js
@@ -13,6 +13,8 @@ const path = require('path');
 const fs = require('fs-extra');
 const expect = require('expect.js');
 
+const { green } = require('colors');
+
 describe('test getFunCodeAsBase64', () => {
 
   let restoreProcess;
@@ -80,13 +82,15 @@ describe('test getFunCodeAsBase64', () => {
   });
 });
 
-describe('Incorrect environmental variables', () => {
+describe.only('Incorrect environmental variables', () => {
   let restoreProcess;
 
   beforeEach(async () => {
     sandbox.stub(FC.prototype, 'getFunction').resolves({});
     sandbox.stub(FC.prototype, 'updateFunction').resolves({});
     sandbox.stub(zip, 'pack').resolves({});
+
+    sandbox.stub(console, 'log');
 
     fc = await proxyquire('../lib/fc', {
       './package/zip': zip,
@@ -144,5 +148,100 @@ describe('Incorrect environmental variables', () => {
           PYTHONUSERBASE: '/code/.fun/python'
         }
       });
+  });
+
+  it('invoke function sync', async () => {
+
+    sandbox.stub(FC.prototype, 'invokeFunction').returns({
+      'headers': {
+          'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
+          'content-length': '6',
+          'content-type': 'application/octet-stream',
+          'x-fc-code-checksum': '17380263816131011825',
+          'x-fc-invocation-duration': '18',
+          'x-fc-invocation-service-version': 'LATEST',
+          'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
+          'x-fc-max-memory-usage': '30.99',
+          'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
+          'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
+      },
+      'data': '[\'OK\']'
+  });
+    const rs = await fc.invokeFunction({
+      serviceName: 'serviceName', 
+      functionName: 'functionName', 
+      event: 'event', 
+      invocationType: 'Sync'
+    });
+
+    assert.calledWith(FC.prototype.invokeFunction, 'serviceName', 'functionName', 'event', {
+      'X-Fc-Log-Type': 'Tail',
+      'X-Fc-Invocation-Type': 'Sync'
+    });
+
+    assert.callCount(console.log, 4);
+
+    expect(rs).to.eql({
+      'headers': {
+          'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
+          'content-length': '6',
+          'content-type': 'application/octet-stream',
+          'x-fc-code-checksum': '17380263816131011825',
+          'x-fc-invocation-duration': '18',
+          'x-fc-invocation-service-version': 'LATEST',
+          'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
+          'x-fc-max-memory-usage': '30.99',
+          'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
+          'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
+      },
+      'data': '[\'OK\']'
+    });
+  });
+
+  it('invoke function async', async () => {
+
+    sandbox.stub(FC.prototype, 'invokeFunction').returns({
+      'headers': {
+          'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
+          'content-length': '6',
+          'content-type': 'application/octet-stream',
+          'x-fc-code-checksum': '17380263816131011825',
+          'x-fc-invocation-duration': '18',
+          'x-fc-invocation-service-version': 'LATEST',
+          'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
+          'x-fc-max-memory-usage': '30.99',
+          'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
+          'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
+      },
+      'data': '[\'OK\']'
+  });
+    const rs = await fc.invokeFunction({
+      serviceName: 'serviceName', 
+      functionName: 'functionName', 
+      event: 'event', 
+      invocationType: 'Async'
+    });
+
+    assert.calledWith(FC.prototype.invokeFunction, 'serviceName', 'functionName', 'event', {
+      'X-Fc-Invocation-Type': 'Async'
+    });
+
+    assert.calledWith(console.log, green('✔ ') + 'serviceName/functionName async invoke success.');
+
+    expect(rs).to.eql({
+      'headers': {
+          'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
+          'content-length': '6',
+          'content-type': 'application/octet-stream',
+          'x-fc-code-checksum': '17380263816131011825',
+          'x-fc-invocation-duration': '18',
+          'x-fc-invocation-service-version': 'LATEST',
+          'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
+          'x-fc-max-memory-usage': '30.99',
+          'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
+          'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
+      },
+      'data': '[\'OK\']'
+    });
   });
 });

--- a/test/fc.test.js
+++ b/test/fc.test.js
@@ -179,7 +179,7 @@ describe('Incorrect environmental variables', () => {
       'X-Fc-Invocation-Type': 'Sync'
     });
 
-    assert.callCount(console.log, 4);
+    assert.callCount(console.log, 5);
 
     expect(rs).to.eql({
       'headers': {

--- a/test/fc.test.js
+++ b/test/fc.test.js
@@ -154,19 +154,19 @@ describe.only('Incorrect environmental variables', () => {
 
     sandbox.stub(FC.prototype, 'invokeFunction').returns({
       'headers': {
-          'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
-          'content-length': '6',
-          'content-type': 'application/octet-stream',
-          'x-fc-code-checksum': '17380263816131011825',
-          'x-fc-invocation-duration': '18',
-          'x-fc-invocation-service-version': 'LATEST',
-          'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
-          'x-fc-max-memory-usage': '30.99',
-          'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
-          'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
+        'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
+        'content-length': '6',
+        'content-type': 'application/octet-stream',
+        'x-fc-code-checksum': '17380263816131011825',
+        'x-fc-invocation-duration': '18',
+        'x-fc-invocation-service-version': 'LATEST',
+        'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
+        'x-fc-max-memory-usage': '30.99',
+        'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
+        'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
       },
       'data': '[\'OK\']'
-  });
+    });
     const rs = await fc.invokeFunction({
       serviceName: 'serviceName', 
       functionName: 'functionName', 
@@ -183,16 +183,16 @@ describe.only('Incorrect environmental variables', () => {
 
     expect(rs).to.eql({
       'headers': {
-          'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
-          'content-length': '6',
-          'content-type': 'application/octet-stream',
-          'x-fc-code-checksum': '17380263816131011825',
-          'x-fc-invocation-duration': '18',
-          'x-fc-invocation-service-version': 'LATEST',
-          'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
-          'x-fc-max-memory-usage': '30.99',
-          'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
-          'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
+        'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
+        'content-length': '6',
+        'content-type': 'application/octet-stream',
+        'x-fc-code-checksum': '17380263816131011825',
+        'x-fc-invocation-duration': '18',
+        'x-fc-invocation-service-version': 'LATEST',
+        'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
+        'x-fc-max-memory-usage': '30.99',
+        'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
+        'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
       },
       'data': '[\'OK\']'
     });
@@ -202,19 +202,19 @@ describe.only('Incorrect environmental variables', () => {
 
     sandbox.stub(FC.prototype, 'invokeFunction').returns({
       'headers': {
-          'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
-          'content-length': '6',
-          'content-type': 'application/octet-stream',
-          'x-fc-code-checksum': '17380263816131011825',
-          'x-fc-invocation-duration': '18',
-          'x-fc-invocation-service-version': 'LATEST',
-          'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
-          'x-fc-max-memory-usage': '30.99',
-          'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
-          'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
+        'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
+        'content-length': '6',
+        'content-type': 'application/octet-stream',
+        'x-fc-code-checksum': '17380263816131011825',
+        'x-fc-invocation-duration': '18',
+        'x-fc-invocation-service-version': 'LATEST',
+        'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
+        'x-fc-max-memory-usage': '30.99',
+        'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
+        'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
       },
       'data': '[\'OK\']'
-  });
+    });
     const rs = await fc.invokeFunction({
       serviceName: 'serviceName', 
       functionName: 'functionName', 
@@ -230,16 +230,16 @@ describe.only('Incorrect environmental variables', () => {
 
     expect(rs).to.eql({
       'headers': {
-          'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
-          'content-length': '6',
-          'content-type': 'application/octet-stream',
-          'x-fc-code-checksum': '17380263816131011825',
-          'x-fc-invocation-duration': '18',
-          'x-fc-invocation-service-version': 'LATEST',
-          'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
-          'x-fc-max-memory-usage': '30.99',
-          'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
-          'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
+        'access-control-expose-headers': 'Date,x-fc-request-id,x-fc-error-type,x-fc-code-checksum,x-fc-invocation-duration,x-fc-max-memory-usage,x-fc-log-result,x-fc-invocation-code-version',
+        'content-length': '6',
+        'content-type': 'application/octet-stream',
+        'x-fc-code-checksum': '17380263816131011825',
+        'x-fc-invocation-duration': '18',
+        'x-fc-invocation-service-version': 'LATEST',
+        'x-fc-log-result': 'RkMgSW52b2tlIFN0YXJ0IFJlcXVlc3RJZDogYWMyOTI2NGQtMDkwMC00ZjNkLWEwOWEtYmMzZGQyMmIyMzI1DQpsb2FkIGNvZGUgZm9yIGhhbmRsZXI6aW5kZXguaGFuZGxlcg0KRkMgSW52b2tlIEVuZCBSZXF1ZXN0SWQ6IGFjMjkyNjRkLTA5MDAtNGYzZC1hMDlhLWJjM2RkMjJiMjMyNQ0KCkR1cmF0aW9uOiAxNy40NSBtcywgQmlsbGVkIER1cmF0aW9uOiAxMDAgbXMsIE1lbW9yeSBTaXplOiAxMjggTUIsIE1heCBNZW1vcnkgVXNlZDogMzAuOTkgTUI=',
+        'x-fc-max-memory-usage': '30.99',
+        'x-fc-request-id': 'ac29264d-0900-4f3d-a09a-bc3dd22b2325',
+        'date': 'Wed, 21 Aug 2019 03:09:03 GMT'
       },
       'data': '[\'OK\']'
     });

--- a/test/fc.test.js
+++ b/test/fc.test.js
@@ -82,7 +82,7 @@ describe('test getFunCodeAsBase64', () => {
   });
 });
 
-describe.only('Incorrect environmental variables', () => {
+describe('Incorrect environmental variables', () => {
   let restoreProcess;
 
   beforeEach(async () => {

--- a/test/fun-invoke.test.js
+++ b/test/fun-invoke.test.js
@@ -193,9 +193,9 @@ describe('fun-invoke test', () => {
         'qualifier': null,
         'triggerConfig': {
           'methods': [
-              'GET',
-              'POST',
-              'PUT'
+            'GET',
+            'POST',
+            'PUT'
           ],
           'authType': 'anonymous'
         },

--- a/test/fun-invoke.test.js
+++ b/test/fun-invoke.test.js
@@ -23,7 +23,7 @@ const file = {
   getEvent: sandbox.stub()
 };
 
-describe.only('fun-invoke test', () => {
+describe('fun-invoke test', () => {
   let restoreProcess;
 
   beforeEach(() => {

--- a/test/fun-invoke.test.js
+++ b/test/fun-invoke.test.js
@@ -219,6 +219,47 @@ describe('fun-invoke test', () => {
     expect().fail('expect throw Error.');
 
   });
+
+
+  it('http trigger bind more than one qualifier', async () => {
+
+    service.getTriggerMetas.returns([
+      {
+        'triggerName': 'http-test',
+        'description': '',
+        'triggerId': 'c364dbea-31d7-43a9-93e2-2cad4ea4c4e3',
+        'sourceArn': null,
+        'triggerType': 'http',
+        'invocationRole': null,
+        'qualifier': 'superman',
+        'triggerConfig': {
+          'methods': [
+            'GET',
+            'POST',
+            'PUT'
+          ],
+          'authType': 'anonymous'
+        },
+        'createdTime': '2019-04-08T08:20:00Z',
+        'lastModifiedTime': '2019-08-23T02:32:12Z'
+      }
+    ]);
+
+    tpl.getTpl.returns(mockData.tplWithDuplicatedFunction);
+
+    try {
+      await invokeFuntion('python3', {
+        event: '',
+        invocationType: 'Sync'
+      });
+    } catch (error) {
+      assert.notCalled(fc.invokeFunction);
+      return;
+    }
+
+    expect().fail('expect throw Error.');
+
+  });
 });
 
 describe('tpl detectTplPath test', () => {

--- a/test/fun-invoke.test.js
+++ b/test/fun-invoke.test.js
@@ -11,17 +11,19 @@ const prompt = require('../lib/init/prompt');
 
 const mockData = require('./tpl-mock-data');
 
+const validate = sandbox.stub();
+
 const tpl = {
 
   getTpl: sandbox.stub(),
-  detectTplPath: sandbox.stub().resolves('')
+  detectTplPath: sandbox.stub().resolves({})
 };
 
 const file = {
   getEvent: sandbox.stub()
 };
 
-describe('fun-invoke test', () => {
+describe.only('fun-invoke test', () => {
   let restoreProcess;
 
   beforeEach(() => {
@@ -52,7 +54,8 @@ describe('fun-invoke test', () => {
       '../fc': fc,
       '../tpl': tpl,
       '../init/prompt': prompt,
-      '../utils/file': file
+      '../utils/file': file,
+      '../../lib/commands/validate': validate
     })(invokeName, options);
   }
 

--- a/test/fun-invoke.test.js
+++ b/test/fun-invoke.test.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const assert = sinon.assert;
+const proxyquire = require('proxyquire');
+const { setProcess } = require('./test-utils');
+
+const fc = require('../lib/fc');
+const prompt = require('../lib/init/prompt');
+
+const mockData = require('./tpl-mock-data');
+
+const tpl = {
+
+  getTpl: sandbox.stub(),
+  detectTplPath: sandbox.stub().resolves('')
+};
+
+const file = {
+  getEvent: sandbox.stub()
+};
+
+describe('fun-invoke test', () => {
+  let restoreProcess;
+
+  beforeEach(() => {
+
+    sandbox.stub(prompt, 'promptForFunctionSelection').resolves({
+      serviceName: 'localdemo',
+      functionName: 'python3'
+    });
+
+    sandbox.stub(fc, 'invokeFunction').resolves({});
+
+    restoreProcess = setProcess({
+      ACCOUNT_ID: 'ACCOUNT_ID',
+      ACCESS_KEY_ID: 'ACCESS_KEY_ID',
+      ACCESS_KEY_SECRET: 'ACCESS_KEY_SECRET',
+      DEFAULT_REGION: 'cn-shanghai'
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    restoreProcess();
+  });
+
+  async function invokeFuntion(invokeName, options) {
+
+    await proxyquire('../lib/commands/invoke.js', {
+      '../fc': fc,
+      '../tpl': tpl,
+      '../init/prompt': prompt,
+      '../utils/file': file
+    })(invokeName, options);
+  }
+
+  it('serviceName/functionName and event is empty stirng and uppercase Sync', async () => {
+
+    await invokeFuntion('serviceName/functionName', {
+      event: '',
+      invocationType: 'Sync'
+
+    });
+
+    assert.calledWith(fc.invokeFunction, {
+      serviceName: 'serviceName',
+      functionName: 'functionName',
+      event: '',
+      invocationType: 'Sync'
+    });
+  });
+
+  it('serviceName/functionName and event is eventStdin and uppercase Sync', async () => {
+
+    file.getEvent.returns('eventStdin');
+
+    await invokeFuntion('serviceName/functionName', {
+      event: '',
+      invocationType: 'Sync',
+      eventStdin: 'eventStdin'
+    });
+
+    assert.calledWith(fc.invokeFunction, {
+      serviceName: 'serviceName',
+      functionName: 'functionName',
+      event: 'eventStdin',
+      invocationType: 'Sync'
+    });
+  });
+
+  it('serviceName/functionName and event is empty stirng and lowercase async', async () => {
+
+    await invokeFuntion('serviceName/functionName', {
+      event: '',
+      invocationType: 'async'
+
+    });
+
+    assert.calledWith(fc.invokeFunction, {
+      serviceName: 'serviceName',
+      functionName: 'functionName',
+      event: '',
+      invocationType: 'Async'
+    });
+  });
+
+
+  it('serviceName/functionName and event is eventFile and uppercase Sync', async () => {
+
+    file.getEvent.returns('eventFile');
+
+    await invokeFuntion('serviceName/functionName', {
+      event: '',
+      invocationType: 'Sync',
+      eventFile: './'
+    });
+
+    assert.calledWith(fc.invokeFunction, {
+      serviceName: 'serviceName',
+      functionName: 'functionName',
+      event: 'eventFile',
+      invocationType: 'Sync'
+    });
+  });
+
+
+  it('single functionName and event is empty stirng and uppercase Sync', async () => {
+
+    tpl.getTpl.returns(mockData.tpl);
+
+    await invokeFuntion('python3', {
+      event: '',
+      invocationType: 'Sync'
+
+    });
+
+    assert.calledWith(fc.invokeFunction, {
+      serviceName: 'localdemo',
+      functionName: 'python3',
+      event: '',
+      invocationType: 'Sync'
+    });
+  });
+
+  it('duplicated functions and event is empty stirng and uppercase Sync', async () => {
+
+    tpl.getTpl.returns(mockData.tplWithDuplicatedFunction);
+
+    await invokeFuntion('python3', {
+      event: '',
+      invocationType: 'Sync'
+
+    });
+
+    assert.calledWith(fc.invokeFunction, {
+      serviceName: 'localdemo',
+      functionName: 'python3',
+      event: '',
+      invocationType: 'Sync'
+    });
+  });
+});

--- a/test/fun-invoke.test.js
+++ b/test/fun-invoke.test.js
@@ -3,15 +3,25 @@
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 const assert = sinon.assert;
+const expect = require('expect.js');
+
 const proxyquire = require('proxyquire');
 const { setProcess } = require('./test-utils');
 
 const fc = require('../lib/fc');
 const prompt = require('../lib/init/prompt');
 
+const { detectTplPath} = require('../lib/tpl');
+
+const fs = require('fs-extra');
+const path = require('path');
+
+const rimraf = require('rimraf');
+
 const mockData = require('./tpl-mock-data');
 
 const validate = sandbox.stub();
+
 
 const tpl = {
 
@@ -163,5 +173,21 @@ describe('fun-invoke test', () => {
       event: '',
       invocationType: 'Sync'
     });
+  });
+});
+
+describe('tpl detectTplPath test', () => {
+
+  it('yml exits', async () => {
+    const ymlPath = path.join(process.cwd(), './template.yml');
+    await fs.createFile(ymlPath);
+    const result = await detectTplPath();
+    rimraf.sync(ymlPath);
+    expect(result).to.be(path.join(process.cwd(), './template.yml'));
+  });
+
+  it('yml not exits', async () => {
+    const result = await detectTplPath();
+    expect(result).to.be(null);
   });
 });

--- a/test/fun-invoke.test.js
+++ b/test/fun-invoke.test.js
@@ -8,6 +8,8 @@ const expect = require('expect.js');
 const proxyquire = require('proxyquire');
 const { setProcess } = require('./test-utils');
 
+const service = require('../lib/import/service');
+
 const fc = require('../lib/fc');
 const prompt = require('../lib/init/prompt');
 
@@ -37,6 +39,8 @@ describe('fun-invoke test', () => {
   let restoreProcess;
 
   beforeEach(() => {
+
+    sandbox.stub(service, 'getTriggerMetas').resolves({});
 
     sandbox.stub(prompt, 'promptForFunctionSelection').resolves({
       serviceName: 'localdemo',

--- a/test/init/prompt.test.js
+++ b/test/init/prompt.test.js
@@ -120,6 +120,9 @@ describe('prompt', () => {
   it('for same function', async () => {
     inquirer.prompt.returns(Promise.resolve({function: 'service/function'}));
     const func = await promptStub.promptForFunctionSelection(['service/function', 'service1/function1']);
-    expect(func).to.be('service/function');
+    expect(func).to.eql({
+      serviceName: 'service',
+      functionName: 'function'
+    });
   });
 });


### PR DESCRIPTION
  目前的 fun 已经具备了本地调用以及本地调试的本地开发功能，在此基础上提供远端调用功能后会使 fun 的用户感受到更完整的开发体验，形成开发闭环。

  1.本地开发、调试、调用
  2.部署到云端
  3.远端调用查看结果

  上述体验是目前 VSCode 插件可以提供给用户的，但是并不是所有的用户都习惯使用 VSCode 进行编辑，因此这块能力需要迁移在更加通用的工具 fun 上。虽然用户可以通过控制台或 fcli 命令行工具来进行远端调用，但是需要用户花费额外的成本