### PR TITLE
fix .fun/tmp ignore

### DIFF
--- a/bin/fun-local-invoke.js
+++ b/bin/fun-local-invoke.js
@@ -28,7 +28,7 @@ program
     `a file containing event data passed to the function during
                              invoke, If this option is not specified, it defaults to
                              reading event from stdin`)
-  .option('--tmp-dir <tmpDir>', `The temp directory mounted to /tmp , default to './.fun/invoke-tmp/{service}/{function}/'`)
+  .option('--tmp-dir <tmpDir>', `The temp directory mounted to /tmp , default to './.fun/tmp/invoke/{service}/{function}/'`)
 
   .parse(process.argv);
 

--- a/lib/commands/local/invoke.js
+++ b/lib/commands/local/invoke.js
@@ -42,7 +42,7 @@ async function localInvoke(invokeName, tpl, debugPort, event, debugIde, baseDir,
   debug(`found serviceName: ${serviceName}, functionName: ${functionName}, functionRes: ${functionRes}`);
 
 
-  const absTmpDir = tmpDir ? path.resolve(tmpDir) : path.resolve(baseDir, codeUri, '.fun', 'invoke-tmp', serviceName, functionName);
+  const absTmpDir = tmpDir ? path.resolve(tmpDir) : path.resolve(baseDir, codeUri, '.fun', 'tmp', 'invoke', serviceName, functionName);
 
   await ensureTmpDir(absTmpDir);
 

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -121,6 +121,7 @@ async function getFunCodeAsBase64(baseDir, codeUri, runtime, functionName) {
   }
 
   const ignore = generateFunIngore(baseDir, codeAbsPath);
+  console.log('ignore:' + ignore);
 
   await detectLibrary(codeAbsPath, runtime, baseDir, functionName, '\t\t');
 

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -121,7 +121,6 @@ async function getFunCodeAsBase64(baseDir, codeUri, runtime, functionName) {
   }
 
   const ignore = generateFunIngore(baseDir, codeAbsPath);
-  console.log('ignore:' + ignore);
 
   await detectLibrary(codeAbsPath, runtime, baseDir, functionName, '\t\t');
 

--- a/lib/install/task.js
+++ b/lib/install/task.js
@@ -87,7 +87,7 @@ class AptTask extends InstallTask {
 
   constructor(name, runtime, codeUri, pkgName, local, target, env, context, verbose) {
     super(name, runtime, codeUri, pkgName, local, target, env, context, verbose);
-    this.cacheDir = '/code/.fun/install-tmp';
+    this.cacheDir = '/code/.fun/tmp/install';
   }
 
   async beforeRun() {

--- a/lib/package/ignore.js
+++ b/lib/package/ignore.js
@@ -5,7 +5,7 @@ const parser = require('git-ignore-parser'),
   fs = require('fs'),
   path = require('path');
 
-const ignoredFile = ['.git', '.svn', '.env', '.fun/nas'];
+const ignoredFile = ['.git', '.svn', '.env', '.fun/nas', '.fun/tmp'];
 
 module.exports = function (baseDir) {
 


### PR DESCRIPTION
1.  fix -> fun deploy 的时候有没有把 .fun/invoke-tmp 和 .fun/install-tmp 给排除掉

2. 修改临时目录层级，避免增加不同业务而变更 fun deploy 代码
.fun/invoke-tmp ->  .fun/tmp/invoke  **&&**  .fun/install-tmp -> .fun/tmp/install 
