### PR TITLE
pycharm debug support

### DIFF
--- a/bin/fun-local-invoke.js
+++ b/bin/fun-local-invoke.js
@@ -20,10 +20,8 @@ program
   .option('-d, --debug-port <port>',
     `specify the sandboxed container starting in debug mode,
                              and exposing this port on localhost`)
-  // todo: add auto option to auto config vscode
-  .option('-c, --config <ide/debugger>',
-    `output configurations for the specified ide/debugger, where
-                             the ide/debugger can currently only be vscode`)
+  .option('-c, --config <ide/debugger>', 
+    'select which IDE to use when debugging and output related debug config tips for the IDE. Options：\'vscode\', \'pycharm\'')
   .option('-e, --event <path>',
     `a file containing event data passed to the function during
                              invoke, If this option is not specified, it defaults to

--- a/bin/fun-local-start.js
+++ b/bin/fun-local-start.js
@@ -25,7 +25,8 @@ program
   .usage('[options]')
   .option('-d, --debug-port <port>', 'specify the sandbox container starting in debug' +
     ' mode, and exposing this port on localhost')
-  .option('-c, --config <ide/debugger>', 'output ide debug configuration. Options：\'vscode\'')
+  .option('-c, --config <ide/debugger>', 
+    'select which IDE to use when debugging and output related debug config tips for the IDE. Options：\'vscode\', \'pycharm\'')
   .parse(process.argv);
 
 if (program.args.length) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -44,7 +44,7 @@ const getPopClient = async (endpoint, apiVersion) => {
     endpoint: endpoint,
     apiVersion: apiVersion,
     accessKeyId: profile.accessKeyId,
-    secretAccessKey: profile.accessKeySecret,
+    accessKeySecret: profile.accessKeySecret,
     opts: {
       timeout: profile.timeout * 1000
     }

--- a/lib/commands/local/invoke.js
+++ b/lib/commands/local/invoke.js
@@ -41,8 +41,7 @@ async function localInvoke(invokeName, tpl, debugPort, event, debugIde, baseDir,
 
   debug(`found serviceName: ${serviceName}, functionName: ${functionName}, functionRes: ${functionRes}`);
 
-
-  const absTmpDir = tmpDir ? path.resolve(tmpDir) : path.resolve(baseDir, codeUri, '.fun', 'tmp', 'invoke', serviceName, functionName);
+  const absTmpDir = tmpDir ? path.resolve(tmpDir) : path.resolve(baseDir, '.fun', 'tmp', 'invoke', serviceName, functionName);
 
   await ensureTmpDir(absTmpDir);
 

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -10,7 +10,7 @@ const { red, yellow } = require('colors');
 const debug = require('debug')('fun:local');
 const _ = require('lodash');
 
-var ip = require('ip');
+const ip = require('ip');
 
 const IDE_VSCODE = 'vscode';
 const IDE_PYCHARM = 'pycharm';
@@ -169,9 +169,9 @@ function generateDebugEnv(runtime, debugPort, debugIde) {
   case 'python3':
     if (debugIde === IDE_PYCHARM) {
       return {};
-    } else {
-      return { 'DEBUG_OPTIONS': `-m ptvsd --host 0.0.0.0 --port ${debugPort} --wait` };
-    }
+    } 
+    return { 'DEBUG_OPTIONS': `-m ptvsd --host 0.0.0.0 --port ${debugPort} --wait` };
+    
   case 'java8':
     return { 'DEBUG_OPTIONS': `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=${debugPort}` };
   case 'php7.2':

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -5,22 +5,33 @@ const fs = require('fs');
 const path = require('path');
 
 const lstat = util.promisify(fs.lstat);
-const { red } = require('colors');
+const { red, yellow } = require('colors');
 
 const debug = require('debug')('fun:local');
+const _ = require('lodash');
 
 var ip = require('ip');
 
-const allowedDebugIdes = ['vscode'];
+const IDE_VSCODE = 'vscode';
+const IDE_PYCHARM = 'pycharm';
+
+const allowedDebugIdes = [IDE_VSCODE, IDE_PYCHARM];
 
 function getDebugIde(options) {
   if (options.config) {
     const debugIde = options.config;
 
-    if (allowedDebugIdes.indexOf(debugIde.toLowerCase()) > -1) {
-      return debugIde;
-    } 
-    throw new Error(red(`Error parsing debug config. Option is one of: ${JSON.stringify(allowedDebugIdes)}`));
+    const ide = _.find(allowedDebugIdes, (allowedDebugIde) => {
+      if (allowedDebugIde === debugIde.toLowerCase()) {
+        return allowedDebugIde;
+      }
+    });
+
+    if (!ide) {
+      throw new Error(red(`Error parsing debug config. Option is one of: ${JSON.stringify(allowedDebugIdes)}`));
+    }
+
+    return ide;
   }
 
   return null;
@@ -145,7 +156,7 @@ async function generateVscodeDebugConfig(serviceName, functionName, runtime, cod
   debug('CodePath: ' + codePath);
 }
 
-function generateDebugEnv(runtime, debugPort) {
+function generateDebugEnv(runtime, debugPort, debugIde) {
   const remoteIp = ip.address();
 
   switch (runtime) {
@@ -156,7 +167,11 @@ function generateDebugEnv(runtime, debugPort) {
     return { 'DEBUG_OPTIONS': `--debug-brk=${debugPort}` };
   case 'python2.7':
   case 'python3':
-    return { 'DEBUG_OPTIONS': `-m ptvsd --host 0.0.0.0 --port ${debugPort} --wait` };
+    if (debugIde === IDE_PYCHARM) {
+      return {};
+    } else {
+      return { 'DEBUG_OPTIONS': `-m ptvsd --host 0.0.0.0 --port ${debugPort} --wait` };
+    }
   case 'java8':
     return { 'DEBUG_OPTIONS': `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=${debugPort}` };
   case 'php7.2':
@@ -167,26 +182,34 @@ function generateDebugEnv(runtime, debugPort) {
   }
 }
 
-function generateDockerDebugOpts(runtime, debugPort) {
+function generateDockerDebugOpts(runtime, debugPort, debugIde) {
   const exposedPort = `${debugPort}/tcp`;
 
-  if (runtime === 'php7.2') { return {}; }
-
-  return {
-    ExposedPorts: {
-      [exposedPort]: {}
-    },
-    HostConfig: {
-      PortBindings: {
-        [exposedPort]: [
-          {
-            'HostIp': '',
-            'HostPort': `${debugPort}`
-          }
-        ]
-      }
+  if (debugIde === IDE_PYCHARM) {
+    if (runtime !== 'python2.7' && runtime !== 'python3') {
+      throw new Error(`${yellow(IDE_PYCHARM)} debug config only support for runtime [python2.7, python3]`);
+    } else {
+      return {};
     }
-  };
+  } else if (runtime === 'php7.2') {
+    return {};
+  } else {
+    return {
+      ExposedPorts: {
+        [exposedPort]: {}
+      },
+      HostConfig: {
+        PortBindings: {
+          [exposedPort]: [
+            {
+              'HostIp': '',
+              'HostPort': `${debugPort}`
+            }
+          ]
+        }
+      }
+    };
+  }
 }
 
 module.exports = {

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -17,7 +17,7 @@ const IDE_PYCHARM = 'pycharm';
 
 const allowedDebugIdes = [IDE_VSCODE, IDE_PYCHARM];
 
-function getDebugIde(options) {
+function getDebugIde(options = {}) {
   if (options.config) {
     const debugIde = options.config;
 

--- a/lib/docker-opts.js
+++ b/lib/docker-opts.js
@@ -207,7 +207,7 @@ async function generateContainerBuildOpts(runtime, containerName, mounts, cmd, e
   return opts;
 }
 
-async function generateLocalInvokeOpts(runtime, containerName, mounts, cmd, debugPort, envs, dockerUser) {
+async function generateLocalInvokeOpts(runtime, containerName, mounts, cmd, debugPort, envs, dockerUser, debugIde) {
 
   const hostOpts = {
     HostConfig: {
@@ -217,9 +217,9 @@ async function generateLocalInvokeOpts(runtime, containerName, mounts, cmd, debu
   };
 
   let debugOpts = {};
-
+  
   if (debugPort) {
-    debugOpts = generateDockerDebugOpts(runtime, debugPort);
+    debugOpts = generateDockerDebugOpts(runtime, debugPort, debugIde);
   }
 
   const ioOpts = {
@@ -255,7 +255,7 @@ function resolveMockScript(runtime) {
   return `/var/fc/runtime/${runtime}/mock.sh`;
 }
 
-async function generateLocalStartRunOpts(runtime, name, mounts, cmd, debugPort, envs, dockerUser) {
+async function generateLocalStartRunOpts(runtime, name, mounts, cmd, debugPort, envs, dockerUser, debugIde) {
 
   const hostOpts = {
     HostConfig: {
@@ -267,7 +267,7 @@ async function generateLocalStartRunOpts(runtime, name, mounts, cmd, debugPort, 
   let debugOpts = {};
 
   if (debugPort) {
-    debugOpts = generateDockerDebugOpts(runtime, debugPort);
+    debugOpts = generateDockerDebugOpts(runtime, debugPort, debugIde);
   }
 
   const imageName = await resolveRuntimeToDockerImage(runtime);

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -332,7 +332,7 @@ function generateRamdomContainerName() {
   return `fun_local_${new Date().getTime()}_${Math.random().toString(36).substr(2, 7)}`;
 }
 
-async function generateDockerEnvs(baseDir, functionProps, debugPort, httpParams, nasConfig, ishttpTrigger) {
+async function generateDockerEnvs(baseDir, functionProps, debugPort, httpParams, nasConfig, ishttpTrigger, debugIde) {
 
   const envs = {};
 
@@ -349,7 +349,7 @@ async function generateDockerEnvs(baseDir, functionProps, debugPort, httpParams,
   const runtime = functionProps.Runtime;
 
   if (debugPort) {
-    const debugEnv = generateDebugEnv(runtime, debugPort);
+    const debugEnv = generateDebugEnv(runtime, debugPort, debugIde);
 
     debug('debug env: ' + debugEnv);
 
@@ -383,7 +383,7 @@ async function pullImageIfNeed(imageName) {
   }
 }
 
-async function showDebugIdeTips(serviceName, functionName, runtime, codeSource, debugPort) {
+async function showDebugIdeTipsForVscode(serviceName, functionName, runtime, codeSource, debugPort) {
   const vscodeDebugConfig = await generateVscodeDebugConfig(serviceName, functionName, runtime, codeSource, debugPort);
 
   // todo: auto detect .vscode/launch.json in codeuri path.
@@ -391,6 +391,10 @@ async function showDebugIdeTips(serviceName, functionName, runtime, codeSource, 
   console.log('///////////////// config begin /////////////////');
   console.log(JSON.stringify(vscodeDebugConfig, null, 4));
   console.log('///////////////// config end /////////////////');
+}
+
+async function showDebugIdeTipsForPycharm() {
+  console.log("show"); // todo: 
 }
 
 function writeEventToStreamAndClose(stream, event) {
@@ -898,8 +902,8 @@ module.exports = {
   pullImage,
   resolveCodeUriToMount, generateFunctionEnvs, run, generateRamdomContainerName,
   generateDockerEnvs, pullImageIfNeed,
-  showDebugIdeTips, resolveDockerUser, resolveNasConfigToMounts,
+  showDebugIdeTipsForVscode, resolveDockerUser, resolveNasConfigToMounts,
   startInstallationContainer, startContainer, isDockerToolBox,
   conventInstallTargetsToMounts, startSboxContainer, buildImage, copyFromImage,
-  resolveTmpDirToMount
+  resolveTmpDirToMount, showDebugIdeTipsForPycharm
 };

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -14,6 +14,7 @@ const nas = require('./nas');
 const { parseArgsStringToArgv } = require('string-argv');
 const { addEnv, addInstallTargetEnv, resolveLibPathsFromLdConf } = require('./install/env');
 const { findPathsOutofSharedPaths } = require('./docker-support');
+const ip = require('ip');
 const tar = require('tar-fs');
 
 const _ = require('lodash');
@@ -393,8 +394,25 @@ async function showDebugIdeTipsForVscode(serviceName, functionName, runtime, cod
   console.log('///////////////// config end /////////////////');
 }
 
-async function showDebugIdeTipsForPycharm() {
-  console.log("show"); // todo: 
+async function showDebugIdeTipsForPycharm(codeSource, debugPort) {
+
+  const stats = await fs.lstat(codeSource);
+
+  if (!stats.isDirectory()) {
+    codeSource = path.dirname(codeSource);
+  }
+
+  console.log(yellow(`\n========= Tips for PyCharm remote debug =========
+Local host name: ${ip.address()}
+Port           : ${yellow(debugPort)}
+Path mappings  : ${yellow(codeSource)}=/code
+
+Debug Code needed to copy to your function code:
+
+import pydevd
+pydevd.settrace('${ip.address()}', port=${debugPort}, stdoutToServer=True, stderrToServer=True)
+
+=========================================================================\n`));
 }
 
 function writeEventToStreamAndClose(stream, event) {

--- a/lib/local/api-invoke.js
+++ b/lib/local/api-invoke.js
@@ -18,7 +18,7 @@ class ApiInvoke extends Invoke {
   async init() {
     await super.init();
 
-    this.envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, null, this.nasConfig, true);
+    this.envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, null, this.nasConfig, true, this.debugIde);
     this.cmd = docker.generateDockerCmd(this.functionProps, true);
     this.opts = await dockerOpts.generateLocalInvokeOpts(this.runtime, 
       this.containerName, 
@@ -26,7 +26,8 @@ class ApiInvoke extends Invoke {
       this.cmd, 
       this.debugPort,
       this.envs, 
-      this.dockerUser);
+      this.dockerUser,
+      this.debugIde);
   }
 
   async doInvoke(req, res) {

--- a/lib/local/http-invoke.js
+++ b/lib/local/http-invoke.js
@@ -110,7 +110,7 @@ class HttpInvoke extends Invoke {
 
   async _generateRunner() {
 
-    const envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, null, this.nasConfig, true);
+    const envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, null, this.nasConfig, true, this.debugIde);
 
     const opts = await dockerOpts.generateLocalStartRunOpts(this.runtime,
       this.containerName,
@@ -135,7 +135,7 @@ class HttpInvoke extends Invoke {
 
       const httpParams = generateHttpParams(req, this.endpointPrefix);
 
-      const envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, httpParams, this.nasConfig, true);
+      const envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, httpParams, this.nasConfig, true, this.debugIde);
 
       if (this.debugPort) {
         // don't reuse container
@@ -150,7 +150,8 @@ class HttpInvoke extends Invoke {
           cmd,
           this.debugPort,
           envs,
-          this.dockerUser);
+          this.dockerUser,
+          this.debugIde);
 
         await docker.run(opts,
           event,

--- a/lib/local/invoke.js
+++ b/lib/local/invoke.js
@@ -75,7 +75,6 @@ class Invoke {
     const allMount = [this.codeMount, ...this.nasMounts];
 
     if (!_.isEmpty(this.tmpDirMount)) {
-
       allMount.push(this.tmpDirMount);
     }
 
@@ -102,7 +101,12 @@ class Invoke {
 
   async showDebugIdeTips() {
     if (this.debugPort && this.debugIde) {
-      await docker.showDebugIdeTips(this.serviceName, this.functionName, this.runtime, this.codeMount.Source, this.debugPort);
+      // not show tips if debugIde is vscode
+      if (this.debugIde === 'vscode') {
+        await docker.showDebugIdeTipsForVscode(this.serviceName, this.functionName, this.runtime, this.codeMount.Source, this.debugPort);
+      } else if (this.debugIde === 'pycharm') {
+        await docker.showDebugIdeTipsForPycharm(this.serviceName, this.functionName, this.runtime, this.codeMount.Source, this.debugPort);
+      }
     }
   }
 

--- a/lib/local/invoke.js
+++ b/lib/local/invoke.js
@@ -101,11 +101,11 @@ class Invoke {
 
   async showDebugIdeTips() {
     if (this.debugPort && this.debugIde) {
-      // not show tips if debugIde is vscode
+      // not show tips if debugIde is null
       if (this.debugIde === 'vscode') {
         await docker.showDebugIdeTipsForVscode(this.serviceName, this.functionName, this.runtime, this.codeMount.Source, this.debugPort);
       } else if (this.debugIde === 'pycharm') {
-        await docker.showDebugIdeTipsForPycharm(this.serviceName, this.functionName, this.runtime, this.codeMount.Source, this.debugPort);
+        await docker.showDebugIdeTipsForPycharm(this.codeMount.Source, this.debugPort);
       }
     }
   }

--- a/lib/local/local-invoke.js
+++ b/lib/local/local-invoke.js
@@ -12,7 +12,7 @@ class LocalInvoke extends Invoke {
   async init() {
     await super.init();
 
-    this.envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, null, this.nasConfig);
+    this.envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, null, this.nasConfig, false, this.debugIde);
     this.cmd = docker.generateDockerCmd(this.functionProps, false);
     this.opts = await dockerOpts.generateLocalInvokeOpts(this.runtime,
       this.containerName,
@@ -20,7 +20,8 @@ class LocalInvoke extends Invoke {
       this.cmd,
       this.debugPort,
       this.envs,
-      this.dockerUser);
+      this.dockerUser,
+      this.debugIde);
   }
 
   async doInvoke(event, { outputStream, errorStream } = {}) {

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -219,7 +219,7 @@ describe('test generateDebugEnv', () => {
 describe('test generateDockerDebugOpts', () => {
   it('test not php7.2', async function () {
     for (let runtime of ['python2.7', 'python3', 'java8', 'nodejs6', 'nodejs8']) {
-      const debugOpts = await generateDockerDebugOpts(runtime, 9000); // todo: 
+      const debugOpts = await generateDockerDebugOpts(runtime, 9000); 
 
       expect(debugOpts).to.eql({
         'ExposedPorts': {
@@ -240,7 +240,7 @@ describe('test generateDockerDebugOpts', () => {
   });
 
   it('test php7.2', async function () {
-    const opts = await generateDockerDebugOpts('php7.2', 9000); // todo: 
+    const opts = await generateDockerDebugOpts('php7.2', 9000);
     expect(opts).to.be.empty();
   });
 });

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -209,7 +209,7 @@ describe('test generateDebugEnv', () => {
 describe('test generateDockerDebugOpts', () => {
   it('test not php7.2', async function () {
     for (let runtime of ['python2.7', 'python3', 'java8', 'nodejs6', 'nodejs8']) {
-      const debugOpts = await generateDockerDebugOpts(runtime, 9000);
+      const debugOpts = await generateDockerDebugOpts(runtime, 9000); // todo: 
 
       expect(debugOpts).to.eql({
         'ExposedPorts': {
@@ -230,7 +230,7 @@ describe('test generateDockerDebugOpts', () => {
   });
 
   it('test php7.2', async function () {
-    const opts = await generateDockerDebugOpts('php7.2', 9000);
+    const opts = await generateDockerDebugOpts('php7.2', 9000); // todo: 
     expect(opts).to.be.empty();
   });
 });

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -3,7 +3,8 @@
 const expect = require('expect.js');
 
 const {
-  generateVscodeDebugConfig, generateDebugEnv, generateDockerDebugOpts
+  generateVscodeDebugConfig, generateDebugEnv,
+  generateDockerDebugOpts, getDebugIde
 } = require('../lib/debug');
 
 const serviceName = 'testService';
@@ -204,6 +205,15 @@ describe('test generateDebugEnv', () => {
     expect(env).to.eql({ 'DEBUG_OPTIONS': '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address=9000' });
   });
 
+  it('test python3 with pycharm', async function () {
+    const env = await generateDebugEnv('python3', 9000, 'pycharm');
+    expect(env).to.eql({});
+  });
+
+  it('test python2.7 with pycharm', async function () {
+    const env = await generateDebugEnv('python2.7', 9000, 'pycharm');
+    expect(env).to.eql({});
+  });
 });
 
 describe('test generateDockerDebugOpts', () => {
@@ -232,5 +242,32 @@ describe('test generateDockerDebugOpts', () => {
   it('test php7.2', async function () {
     const opts = await generateDockerDebugOpts('php7.2', 9000); // todo: 
     expect(opts).to.be.empty();
+  });
+});
+
+describe('test getDebugIde', () => {
+  it('test debug ide1', () => {
+    const ide = getDebugIde({ config: 'vscode' });
+    expect(ide).to.eql('vscode');
+  });
+
+  it('test debug ide2', () => {
+    const ide = getDebugIde({ config: 'vsCode' });
+    expect(ide).to.eql('vscode');
+  });
+
+  it('test debug ide3', () => {
+    const ide = getDebugIde({ config: 'pycharm' });
+    expect(ide).to.eql('pycharm');
+  });
+
+  it('test debug ide4', () => {
+    const ide = getDebugIde({ config: 'PYCHARM' });
+    expect(ide).to.eql('pycharm');
+  });
+
+  it('test debug ide6', () => {
+    const ide = getDebugIde();
+    expect(ide).to.be(null);
   });
 });

--- a/test/docker-opts.test.js
+++ b/test/docker-opts.test.js
@@ -142,7 +142,7 @@ describe('test generateLocalInvokeOpts', () => {
       Source: '/test',
       Target: '/code',
       ReadOnly: true
-    }], 'cmd', 9000, envs, '1000:1000');
+    }], 'cmd', 9000, envs, '1000:1000');  // todo: 
 
     expect(opts).to.eql({
       'name': 'test',
@@ -195,7 +195,7 @@ describe('test generateLocalInvokeOpts', () => {
       Source: '/test',
       Target: '/code',
       ReadOnly: true
-    }], null, null, null, null);
+    }], null, null, null, null); // todo: 
 
     expect(opts).to.eql({
       'name': 'test',

--- a/test/docker-opts.test.js
+++ b/test/docker-opts.test.js
@@ -142,7 +142,7 @@ describe('test generateLocalInvokeOpts', () => {
       Source: '/test',
       Target: '/code',
       ReadOnly: true
-    }], 'cmd', 9000, envs, '1000:1000');  // todo: 
+    }], 'cmd', 9000, envs, '1000:1000');
 
     expect(opts).to.eql({
       'name': 'test',
@@ -195,7 +195,7 @@ describe('test generateLocalInvokeOpts', () => {
       Source: '/test',
       Target: '/code',
       ReadOnly: true
-    }], null, null, null, null); // todo: 
+    }], null, null, null, null);
 
     expect(opts).to.eql({
       'name': 'test',

--- a/test/local/invoke.test.js
+++ b/test/local/invoke.test.js
@@ -160,6 +160,7 @@ describe('test showDebugIdeTips', async () => {
     sandbox.stub(docker, 'resolveTmpDirToMount').resolves({});
 
     sandbox.stub(docker, 'showDebugIdeTipsForVscode').resolves({});
+    sandbox.stub(docker, 'showDebugIdeTipsForPycharm').resolves({});
 
     Invoke = proxyquire('../../lib/local/invoke', {
       '../docker': docker
@@ -181,7 +182,7 @@ describe('test showDebugIdeTips', async () => {
 
     await invoke.showDebugIdeTips();
 
-    assert.notCalled(docker.showDebugIdeTips);
+    assert.notCalled(docker.showDebugIdeTipsForVscode);
   });
 
   it('test does nothing2', async () => {
@@ -195,7 +196,7 @@ describe('test showDebugIdeTips', async () => {
 
     await invoke.showDebugIdeTips();
 
-    assert.notCalled(docker.showDebugIdeTips);
+    assert.notCalled(docker.showDebugIdeTipsForVscode);
   });
 
 
@@ -210,10 +211,10 @@ describe('test showDebugIdeTips', async () => {
 
     await invoke.showDebugIdeTips();
 
-    assert.notCalled(docker.showDebugIdeTips);
+    assert.notCalled(docker.showDebugIdeTipsForVscode);
   });
 
-  it('test show debug ide tips', async () => {
+  it('test show vscode debug tips', async () => {
     const invoke = new Invoke(serviceName,
       serviceResWithNasConfig,
       functionName,
@@ -226,7 +227,7 @@ describe('test showDebugIdeTips', async () => {
     
     await invoke.showDebugIdeTips();
     
-    assert.calledWith(docker.showDebugIdeTips, 
+    assert.calledWith(docker.showDebugIdeTipsForVscode, 
       serviceName, 
       functionName,
       'python3', 
@@ -234,4 +235,21 @@ describe('test showDebugIdeTips', async () => {
       debugPort);
   });
 
+  it('test show pycharm debug tips', async () => {
+    const invoke = new Invoke(serviceName,
+      serviceResWithNasConfig,
+      functionName,
+      functionRes,
+      debugPort,
+      'pycharm',
+      baseDir);
+
+    await invoke.init();
+    
+    await invoke.showDebugIdeTips();
+    
+    assert.calledWith(docker.showDebugIdeTipsForPycharm, 
+      '.', 
+      debugPort);
+  });
 });

--- a/test/local/invoke.test.js
+++ b/test/local/invoke.test.js
@@ -159,7 +159,7 @@ describe('test showDebugIdeTips', async () => {
     sandbox.stub(docker, 'pullImageIfNeed').resolves({});
     sandbox.stub(docker, 'resolveTmpDirToMount').resolves({});
 
-    sandbox.stub(docker, 'showDebugIdeTips').resolves({});
+    sandbox.stub(docker, 'showDebugIdeTipsForVscode').resolves({});
 
     Invoke = proxyquire('../../lib/local/invoke', {
       '../docker': docker


### PR DESCRIPTION
命令形式：

```
../../bin/fun.js local invoke -d 3000 --config pycharm python3
```

日志： 

```
using template: .fun/build/artifacts/template.yml

========= Tips for PyCharm remote debug =========
Local host name: 30.43.115.186
Port           : 3000
Path mappings  : /Users/tan/code/fun/examples/local/python3=/code

Debug Code needed to copy to your function code:

import pydevd
pydevd.settrace('30.43.115.186', port=3000, stdoutToServer=True, stderrToServer=True)

=========================================================================
```