### PR TITLE
sunfeiyu/fix_bug_on_partial_deployment

### DIFF
--- a/lib/definition.js
+++ b/lib/definition.js
@@ -354,7 +354,7 @@ function deleteUnmatchFunctionsUnderServiceRes({
 
     if (functions.functionName !== functionName) {
 
-      serviceRes = _.omit(serviceRes, functionName);
+      serviceRes = _.omit(serviceRes, functions.functionName);
     }
   } 
 

--- a/test/definition.test.js
+++ b/test/definition.test.js
@@ -116,6 +116,15 @@ describe('test findFunctionByServiceAndFunctionName', () => {
     expect(serviceName).to.be('localdemo2');
     expect(serviceRes).to.be(tplWithDuplicatedFunction.Resources.localdemo2);
   });
+
+  it('test find certain function by service and functionName on duplicated function under a service', async function () {
+
+    let {serviceName, serviceRes} = await definition.findServiceByCertainServiceAndFunctionName(tplWithDuplicatedFunctionsInService.Resources, 'localdemo', 'python3' );
+
+    expect(serviceName).to.be('localdemo');
+    expect(serviceRes).to.eql(tpl.Resources.localdemo);
+  });
+
 });
 
 describe('test matching function', () => {


### PR DESCRIPTION
1.修复 ：fun deploy  a/b  却部署 a/c （原因：上个版本中的测试用例漏掉此情况导致疏忽上线）
2.增加此情况的测试用例