### PR TITLE
permission tips

### DIFF
--- a/docs/usage/faq-zh.md
+++ b/docs/usage/faq-zh.md
@@ -112,3 +112,23 @@ Resources:
 ![image.png](/figures/add_docker_file_sharing.png)
 
 **注**：更多信息请参考 [Docker For Mac](https://docs.docker.com/docker-for-mac/osxfs/)
+
+## Fun Nas Init && Fun Nas Sync && Fun Nas Rm
+
+### Warning: fun nas xxx: ${nasPath} has no '-w-' or '-wx' permission, this may cause permission problem, more information please refer to...
+
+原因: 用户挂载的 NAS 盘路径或操作的 NAS 盘路径 nasPath 没有修改权限（文件为 '-w-', 文件夹为 '-wx'），用户对 nasPath 的改动操作可能会产生权限问题，提示 "permission denied" 这类错误，具体可以通过 fun nas ls -l nas://${serviceName}${nasPath} 来查看相应权限。
+
+解决方法: 通过 ecs 挂载 NAS 后修改对应 NAS 目录的权限
+
+### Warning: fun nas xxx: UserId: xxx and GroupId: xxx in your NasConfig are mismatched with UserId: xxx and GroupId: xxx of ${nasPath}, which may cause permission problem, more information please refer to...
+
+原因: 用户挂载的 NAS 盘路径或操作的 NAS 盘路径 nasPath 的 UserId 和 GroupId 与用户在 template.yml 中 NasConfig 下设置的 UserId 和 GroupId 不一致，用户对 nasPath 作出改动操作可能会产生权限问题，提示 "permission denied" 这类错误，具体可以通过 fun nas ls -l nas://${serviceName}${nasPath} 来查看相应的权限和 UserId 和 GroupId。
+
+解决方法: 将 NasConfig 下的 UserId 和 GroupId 设置为 Warning 中提示的 NAS 盘路径的 UserId 和 GroupId。若 NasConfig 为 Auto ，则UserId 和 GroupId 默认为 10003 无法变更，若要对指定路径文件/文件夹进行变更操作，需要对 NasConfig 进行手工设置，填写具有足够权限的 UserId 和 GroupId。
+
+### Warning: fun nas xxx: UserId: xxx and GroupId: xxx have no '-w-' or '-wx' permission to ${nasPath}, which may cause permission problem, more information please refer to...
+
+原因: 用户挂载的 NAS 盘路径或操作的 NAS 盘路径 nasPath 的 UserId 和 GroupId 没有修改权限（文件为 '-w-', 文件夹为 '-wx'），用户对 nasPath 的改动操作可能会产生权限问题，提示 "permission denied" 这类错误，具体可以通过 fun nas ls -l nas://${serviceName}${nasPath} 来查看相应权限。
+
+解决方法: 这种情况下其他用户（除了上述的 UserId 和属于 GroupId 的 UserId 之外的 UserId）具有写权限，可以将 NasConfig 中的 UserId 改成前面描述的“其他用户”来避免权限问题。

--- a/lib/commands/nas/ls.js
+++ b/lib/commands/nas/ls.js
@@ -2,7 +2,7 @@
 
 const lsNasFile = require('../../nas/ls');
 const { parseNasUri } = require('../../nas/path');
-const { detectTplPath } = require('../../tpl');
+const { detectTplPath, getTpl } = require('../../tpl');
 const { getDefaultService } = require('../../nas/support');
 const path = require('path');
 const validate = require('../../validate/validate');
@@ -11,19 +11,19 @@ const { red } = require('colors');
 async function ls(nasDir, options) {
 
   const tplPath = await detectTplPath(false);
-
+  
   if (!tplPath) {
     throw new Error(red('Current folder not a fun project\nThe folder must contains template.[yml|yaml] or faas.[yml|yaml] .'));
   } else if (path.basename(tplPath).startsWith('template')) {
     await validate(tplPath);
-    
+    const tpl = await getTpl(tplPath);
     const isAll = options.all;
     const isLong = options.long;
     
     var { nasPath, serviceName } = await parseNasUri(nasDir); 
     // 此时 nasDir 的格式应为 nas://${ serviceName }${ mountDir }
     if (serviceName === '') {
-      serviceName = await getDefaultService(tplPath);
+      serviceName = getDefaultService(tpl);
     }
     await lsNasFile(serviceName, nasPath, isAll, isLong);
   } else {

--- a/lib/commands/nas/rm.js
+++ b/lib/commands/nas/rm.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const rmNasFile = require('../../nas/rm');
+const { convertTplToServiceNasIdMappings } = require('../../nas');
 const { parseNasUri } = require('../../nas/path');
-const { detectTplPath } = require('../../tpl');
+const { detectTplPath, getTpl } = require('../../tpl');
 const { getDefaultService } = require('../../nas/support');
 const path = require('path');
 const validate = require('../../validate/validate');
@@ -16,17 +17,20 @@ async function rm(nasDir, options) {
     throw new Error(red('Current folder not a fun project\nThe folder must contains template.[yml|yaml] or faas.[yml|yaml] .'));
   } else if (path.basename(tplPath).startsWith('template')) {
     await validate(tplPath);
-    
+    const tpl = await getTpl(tplPath);
+
     const isRecursive = options.recursive;
     const isForce = options.force;
     
     var { nasPath, serviceName } = await parseNasUri(nasDir); 
     
     if (serviceName === '') {
-      serviceName = await getDefaultService(tplPath);
+      serviceName = getDefaultService(tpl);
     }
+    const serviceNasIdMappings = convertTplToServiceNasIdMappings(tpl);
+    const nasId = serviceNasIdMappings[serviceName];
     
-    await rmNasFile(serviceName, nasPath, isRecursive, isForce);
+    await rmNasFile(serviceName, nasPath, isRecursive, isForce, nasId);
   } else {
     throw new Error(red('The template file name must be template.[yml|yaml].'));
   }

--- a/lib/commands/nas/sync.js
+++ b/lib/commands/nas/sync.js
@@ -26,6 +26,8 @@ async function sync(options) {
     var mntDirs = options.mountDir;
     
     const serviceNasMappings = await nas.convertTplToServiceNasMappings(baseDir, tpl);
+    const serviceNasIdMappings = nas.convertTplToServiceNasIdMappings(tpl);
+    
     const localNasTmpDir = path.join(baseDir, '.fun', 'tmp', 'nas', 'sync');
     var errors = [];
     for (const serviceName in serviceNasMappings) {
@@ -36,18 +38,19 @@ async function sync(options) {
         //对 service 进行 fun nas init 操作
         await deployNasService(baseDir, tpl, service);
       }
-
+      const nasId = serviceNasIdMappings[serviceName];
+      
       for (const { localNasDir, remoteNasDir } of serviceNasMappings[serviceName]) {
 
         if (mntDirs && !mntDirs.includes(remoteNasDir)) { continue; }
 
         const srcPath = localNasDir;
 
-        const dstPath = `nas://${serviceName}:${remoteNasDir}/`;
+        const dstPath = `nas://${serviceName}${remoteNasDir}/`;
 
         console.log(`Starting upload ${srcPath} to ${dstPath}`);
         try {
-          await cp(srcPath, dstPath, true, localNasTmpDir);
+          await cp(srcPath, dstPath, true, localNasTmpDir, nasId);
         } catch (error) {
           errors.push(`Upload ${srcPath} To ${dstPath} ${error}`);
         }
@@ -57,7 +60,7 @@ async function sync(options) {
     if (errors.length) {
       console.log();
       _.forEach(errors, (error) => {
-        console.log(red(error));
+        console.log(red(`${error}\n`));
       });
     }
     tips.showInitNextTips();

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -379,26 +379,32 @@ async function ensureNasDirExist({
     } return null;
   });
 
-  const dirsNeedToCheck = mapMountPointDir(mountPoints, (mountPointDomain, remoteDir, mountDir) => {
+  const nasMountDirs = mapMountPointDir(mountPoints, (mountPointDomain, remoteDir, mountDir) => {
     if (remoteDir !== '/') {
-      return path.posix.join(mountDir, remoteDir);
+      return { mountDir, remoteDir };
     } 
     return null;
   });
 
-  debug('dirs need to check: %s', dirsNeedToCheck);
+  debug('dirs need to check: %s', nasMountDirs);
 
-  if (!_.isEmpty(dirsNeedToCheck)) {
-    console.log(`\tChecking if nas directories ${dirsNeedToCheck} exists, if not, it will be created automatically`);
+  if (!_.isEmpty(nasMountDirs)) {
+    let nasRemoteDirs = [];
+    let nasDirsNeedToCheck = [];
+    for (let nasMountDir of nasMountDirs) {
+      nasRemoteDirs.push(nasMountDir.remoteDir);
+      nasDirsNeedToCheck.push(path.posix.join(nasMountDir.mountDir, nasMountDir.remoteDir));
+    }
+    console.log(`\tChecking if nas directories ${nasRemoteDirs} exists, if not, it will be created automatically`);
 
     const utilFunctionName = await makeFcUtilsFunctionNasDirChecker(role, vpcConfig, modifiedNasConfig);
-
+    
     await invokeFcUtilsFunction({
       functionName: utilFunctionName,
-      event: JSON.stringify(dirsNeedToCheck)
+      event: JSON.stringify(nasDirsNeedToCheck)
     });
   
-    console.log(green('\tChecking nas directories done', JSON.stringify(dirsNeedToCheck)));
+    console.log(green('\tChecking nas directories done', JSON.stringify(nasRemoteDirs)));
   } 
 }
 

--- a/lib/nas.js
+++ b/lib/nas.js
@@ -3,6 +3,7 @@
 const getProfile = require('./profile').getProfile;
 const { getNasPopClient } = require('./client');
 const _ = require('lodash');
+const { isNasAutoConfig } = require('./definition');
 const debug = require('debug')('fun:nas');
 const { green } = require('colors');
 const { sleep } = require('./time');
@@ -309,6 +310,33 @@ async function convertTplToServiceNasMappings(baseDir, tpl) {
   return serviceNasMappings;
 }
 
+function convertTplToServiceNasIdMappings(tpl) {
+  const serviceNasIdMappings = {};
+
+  for (const { serviceName, serviceRes } of definition.findServices(tpl.Resources)) {    
+    const nasConfig = (serviceRes.Properties || {}).NasConfig;
+
+    const nasId = getNasIdFromNasConfig(nasConfig);
+
+    serviceNasIdMappings[serviceName] = nasId;
+  }
+  
+  return serviceNasIdMappings;
+}
+
+function getNasIdFromNasConfig(nasConfig) {
+  if (isNasAutoConfig(nasConfig)) {
+    return {
+      UserId: 10003, 
+      GroupId: 10003
+    };
+  } 
+  return {
+    UserId: nasConfig.UserId, 
+    GroupId: nasConfig.GroupId
+  };
+}
+
 module.exports = {
   findNasFileSystem,
   findMountTarget,
@@ -317,5 +345,7 @@ module.exports = {
   resolveMountPoint,
   convertMountPointToNasMapping,
   convertNasConfigToNasMappings,
-  convertTplToServiceNasMappings
+  convertTplToServiceNasMappings, 
+  convertTplToServiceNasIdMappings, 
+  getNasIdFromNasConfig
 };

--- a/lib/nas/cp.js
+++ b/lib/nas/cp.js
@@ -7,7 +7,7 @@ const upload = require('./cp/upload');
 const { getNasHttpTriggerPath } = require('./request');
 const { green } = require('colors');
 
-async function cp(srcPath, dstPath, recursive, localNasTmpDir) {
+async function cp(srcPath, dstPath, recursive, localNasTmpDir, nasId) {
   if (srcPath === undefined || dstPath === undefined) {
     console.log('Input path empty error, please input again!');
     return;
@@ -40,7 +40,7 @@ async function cp(srcPath, dstPath, recursive, localNasTmpDir) {
 
     const nasHttpTriggerPath = await getNasHttpTriggerPath(serviceName);
 
-    await upload(resolvedSrc, resolvedDst, nasHttpTriggerPath, recursive, localNasTmpDir);
+    await upload(resolvedSrc, resolvedDst, nasHttpTriggerPath, recursive, localNasTmpDir, nasId);
 
   } else if (isNasProtocol(srcPath) && isNasProtocol(dstPath)) {
     //nas => nas

--- a/lib/nas/cp/upload.js
+++ b/lib/nas/cp/upload.js
@@ -7,7 +7,8 @@ const { green, red } = require('colors');
 const constants = require('../constants');
 const { 
   chunk,  
-  splitRangeBySize } = require('../support');
+  splitRangeBySize, 
+  checkWritePerm } = require('../support');
 
 const {
   getFileHash,
@@ -31,7 +32,7 @@ const {
 
 const { createProgressBar } = require('../../import/utils');
 
-async function upload(srcPath, dstPath, nasHttpTriggerPath, recursive, localNasTmpDir) {
+async function upload(srcPath, dstPath, nasHttpTriggerPath, recursive, localNasTmpDir, nasId) {
   console.log('NAS path checking...');
 
   const statsRes = await statsRequest(dstPath, nasHttpTriggerPath);
@@ -44,6 +45,11 @@ async function upload(srcPath, dstPath, nasHttpTriggerPath, recursive, localNasT
 
   if (stats.isFile && !stats.isDir) {
     throw new Error(`Check error : ${dstPath} is a file, but ${srcPath} is a folder`);
+  }
+  const permTip = checkWritePerm(stats, nasId, dstPath);
+  if (permTip) {
+    const warningInfo = `fun nas sync: ${permTip}`;
+    console.log(red(`Warning: ${warningInfo}`));
   }
 
   console.log('zipping ' + srcPath);

--- a/lib/nas/init.js
+++ b/lib/nas/init.js
@@ -7,9 +7,12 @@ const { getProfile, mark } = require('../profile');
 const { deployService } = require('../deploy/deploy-by-tpl');
 const definition = require('../definition');
 const constants = require('./constants');
-const { green } = require('colors');
+const { green, red } = require('colors');
 const tips = require('./tips');
 const nas = require('../nas');
+const { statsRequest, getNasHttpTriggerPath } = require('./request');
+const { checkWritePerm } = require('./support');
+
 async function deployNasService(baseDir, tpl, service) {
   const profile = await getProfile();
 
@@ -80,15 +83,25 @@ async function deployNasService(baseDir, tpl, service) {
 
     const nasMappings = await nas.convertNasConfigToNasMappings(baseDir, nasConfig, serviceName);
     console.log(green(`Create local NAS directory of service ${serviceName}:`));
-    
+    const nasId = nas.getNasIdFromNasConfig(nasConfig);
+    const nasHttpTriggerPath = await getNasHttpTriggerPath(serviceName);
+    let permTipArr = [];
     for (let mappings of nasMappings) {
       console.log(`\t${mappings.localNasDir}`);
       // TO DO ：检查 NasConfig 中的 UserId 和 GroupId 是否与远端一致
+      const statsRes = await statsRequest(mappings.remoteNasDir, nasHttpTriggerPath);
+      const stats = statsRes.data;
+      const permTip = checkWritePerm(stats, nasId, mappings.remoteNasDir);
+      if (permTip) {
+        permTipArr.push(permTip);
+      }
+    }
+    for (let permTip of permTipArr) {
+      console.log(red(`\nWarning: fun nas init: ${permTip}`));
     }
   }
 
-  console.log();
-  console.log(green('Fun nas init Success'));
+  console.log(green('\nFun nas init Success'));
   if (!service) { tips.showInitNextTips(); }
 }
 

--- a/lib/nas/rm.js
+++ b/lib/nas/rm.js
@@ -1,15 +1,33 @@
 'use strict';
-const { sendCmdRequest, getNasHttpTriggerPath } = require('./request');
-const { green } = require('colors');
+const { sendCmdRequest, getNasHttpTriggerPath, statsRequest } = require('./request');
+const { green, red } = require('colors');
+const { checkWritePerm } = require('./support');
 
 function generateRmCmd(nasPath, isRecursiveOpt, isForceOpt) {
   let cmd = 'rm ' + (isRecursiveOpt ? '-R ' : '') + (isForceOpt ? '-f ' : '') + nasPath;
   return cmd;
 }
 
-async function rm(serviceName, nasPath, isRecursiveOpt, isForceOpt) {
+async function rm(serviceName, nasPath, isRecursiveOpt, isForceOpt, nasId) {
   console.log('Removing...');
   const nasHttpTriggerPath = await getNasHttpTriggerPath(serviceName);
+  const statsRes = await statsRequest(nasPath, nasHttpTriggerPath);
+
+  const stats = statsRes.data;
+
+  if (!stats.isExist) {
+    throw new Error(`${nasPath} not exist`);
+  }
+
+  if (stats.isDir && !isRecursiveOpt) {
+    throw new Error(`fun nas rm: ${nasPath}: is a directory`);
+  }
+
+  const permTip = checkWritePerm(stats, nasId, nasPath);
+  if (permTip) {
+    const warningInfo = `fun nas rm: ${permTip}`;
+    console.log(red(`Warning: ${warningInfo}`));
+  }
 
   const rmCmd = generateRmCmd(nasPath, isRecursiveOpt, isForceOpt);
 

--- a/lib/nas/support.js
+++ b/lib/nas/support.js
@@ -1,10 +1,9 @@
 'use strict';
-const { getTpl } = require('../tpl');
 const { findServices } = require('../definition');
 const { red } = require('colors');
+const _ = require('lodash');
 
-async function getDefaultService(tplPath) {
-  const tpl = await getTpl(tplPath);
+function getDefaultService(tpl) {
   const services = findServices(tpl.Resources);
 
   if (services.length === 1) {
@@ -13,6 +12,9 @@ async function getDefaultService(tplPath) {
   throw new Error(red('There should be one and only one service in your template.[yml|yaml].'));
 }
 function chunk(arr, size) {
+  if (size < 1) {
+    throw new Error('chunk step should not be 0');
+  }
   return Array(Math.ceil(arr.length / size)).fill().map((_, i) => arr.slice(i * size, i * size + size));
 }
 
@@ -31,22 +33,57 @@ function splitRangeBySize(start, end, chunkSize) {
   }
   return res;
 }
+// 检查nasId 是否有 nasPath 的写权限
+// 返回相关字符串信息,undefined 表示有权限，否则无权限且返回相应 tip
+function checkWritePerm(stats, nasId, nasPath) {
+  if (!stats.isExist) {
+    return `${nasPath} not exist`;
+  }
+  const userId = nasId.UserId;
+  const groupId = nasId.GroupId;
 
-function getIdInfoFromNasConfig(nasConfig) {
-  if (nasConfig === 'Auto') {
-    return {
-      uid: 10003, 
-      gid: 10003
-    };
-  } 
-  return {
-    uid: nasConfig.UserId, 
-    gid: nasConfig.GroupId
-  };
+  const mode = stats.mode;
+  const nasPathUserId = stats.UserId;
+  const nasPathGroupId = stats.GroupId;
+  if (nasPathUserId === 0 && nasPathGroupId === 0) {
+    return undefined;
+  }
+  
+  // permStirng 为 ‘777’ 形式的权限形式 
+  let permString = (mode & parseInt('777', 8)).toString(8);
+  const [ ownerCanWrite, groupCanWrite, otherCanWrite ] = _.map(permString, (perm) => hasWritePerm(parseInt(perm), stats, nasPath));
+
+  if (!ownerCanWrite && !groupCanWrite && !otherCanWrite) {
+
+    return `${nasPath} has no '-w-' or '-wx' permission, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md`;
+  } else if (ownerCanWrite && groupCanWrite && otherCanWrite) {
+    
+    return undefined;
+  } else if ((userId === nasPathUserId && !ownerCanWrite) && (groupId === nasPathGroupId && !groupCanWrite) && otherCanWrite) {
+
+    return `UserId: ${nasPathUserId} and GroupId: ${nasPathGroupId} have no '-w-' or '-wx' permission to ${nasPath}, which may cause permission problem, \
+more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md`;
+  } else if (!( (userId === nasPathUserId && ownerCanWrite) || (groupId === nasPathGroupId && groupCanWrite) )) {
+
+    return `UserId: ${userId} and GroupId: ${groupId} in your NasConfig are mismatched with UserId: ${nasPathUserId} and GroupId: ${nasPathGroupId} of ${nasPath}, \
+which may cause permission problem, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md`;
+  }
+  return undefined;
+}
+function hasWritePerm(num, stats, nasPath) {
+  if (stats.isDir && !stats.isFile) {
+    // -wx, num | 100 === 7
+    return ((num | 4) === 7);
+  } else if (stats.isFile && !stats.isDir) {
+    // -w-, num | 101
+    return ((num | 5) === 7);
+  } else if (stats.isFile && stats.isDir) {
+    throw new Error(`isFile and isDir attributes of ${nasPath} are true simultaneously`);
+  }
 }
 
 module.exports = { 
   getDefaultService, 
   chunk, 
   splitRangeBySize, 
-  getIdInfoFromNasConfig };
+  checkWritePerm };

--- a/lib/utils/fun-nas-server/index.js
+++ b/lib/utils/fun-nas-server/index.js
@@ -98,7 +98,10 @@ app.get('/stats', async (req, res) => {
       path: dstPath,
       isExist: true,
       isDir: stats.isDirectory(),
-      isFile: stats.isFile()
+      isFile: stats.isFile(), 
+      UserId: stats.uid, 
+      GroupId: stats.gid, 
+      mode: stats.mode
     });
   } else {
     res.send({

--- a/lib/utils/fun-nas-server/test/index.test.js
+++ b/lib/utils/fun-nas-server/test/index.test.js
@@ -2,7 +2,7 @@
 
 const util = require('util');
 const os = require('os');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const expect = require('expect.js');
 const mkdirp = require('mkdirp-promise');
@@ -87,8 +87,15 @@ describe('POST /commands test', () => {
 
 describe('GET /stats test', () => {
   const dirPath = `${os.tmpdir()}/.stats/`;
+  let uid;
+  let gid;
+  let mode;
   beforeEach(async () => {
     await mkdirp(dirPath);
+    const stats = await fs.lstat(dirPath);
+    uid = stats.uid;
+    gid = stats.gid;
+    mode = stats.mode;
   });
   afterEach(() => {
     rimraf.sync(dirPath);
@@ -105,13 +112,16 @@ describe('GET /stats test', () => {
           path: dirPath,
           isExist: true,
           isDir: true,
-          isFile: false
+          isFile: false, 
+          UserId: uid, 
+          GroupId: gid, 
+          mode: mode
         }, done);
   });
 
   it('path not exist test', (done) => {
     const notExistPath = path.join(dirPath, 'notExist');
-    const query = { dstPath: notExistPath};
+    const query = { dstPath: notExistPath };
     request.get('/stats')
       .query(query)
       .expect(200)
@@ -126,13 +136,13 @@ describe('GET /stats test', () => {
 
   it('path empty test', (done) => {
     const emptyPath = '';
-    const query = { dstPath: emptyPath};
+    const query = { dstPath: emptyPath };
 
     request.get('/stats')
       .query(query)
       .expect(200)
       .end((err, res) => {
-        expect(res.body).to.key('error');
+        expect(res.body).to.eql({ error: 'missing dstPath parameter' });
         done();
       });
   });

--- a/test/commands/nas/ls.test.js
+++ b/test/commands/nas/ls.test.js
@@ -7,11 +7,13 @@ const proxyquire = require('proxyquire');
 const sandbox = sinon.createSandbox();
 const assert = sinon.assert;
 const path = require('path');
+const mockdata = require('./mock-data');
 const lsNasFile = sandbox.stub();
 const validate = sandbox.stub();
 
 const tpl = {
-  detectTplPath: sandbox.stub().returns('/template.yml')
+  detectTplPath: sandbox.stub(), 
+  getTpl: sandbox.stub()
 };
 
 const lsStub = proxyquire('../../../lib/commands/nas/ls', {
@@ -26,21 +28,33 @@ describe('command ls test', () => {
       all: true, 
       long: true
     };
-
+  beforeEach(() => {
+    tpl.detectTplPath.returns('/template.yml');
+    tpl.getTpl.returns(mockdata.tpl);
+  });
+  
   afterEach(() => {
     sandbox.reset();
   });
     
   it('valid nas path', async () => {
-    const nasPath = 'nas://demo:/mnt/nas';
+    const nasPath = 'nas://demo/mnt/nas';
 
     await lsStub(nasPath, options);
     const mntDir = path.posix.join('/', 'mnt', 'nas');
     assert.calledWith(lsNasFile, 'demo', mntDir, options.all, options.long);
   });
 
+  it('valid nas path with short nasPath', async () => {
+    const nasPath = 'nas:///mnt/nas';
+
+    await lsStub(nasPath, options);
+    const mntDir = path.posix.join('/', 'mnt', 'nas');
+    assert.calledWith(lsNasFile, mockdata.serviceName, mntDir, options.all, options.long);
+  });
+
   it('invalid nas path', async () => {
-    const nasPath = '://demo://mnt/nas';
+    const nasPath = '://demo//mnt/nas';
     let err;
 
     try {

--- a/test/commands/nas/mock-data.js
+++ b/test/commands/nas/mock-data.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const nasConfig = {
-  UserId: 10003,
-  GroupId: 10003,
+  UserId: 1000,
+  GroupId: 1000,
   MountPoints: [{
     ServerAddr: '359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com:/',
     MountDir: '/mnt/nas'
@@ -32,10 +32,15 @@ const tpl = {
     }
   }
 };
-
+const nasId = 
+{
+  UserId: 1000,
+  GroupId: 1000
+};
 module.exports = {
   nasConfig, 
   tpl, 
   vpcConfig, 
-  serviceName
+  serviceName, 
+  nasId
 };

--- a/test/commands/nas/rm.test.js
+++ b/test/commands/nas/rm.test.js
@@ -4,6 +4,7 @@
 const expect = require('expect.js');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
+const mockdata = require('./mock-data');
 const sandbox = sinon.createSandbox();
 const assert = sinon.assert;
 const path = require('path');
@@ -12,7 +13,8 @@ const rmNasFile = sandbox.stub();
 const validate = sandbox.stub();
 
 const tpl = {
-  detectTplPath: sandbox.stub().returns('/template.yml')
+  detectTplPath: sandbox.stub(), 
+  getTpl: sandbox.stub()
 };
 
 const rmStub = proxyquire('../../../lib/commands/nas/rm', {
@@ -23,21 +25,26 @@ const rmStub = proxyquire('../../../lib/commands/nas/rm', {
 
 describe('command rm test', () => {
   const options = 
-    {
-      recursive: true, 
-      force: true
-    };
-
+  {
+    recursive: true, 
+    force: true
+  };
+  
+  beforeEach(() => {
+    tpl.detectTplPath.returns('/template.yml');
+    tpl.getTpl.returns(mockdata.tpl);
+  });
   afterEach(() => {
     sandbox.reset();
   });
     
   it('valid nas path', async () => {
-    const nasPath = 'nas://demo:/mnt/nas';
+    const nasPath = `nas://${mockdata.serviceName}/mnt/nas`;
 
     await rmStub(nasPath, options);
     const mntDir = path.posix.join('/', 'mnt', 'nas');
-    assert.calledWith(rmNasFile, 'demo', mntDir, options.recursive, options.force);
+    
+    assert.calledWith(rmNasFile, mockdata.serviceName, mntDir, options.recursive, options.force, mockdata.nasId);
   });
 
   it('invalid nas path', async () => {

--- a/test/commands/nas/sync.test.js
+++ b/test/commands/nas/sync.test.js
@@ -14,8 +14,8 @@ const cp = sandbox.stub();
 const validate = sandbox.stub();
 
 const tpl = {
-  detectTplPath: sandbox.stub().returns(tplPath), 
-  getTpl: sandbox.stub().returns(mockdata.tpl)
+  detectTplPath: sandbox.stub(), 
+  getTpl: sandbox.stub()
 };
 const init = {
   deployNasService: sandbox.stub().resolves()
@@ -34,10 +34,14 @@ describe('fun nas sync test', () => {
     fsPathExists = sandbox.stub(fs, 'pathExists');
     fsPathExists.onCall(0).resolves(true);
     fsPathExists.onCall(1).resolves(true);
+
+    tpl.detectTplPath.returns(tplPath);
+    tpl.getTpl.returns(mockdata.tpl);
   });
 
   afterEach(() => {
     sandbox.restore();
+    sandbox.reset();
   });
 
   it('sync test without service', async () => {
@@ -49,18 +53,18 @@ describe('fun nas sync test', () => {
 
     await syncStub(options);
     const localNasDir = path.join('/', 'demo', '.fun', 'nas', '359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com', '/');
-    assert.calledWith(cp, localNasDir, 'nas://fun-nas-test:/mnt/nas/', true, localNasTmpDir);
+    assert.calledWith(cp, localNasDir, 'nas://fun-nas-test/mnt/nas/', true, localNasTmpDir, mockdata.nasId);
   });
 
   it('sync test with service', async () => {
     const options = {
-      service: 'fun-nas-test', 
+      service: mockdata.serviceName, 
       mntDirs: undefined
     };
     await syncStub(options);
     const localNasDir = path.join('/', 'demo', '.fun', 'nas', '359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com', '/');
     const baseDir = path.dirname(tplPath);
-    assert.calledWith(cp, localNasDir, 'nas://fun-nas-test:/mnt/nas/', true, localNasTmpDir);
+    assert.calledWith(cp, localNasDir, `nas://${mockdata.serviceName}/mnt/nas/`, true, localNasTmpDir, mockdata.nasId);
     assert.calledWith(init.deployNasService, baseDir, mockdata.tpl, options.service);
   });
 

--- a/test/nas.test.js
+++ b/test/nas.test.js
@@ -6,6 +6,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const sinon = require('sinon');
 const yaml = require('js-yaml');
+const mockdata = require('./commands/nas/mock-data');
 const sandbox = sinon.createSandbox();
 const assert = sinon.assert;
 
@@ -594,4 +595,27 @@ describe('test convertTplToServiceNasMappings', () => {
     
   });
 
+});
+
+describe('test convertTplToServiceNasIdMappings', () => {
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('normal tpl resource', () => {
+    const res = nas.convertTplToServiceNasIdMappings(mockdata.tpl);
+    expect(res).to.eql({
+      [mockdata.serviceName]: mockdata.nasId
+    });
+  });
+
+  it('empty tpl resource', () => {
+    const tpl = {
+      ROSTemplateFormatVersion: '2015-09-01',
+      Transform: 'Aliyun::Serverless-2018-04-03',
+      Resources: {}
+    };
+    const res = nas.convertTplToServiceNasIdMappings(tpl);
+    expect(res).to.eql({});
+  });
 });

--- a/test/nas/cp.test.js
+++ b/test/nas/cp.test.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 
 const mkdirp = require('mkdirp-promise');
 const rimraf = require('rimraf');
+const mockdata = require('../commands/nas/mock-data');
 const writeFile = util.promisify(fs.writeFile);
 
 const sinon = require('sinon');
@@ -40,29 +41,29 @@ describe('nas cp test', () => {
   it('local path cp to nas path test', async() => {
     
     const srcPath = filePath;
-    const dstPath = 'nas://fun-nas-test:/mnt/nas';
+    const dstPath = 'nas://fun-nas-test/mnt/nas';
     
-    await cpStub(srcPath, dstPath, false, localNasTmpDir);
+    await cpStub(srcPath, dstPath, false, localNasTmpDir, mockdata.nasId);
     const mntDir = path.posix.join('/', 'mnt', 'nas');
     const nasHttpTriggerPath = `/proxy/${constants.FUN_NAS_SERVICE_PREFIX}fun-nas-test/fun-nas-function/`;
-    assert.calledWith(upload, srcPath, mntDir, nasHttpTriggerPath, false, localNasTmpDir);
+    assert.calledWith(upload, srcPath, mntDir, nasHttpTriggerPath, false, localNasTmpDir, mockdata.nasId);
     
   });
 
   it('src path undefined test', async () => {
     const srcPath = undefined;
-    const dstPath = 'nas://fun-nas-test:/mnt/nas';
+    const dstPath = 'nas://fun-nas-test/mnt/nas';
 
-    await cpStub(srcPath, dstPath, false, localNasTmpDir);
+    await cpStub(srcPath, dstPath, false, localNasTmpDir, mockdata.nasId);
     
     assert.notCalled(upload);
   });
 
   it('local src path is a empty dir test', async () => {
     const srcPath = localEmptyPath;
-    const dstPath = 'nas://fun-nas-test:/mnt/nas';
+    const dstPath = 'nas://fun-nas-test/mnt/nas';
     
-    await cpStub(srcPath, dstPath, true, localNasTmpDir);
+    await cpStub(srcPath, dstPath, true, localNasTmpDir, mockdata.nasId);
 
     assert.notCalled(upload);
     

--- a/test/nas/cp/upload.test.js
+++ b/test/nas/cp/upload.test.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 
 const mkdirp = require('mkdirp-promise');
 const rimraf = require('rimraf');
+const mockdata = require('../../commands/nas/mock-data');
 const writeFile = util.promisify(fs.writeFile);
 const { getFileHash } = require('../../../lib/nas/cp/file');
 const path = require('path');
@@ -80,7 +81,10 @@ describe('upload test', () => {
         path: '/mnt/nas',
         isExist: true,
         isDir: true,
-        isFile: false
+        isFile: false, 
+        UserId: 100, 
+        GroupId: 100, 
+        mode: 123
       }
     });
 
@@ -105,7 +109,7 @@ describe('upload test', () => {
   it('upload file', async() => { 
     await writeFile(zipFilePath, Buffer.alloc(zipFileSize));
     zipHash = await getFileHash(zipFilePath);
-    await uploadStub(srcPath, dstPath, nasHttpTriggerPath, true, localNasTmpDir);
+    await uploadStub(srcPath, dstPath, nasHttpTriggerPath, true, localNasTmpDir, mockdata.nasId);
 
     assert.calledWith(request.statsRequest, dstPath, nasHttpTriggerPath);
     

--- a/test/nas/init.test.js
+++ b/test/nas/init.test.js
@@ -23,10 +23,14 @@ describe('test fun nas init', () => {
   const fs = {
     pathExists: sandbox.stub()
   };
+  const request = {
+    statsRequest: sandbox.stub()
+  };
   const nasInitStub = proxyquire('../../lib/nas/init', {
     '../deploy/deploy-by-tpl': deploy, 
     '../nas': nas, 
-    'fs-extra': fs
+    'fs-extra': fs, 
+    './request': request
   });
   beforeEach(() => {
 
@@ -36,7 +40,18 @@ describe('test fun nas init', () => {
       ACCESS_KEY_ID: 'ACCESS_KEY_ID',
       ACCESS_KEY_SECRET: 'ACCESS_KEY_SECRET'
     });
-
+    request.statsRequest.returns({
+      headers: 200, 
+      data: {
+        path: '/mnt/nas',
+        isExist: true,
+        isDir: true,
+        isFile: false, 
+        UserId: 100, 
+        GroupId: 100, 
+        mode: 123
+      }
+    });
   }); 
 
   afterEach(() => {

--- a/test/nas/path.test.js
+++ b/test/nas/path.test.js
@@ -14,12 +14,12 @@ describe('parseNasUri test', () => {
   const validNasPathResultMap = new Map();
   validNasPathResultMap.set('nas:///mnt/auto', {nasPath: '/mnt/auto', serviceName: ''});
   validNasPathResultMap.set('nas://:/mnt/auto', {nasPath: '/mnt/auto', serviceName: ''});
-  validNasPathResultMap.set('nas://service1:/mnt/auto', {nasPath: '/mnt/auto', serviceName: 'service1'});
-  validNasPathResultMap.set('nas://service1:/mnt', {nasPath: '/mnt', serviceName: 'service1'});
-  validNasPathResultMap.set('nas://service1:/home/', {nasPath: '/home/', serviceName: 'service1'});
-  validNasPathResultMap.set('nas://service1:/home/', {nasPath: '/home/', serviceName: 'service1'});
-  validNasPathResultMap.set('nas://service1:/home/1', {nasPath: '/home/1', serviceName: 'service1'});
-  validNasPathResultMap.set('nas://service1:/', {nasPath: '/', serviceName: 'service1'});
+  validNasPathResultMap.set('nas://service1/mnt/auto', {nasPath: '/mnt/auto', serviceName: 'service1'});
+  validNasPathResultMap.set('nas://service1/mnt', {nasPath: '/mnt', serviceName: 'service1'});
+  validNasPathResultMap.set('nas://service1/home/', {nasPath: '/home/', serviceName: 'service1'});
+  validNasPathResultMap.set('nas://service1/home/', {nasPath: '/home/', serviceName: 'service1'});
+  validNasPathResultMap.set('nas://service1/home/1', {nasPath: '/home/1', serviceName: 'service1'});
+  validNasPathResultMap.set('nas://service1/', {nasPath: '/', serviceName: 'service1'});
   validNasPathResultMap.set('nas://service1:/tmp/', {nasPath: '/tmp/', serviceName: 'service1'});
   validNasPathResultMap.set('nas:///', {nasPath: '/', serviceName: ''});
 

--- a/test/nas/support.test.js
+++ b/test/nas/support.test.js
@@ -1,35 +1,28 @@
 'use strict';
+const os = require('os');
 
+const path = require('path');
 const mockdata = require('../commands/nas/mock-data');
 const sinon = require('sinon');
-const proxyquire = require('proxyquire');
 const sandbox = sinon.createSandbox();
 const expect = require('expect.js');
-
-const tpl = {
-  getTpl: sandbox.stub()
-};
-
-const supportStub = proxyquire('../../lib/nas/support', {
-  '../tpl': tpl
-});
+const { getDefaultService, chunk, splitRangeBySize, checkWritePerm } = require('../../lib/nas/support');
 
 describe('getDefaultService test', () => {
-  
-  afterEach(() => {
-    sandbox.reset();
-  });
-
+  const tplWithEmptyResource = {
+    ROSTemplateFormatVersion: '2015-09-01',
+    Transform: 'Aliyun::Serverless-2018-04-03',
+    Resources: {}
+  };
   it('tpl with only one service', async () => {
-    tpl.getTpl.returns(mockdata.tpl);
-    let res = await supportStub.getDefaultService('tplPath');
+    let res = await getDefaultService(mockdata.tpl);
     expect(res).to.eql(mockdata.serviceName);
   });
 
-  it('tpl with only none service', async () => {
-    tpl.getTpl.returns(mockdata.vpcConfig);
+  it('tpl with none service', async () => {
+    
     try {
-      await supportStub.getDefaultService('tplPath');
+      getDefaultService(tplWithEmptyResource);
     } catch (error) {
       expect(error).to.eql(new Error('There should be one and only one service in your template.[yml|yaml].'));
     }
@@ -41,12 +34,20 @@ describe('chunk test', () => {
     sandbox.restore();
   });
   it('empty arr', () => {
-    let res = supportStub.chunk([], 1);
+    let res = chunk([], 1);
     expect(res).to.eql([]);
   });
   it('not empty arr', () => {
-    let res = supportStub.chunk([1, 2, 3], 2);
+    let res = chunk([1, 2, 3], 2);
     expect(res).to.eql([[1, 2], [3]]);
+  });
+
+  it('0 step', () => {
+    try {
+      chunk([1, 2, 3], 0);
+    } catch (error) {
+      expect(error).to.eql(new Error('chunk step should not be 0'));
+    }
   });
 });
 
@@ -56,19 +57,181 @@ describe('splitRangeBySize test', () => {
   });
 
   it('start > end', () => {
-    const res = supportStub.splitRangeBySize(10, 1, 2);
+    const res = splitRangeBySize(10, 1, 2);
     expect(res).to.be.empty;
   });
   it('start < end', () => {
     
-    const res = supportStub.splitRangeBySize(1, 10, 4);
+    const res = splitRangeBySize(1, 10, 4);
     expect(res).to.eql([{ start: 1, size: 4}, { start: 5, size: 4}, { start: 9, size: 1}]);
   });
   it('chunkSize === 0', () => {
     try {
-      supportStub.splitRangeBySize(1, 10, 0);
+      splitRangeBySize(1, 10, 0);
     } catch (error) {
       expect(error).to.eql(new Error('chunkSize of function splitRangeBySize should not be 0'));
+    }
+  });
+});
+
+describe('checkWritePerm test', () => {
+  const nasPath = path.join(os.tmpdir(), '.nas');
+  const mode_555 = 33133;
+  const mode_557 = 33135;
+  const mode_575 = 33149;
+  const mode_666 = 33206;
+  const mode_755 = 33261;
+  
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('path not exist', () => {
+    const stats = { isExist: false };
+    let nasId = {
+      UserId: -1, 
+      GroupId: -1
+    };
+    const res = checkWritePerm(stats, nasId, nasPath);
+
+    expect(res).to.eql(`${nasPath} not exist`);
+  });
+
+  it('file has no write permission', () => {
+    const stats = {
+      isExist: true, 
+      isDir: false,
+      isFile: true, 
+      UserId: 10, 
+      GroupId: 10, 
+      mode: mode_555
+    };
+    const nasId = {
+      UserId: 10, 
+      GroupId: 10
+    };
+    const res = checkWritePerm(stats, nasId, nasPath);
+    expect(res).to.eql(`${nasPath} has no '-w-' or '-wx' permission, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md`);
+  });
+
+  it('folder has no write permission', () => {
+    const stats = {
+      isExist: true, 
+      isDir: true,
+      isFile: false, 
+      UserId: 10, 
+      GroupId: 10, 
+      mode: mode_666
+    };
+    const nasId = {
+      UserId: 10, 
+      GroupId: 10
+    };
+    const res = checkWritePerm(stats, nasId, nasPath);
+    expect(res).to.eql(`${nasPath} has no '-w-' or '-wx' permission, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md`);
+  });
+
+  it('userId and groupId mismatch', () => {
+    const stats = {
+      isExist: true, 
+      isDir: true,
+      isFile: false, 
+      UserId: 10, 
+      GroupId: 10, 
+      mode: mode_755
+    };
+    const nasId = {
+      UserId: 1, 
+      GroupId: 1
+    };
+    const res = checkWritePerm(stats, nasId, nasPath);
+    expect(res).to.eql(`UserId: ${nasId.UserId} and GroupId: ${nasId.GroupId} in your NasConfig are mismatched with UserId: ${stats.UserId} and GroupId: ${stats.GroupId} of ${nasPath}, \
+which may cause permission problem, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md`);
+  });
+  it('userId match', () => {
+    const stats = {
+      isExist: true, 
+      isDir: true,
+      isFile: false, 
+      UserId: 10, 
+      GroupId: 10, 
+      mode: mode_755
+    };
+    const nasId = {
+      UserId: 10, 
+      GroupId: 1
+    };
+    const res = checkWritePerm(stats, nasId, nasPath);
+    expect(res).to.eql(undefined);
+  });
+  it('groupId match', () => {
+    const stats = {
+      isExist: true, 
+      isDir: true,
+      isFile: false, 
+      UserId: 10, 
+      GroupId: 10, 
+      mode: mode_575
+    };
+    const nasId = {
+      UserId: 1, 
+      GroupId: 10
+    };
+    const res = checkWritePerm(stats, nasId, nasPath);
+    expect(res).to.eql(undefined);
+  });
+  it('file userId and groupId have no write permission', () => {
+    const stats = {
+      isExist: true, 
+      isDir: false,
+      isFile: true, 
+      UserId: 10, 
+      GroupId: 10, 
+      mode: mode_557
+    };
+    const nasId = {
+      UserId: 10, 
+      GroupId: 10
+    };
+    const res = checkWritePerm(stats, nasId, nasPath);
+    expect(res).to.eql(`UserId: ${stats.UserId} and GroupId: ${stats.GroupId} have no '-w-' or '-wx' permission to ${nasPath}, which may cause permission problem, \
+more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md`);
+  });
+  it('floder userId and groupId have no write permission', () => {
+    const stats = {
+      isExist: true, 
+      isDir: true,
+      isFile: false, 
+      UserId: 10, 
+      GroupId: 10, 
+      mode: mode_557
+    };
+    const nasId = {
+      UserId: 10, 
+      GroupId: 10
+    };
+    const res = checkWritePerm(stats, nasId, nasPath);
+    expect(res).to.eql(`UserId: ${stats.UserId} and GroupId: ${stats.GroupId} have no '-w-' or '-wx' permission to ${nasPath}, which may cause permission problem, \
+more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md`);
+  });
+  
+  it('isFile and isDir are both true', () => {
+    const stats = {
+      isExist: true, 
+      isDir: true,
+      isFile: true, 
+      UserId: 10, 
+      GroupId: 10, 
+      mode: mode_557
+    };
+    const nasId = {
+      UserId: 10, 
+      GroupId: 10
+    };
+    try {
+      checkWritePerm(stats, nasId, nasPath);
+    } catch (error) {
+      expect(error).to.eql(new Error(`isFile and isDir attributes of ${nasPath} are true simultaneously`));
     }
   });
 });


### PR DESCRIPTION
1. 增加 fun nas init / fun nas sync / fun nas rm 的权限提示，但并不会中断操作流程，只会报 warning。
2. 修改了 nas-dir-check 的输出信息，避免给用户产生歧义
3. 交互效果：
```
$ fun nas init                       
using template: template.yml
using region: cn-shanghai
using accountId: ***********1670
using accessKeyId: ***********N87x
using timeout: 10

start fun nas init...
Waiting for service _FUN_NAS_poetry to be deployed...
        make sure role 'aliyunfcgeneratedrole-cn-shanghai--FUN-NAS-poetry' is exist
        role 'aliyunfcgeneratedrole-cn-shanghai--FUN-NAS-poetry' is already exist
        attaching police 'AliyunECSNetworkInterfaceManagementAccess' to role: aliyunfcgeneratedrole-cn-shanghai--FUN-NAS-poetry
        attached police 'AliyunECSNetworkInterfaceManagementAccess' to role: aliyunfcgeneratedrole-cn-shanghai--FUN-NAS-poetry
        Checking if nas directories /nas-test,/permission exists, if not, it will be created automatically
        Checking nas directories done ["/nas-test","/permission"]
        Waiting for function fun-nas-function to be deployed...
                Waiting for packaging function fun-nas-function code...
                The function fun-nas-function has been packaged.
                Waiting for HTTP trigger httpTrigger to be deployed...
                methods: POST,GET
                url: https://1613958610541670.cn-shanghai.fc.aliyuncs.com/2016-08-15/proxy/_FUN_NAS_poetry/fun-nas-function/
                function httpTrigger deploy success
        function fun-nas-function deploy success
service _FUN_NAS_poetry deploy success

Create local NAS directory of service poetry:
        /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/372784bc17-hlf61.cn-shanghai.nas.aliyuncs.com/nas-test
        /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com/permission

Warning: fun nas init: UserId: 10 and GroupId: 100 in your NasConfig are mismatched with UserId: 100 and GroupId: 100 of /mnt/nas/hlf61, which may cause permission problem, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md

Warning: fun nas init: UserId: 10 and GroupId: 100 in your NasConfig are mismatched with UserId: 100 and GroupId: 100 of /mnt/nas/lwl67, which may cause permission problem, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md

Fun nas init Success

Tips for next step
======================
$ fun nas info      # Show NAS info
$ fun nas ls        # List NAS files
$ fun nas sync      # Synchronize files to nas
$ fun deploy        # Deploy Resources
```

```
$ fun nas sync 

using template: template.yml
Starting upload /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/372784bc17-hlf61.cn-shanghai.nas.aliyuncs.com/nas-test to nas://poetry:/mnt/nas/hlf61/
NAS path checking...
Warning: fun nas sync: UserId: 10 and GroupId: 100 in your NasConfig are mismatched with UserId: 100 and GroupId: 100 of /mnt/nas/hlf61/, which may cause permission problem, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md
zipping /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/372784bc17-hlf61.cn-shanghai.nas.aliyuncs.com/nas-test
✔ /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/tmp/nas/sync/Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/372784bc17-hlf61.cn-shanghai.nas.aliyuncs.com/.fun-nas-generated-nas-test.zip - zipped
checking NAS tmp dir
Starting upload /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com/permission to nas://poetry:/mnt/nas/lwl67/
NAS path checking...
Warning: fun nas sync: UserId: 10 and GroupId: 100 in your NasConfig are mismatched with UserId: 100 and GroupId: 100 of /mnt/nas/lwl67/, which may cause permission problem, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md
zipping /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com/permission
✔ /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/tmp/nas/sync/Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com/.fun-nas-generated-permission.zip - zipped
checking NAS tmp dir

Upload /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/372784bc17-hlf61.cn-shanghai.nas.aliyuncs.com/nas-test To nas://poetry:/mnt/nas/hlf61/ Error: EACCES: permission denied, mkdir '/mnt/nas/hlf61/.fun_nas_tmp'

Upload /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com/permission To nas://poetry:/mnt/nas/lwl67/ Error: EACCES: permission denied, mkdir '/mnt/nas/lwl67/.fun_nas_tmp'


Tips for next step
======================
$ fun nas info      # Show NAS info
$ fun nas ls        # List NAS files
$ fun nas sync      # Synchronize files to nas
$ fun deploy        # Deploy Resources
```

```
$ fun nas rm -rf nas:///mnt/nas/hlf61/python/python/lib/python3.6/site-packages/PIL/features.py

using template: template.yml
Removing...
Warning: fun nas rm: UserId: 10 and GroupId: 100 in your NasConfig are mismatched with UserId: 100 and GroupId: 100 of /mnt/nas/hlf61/python/python/lib/python3.6/site-packages/PIL/features.py, which may cause permission problem, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md
Command failed: rm -R -f /mnt/nas/hlf61/python/python/lib/python3.6/site-packages/PIL/features.py
rm: cannot remove '/mnt/nas/hlf61/python/python/lib/python3.6/site-packages/PIL/features.py': Permission denied
```

```
$ fun nas rm -rf nas:///mnt/nas/hlf61/python/python/lib/python3.6/site-packages/PIL/features.py

using template: template.yml
Removing...
Warning: fun nas rm: /mnt/nas/hlf61/python/python/lib/python3.6/site-packages/PIL/features.py has no 'w' permission, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md
Command failed: rm -R -f /mnt/nas/hlf61/python/python/lib/python3.6/site-packages/PIL/features.py
rm: cannot remove '/mnt/nas/hlf61/python/python/lib/python3.6/site-packages/PIL/features.py': Permission denied
```