### PR TITLE
add fun nas server version and nasConfig detection in fun nas init

### DIFF
--- a/docs/usage/faq-zh.md
+++ b/docs/usage/faq-zh.md
@@ -64,6 +64,12 @@ Resources:
 
 注意，`Role` 与 `Polices` 不能同时使用，如果配置了 `Role`，则 `Polices` 会被忽略。
 
+### May be UserId and GroupId in NasConfig don't have enough permission, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md
+
+原因: 配置了 NAS 的服务在部署时会自动部署 nas-dir-checker 函数，用于检查 NAS 端挂载的目录是否存在，若不存在则创建远端 NAS 目录，nas-dir-checker 函数的 NasConfig 复用了用户的服务，因此若用户在 NasConfig 中配置的 UserId 和 GroupId 不具有创建远端 NAS 相应目录的权限，或者远端 NAS 相应目录的上层目录无 'w' 或 'x' 权限，则在创建目录过程中会提示 'permission denied' 这类错误。
+
+解决方法: 通过 ecs 挂载 NAS 后修改对应 NAS 目录的权限，或者查看相应目录的 UserId 和 GroupId 并依此修改 NasConfig 中的 UserId 和 GroupId。
+
 ## Fun Local
 
 ### Error starting userland proxy: mkdir /port/tcp:0.0.0.0:80:tcp:172.17.0.2:5000: input/output error.

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -9,7 +9,7 @@ async function deploy(stage, context) {
   let tplPath = context.template;
 
   if (!tplPath) {
-    tplPath = await detectTplPath(true, ['template.packaged.yml']);
+    tplPath = await detectTplPath(false, ['template.packaged.yml']);
   }
 
   if (!tplPath) {

--- a/lib/commands/nas/ls.js
+++ b/lib/commands/nas/ls.js
@@ -7,6 +7,7 @@ const { getDefaultService } = require('../../nas/support');
 const path = require('path');
 const validate = require('../../validate/validate');
 const { red } = require('colors');
+const { deployNasService } = require('../../nas/init');
 
 async function ls(nasDir, options) {
 
@@ -19,12 +20,14 @@ async function ls(nasDir, options) {
     const tpl = await getTpl(tplPath);
     const isAll = options.all;
     const isLong = options.long;
-    
+    const baseDir = path.dirname(tplPath);
     var { nasPath, serviceName } = await parseNasUri(nasDir); 
     // 此时 nasDir 的格式应为 nas://${ serviceName }${ mountDir }
     if (serviceName === '') {
       serviceName = getDefaultService(tpl);
     }
+    await deployNasService(baseDir, tpl, serviceName);
+    
     await lsNasFile(serviceName, nasPath, isAll, isLong);
   } else {
     throw new Error(red('The template file name must be template.[yml|yaml].'));

--- a/lib/commands/nas/rm.js
+++ b/lib/commands/nas/rm.js
@@ -8,7 +8,7 @@ const { getDefaultService } = require('../../nas/support');
 const path = require('path');
 const validate = require('../../validate/validate');
 const { red } = require('colors');
-
+const { deployNasService } = require('../../nas/init');
 async function rm(nasDir, options) {
 
   const tplPath = await detectTplPath(false);
@@ -21,12 +21,13 @@ async function rm(nasDir, options) {
 
     const isRecursive = options.recursive;
     const isForce = options.force;
-    
+    const baseDir = path.dirname(tplPath);
     var { nasPath, serviceName } = await parseNasUri(nasDir); 
     
     if (serviceName === '') {
       serviceName = getDefaultService(tpl);
     }
+    await deployNasService(baseDir, tpl, serviceName);
     const serviceNasIdMappings = convertTplToServiceNasIdMappings(tpl);
     const nasId = serviceNasIdMappings[serviceName];
     

--- a/lib/commands/nas/sync.js
+++ b/lib/commands/nas/sync.js
@@ -8,6 +8,7 @@ const validate = require('../../validate/validate');
 const { red } = require('colors');
 const tips = require('../../nas/tips');
 const { deployNasService } = require('../../nas/init');
+const { toBeUmountedDirs } = require('../../nas/support');
 const _ = require('lodash');
 
 async function sync(options) {
@@ -23,32 +24,40 @@ async function sync(options) {
     const baseDir = path.dirname(tplPath);
 
     var service = options.service;
-    var mntDirs = options.mountDir;
+    var mountedDirs = options.mountDir;
     
     const serviceNasMappings = await nas.convertTplToServiceNasMappings(baseDir, tpl);
-    const serviceNasIdMappings = nas.convertTplToServiceNasIdMappings(tpl);
     
+    if (service) {
+      const nasMappings = serviceNasMappings[service];
+      const configuredMountDirs = _.map(nasMappings, (mapping) => mapping.remoteNasDir);
+      const toUnmountDirs = toBeUmountedDirs(configuredMountDirs, mountedDirs);
+      if (!_.isEmpty(toUnmountDirs)) { console.log(red(`Warning: ${toUnmountDirs} are not configured by service: ${service}`)); }
+    }
+    
+    const serviceNasIdMappings = nas.convertTplToServiceNasIdMappings(tpl);
+
     const localNasTmpDir = path.join(baseDir, '.fun', 'tmp', 'nas', 'sync');
     var errors = [];
     for (const serviceName in serviceNasMappings) {
 
       if (service && serviceName !== service) {
         continue; 
-      } else if (service && serviceName === service) {
-        //对 service 进行 fun nas init 操作
-        await deployNasService(baseDir, tpl, service);
       }
+      
+      //对 service 进行 fun nas init 操作
+      await deployNasService(baseDir, tpl, service);
       const nasId = serviceNasIdMappings[serviceName];
       
       for (const { localNasDir, remoteNasDir } of serviceNasMappings[serviceName]) {
 
-        if (mntDirs && !mntDirs.includes(remoteNasDir)) { continue; }
+        if (mountedDirs && !mountedDirs.includes(remoteNasDir)) { continue; }
 
         const srcPath = localNasDir;
 
         const dstPath = `nas://${serviceName}${remoteNasDir}/`;
 
-        console.log(`Starting upload ${srcPath} to ${dstPath}`);
+        console.log(`starting upload ${srcPath} to ${dstPath}`);
         try {
           await cp(srcPath, dstPath, true, localNasTmpDir, nasId);
         } catch (error) {

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -13,6 +13,7 @@ const { addEnv, resolveLibPathsFromLdConf } = require('./install/env');
 const funignore = require('./package/ignore');
 const _ = require('lodash');
 const bytes = require('bytes');
+const { sleep } = require('./time');
 
 const definition = require('./definition');
 
@@ -278,7 +279,7 @@ async function makeService({
       internetAccess
     });
   }
-
+  
   const isNasAuto = definition.isNasAutoConfig(nasConfig);
   const isVpcAuto = definition.isVpcAutoConfig(vpcConfig);
 
@@ -398,7 +399,7 @@ async function ensureNasDirExist({
     console.log(`\tChecking if nas directories ${nasRemoteDirs} exists, if not, it will be created automatically`);
 
     const utilFunctionName = await makeFcUtilsFunctionNasDirChecker(role, vpcConfig, modifiedNasConfig);
-    
+    await sleep(1000);
     await invokeFcUtilsFunction({
       functionName: utilFunctionName,
       event: JSON.stringify(nasDirsNeedToCheck)
@@ -481,7 +482,10 @@ async function invokeFcUtilsFunction({
 
     if (log) {
       const decodedLog = Buffer.from(log, 'base64');
-
+      if ((decodedLog.toString().toLowerCase()).includes('permission denied')) {
+        throw new Error(`fc utils function ${functionName} invoke error, error message is: ${decodedLog}\n${red('May be UserId and GroupId in NasConfig don\'t have enough \
+permission, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md')}`);
+      }
       throw new Error(`fc utils function ${functionName} invoke error, error message is: ${decodedLog}`);
     }
   }

--- a/lib/nas/cp.js
+++ b/lib/nas/cp.js
@@ -38,7 +38,7 @@ async function cp(srcPath, dstPath, recursive, localNasTmpDir, nasId) {
 
     const { nasPath: resolvedDst, serviceName } = parseNasUri(dstPath);
 
-    const nasHttpTriggerPath = await getNasHttpTriggerPath(serviceName);
+    const nasHttpTriggerPath = getNasHttpTriggerPath(serviceName);
 
     await upload(resolvedSrc, resolvedDst, nasHttpTriggerPath, recursive, localNasTmpDir, nasId);
 

--- a/lib/nas/init.js
+++ b/lib/nas/init.js
@@ -3,34 +3,30 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-const { getProfile, mark } = require('../profile');
 const { deployService } = require('../deploy/deploy-by-tpl');
 const definition = require('../definition');
 const constants = require('./constants');
 const { green, red } = require('colors');
-const tips = require('./tips');
 const nas = require('../nas');
 const { statsRequest, getNasHttpTriggerPath } = require('./request');
-const { checkWritePerm } = require('./support');
+const { checkWritePerm, isNasServerStale } = require('./support');
+const { sleep } = require('../time');
 
 async function deployNasService(baseDir, tpl, service) {
-  const profile = await getProfile();
 
-  console.log(`using region: ${profile.defaultRegion}`);
-  console.log(`using accountId: ${mark(profile.accountId)}`);
-  console.log(`using accessKeyId: ${mark(profile.accessKeyId)}`);
-  console.log(`using timeout: ${profile.timeout}`);
-
-  console.log('');
-
-  console.log('start fun nas init...');
+  console.log('\nstart fun nas init...');
 
   const zipCodePath = path.resolve(__dirname, '../utils/fun-nas-server/dist/fun-nas-server.zip');
-
+  
   if (!await fs.pathExists(zipCodePath)) {
     throw new Error('could not find ../utils/fun-nas-server/dist/fun-nas-server.zip');
   }
-
+  const versionFilePath = path.resolve(__dirname, '../utils/fun-nas-server/dist/VERSION');
+  if (!await fs.pathExists(versionFilePath)) {
+    throw new Error('could not find ../utils/fun-nas-server/dist/VERSION');
+  }
+  const version = (await fs.readFile(versionFilePath)).toString();
+  let permTipArr = [];
   for (const { serviceName, serviceRes } of definition.findServices(tpl.Resources)) {
 
     if (service && service !== serviceName) { continue; }
@@ -44,65 +40,73 @@ async function deployNasService(baseDir, tpl, service) {
     }
     
     const nasServiceName = constants.FUN_NAS_SERVICE_PREFIX + serviceName;
- 
-    const nasServiceRes = {
-      'Type': 'Aliyun::Serverless::Service',
-      'Properties': {
-        'Description': `service for fc nas used for service ${serviceName}`,
-        'VpcConfig': vpcConfig,
-        'NasConfig': nasConfig
-      },
-      [constants.FUN_NAS_FUNCTION]: {
-        Type: 'Aliyun::Serverless::Function',
-        Properties: {
-          Handler: 'index.handler',
-          Runtime: 'nodejs10',
-          CodeUri: zipCodePath,
-          Timeout: 600,
-          MemorySize: 256, 
-          EnvironmentVariables: {
-            PATH: '/code/.fun/root/usr/bin'
-          }
+    console.log(`checking if ${nasServiceName} needs to be deployed...`);
+    if (await isNasServerStale(nasServiceName, nasConfig, version)) {
+      const nasServiceRes = {
+        'Type': 'Aliyun::Serverless::Service',
+        'Properties': {
+          'Description': `service for fc nas used for service ${serviceName}`,
+          'VpcConfig': vpcConfig,
+          'NasConfig': nasConfig
         },
-        Events: {
-          httpTrigger: {
-            Type: 'HTTP',
-            Properties: {
-              AuthType: 'FUNCTION',
-              Methods: ['POST', 'GET']
+        [constants.FUN_NAS_FUNCTION]: {
+          Type: 'Aliyun::Serverless::Function',
+          Properties: {
+            Handler: 'index.handler',
+            Runtime: 'nodejs10',
+            CodeUri: zipCodePath,
+            Timeout: 600,
+            MemorySize: 256, 
+            EnvironmentVariables: {
+              PATH: '/code/.fun/root/usr/bin'
+            }
+          },
+          Events: {
+            httpTrigger: {
+              Type: 'HTTP',
+              Properties: {
+                AuthType: 'FUNCTION',
+                Methods: ['POST', 'GET']
+              }
             }
           }
         }
+      };
+  
+      console.log(`Waiting for service ${nasServiceName} to be deployed...`);
+      await deployService(baseDir, nasServiceName, nasServiceRes);
+      console.log(green(`service ${nasServiceName} deploy success\n`));
+  
+  
+      const nasMappings = await nas.convertNasConfigToNasMappings(baseDir, nasConfig, serviceName);
+      console.log(green(`Create local NAS directory of service ${serviceName}:`));
+      
+      const nasId = nas.getNasIdFromNasConfig(nasConfig);
+      const nasHttpTriggerPath = getNasHttpTriggerPath(serviceName);
+      // 延迟 1 秒，为保证 nas server 部署完成并成功执行
+      // TODO: 利用类似部署 ID 的标识来验证部署的的成功
+      await sleep(1000);
+      
+      for (let mappings of nasMappings) {
+        console.log(`\t${mappings.localNasDir}`);
+        
+        const statsRes = await statsRequest(mappings.remoteNasDir, nasHttpTriggerPath);
+        const stats = statsRes.data;
+        const permTip = checkWritePerm(stats, nasId, mappings.remoteNasDir);
+        if (permTip) {
+          permTipArr.push(permTip);
+        }
       }
-    };
-
-    console.log(`Waiting for service ${nasServiceName} to be deployed...`);
-    await deployService(baseDir, nasServiceName, nasServiceRes);
-    console.log(green(`service ${nasServiceName} deploy success\n`));
-
-
-    const nasMappings = await nas.convertNasConfigToNasMappings(baseDir, nasConfig, serviceName);
-    console.log(green(`Create local NAS directory of service ${serviceName}:`));
-    const nasId = nas.getNasIdFromNasConfig(nasConfig);
-    const nasHttpTriggerPath = await getNasHttpTriggerPath(serviceName);
-    let permTipArr = [];
-    for (let mappings of nasMappings) {
-      console.log(`\t${mappings.localNasDir}`);
-      // TO DO ：检查 NasConfig 中的 UserId 和 GroupId 是否与远端一致
-      const statsRes = await statsRequest(mappings.remoteNasDir, nasHttpTriggerPath);
-      const stats = statsRes.data;
-      const permTip = checkWritePerm(stats, nasId, mappings.remoteNasDir);
-      if (permTip) {
-        permTipArr.push(permTip);
-      }
+    } else {
+      console.log(`skip deploying ${nasServiceName}, which has been deployed`);
     }
-    for (let permTip of permTipArr) {
-      console.log(red(`\nWarning: fun nas init: ${permTip}`));
-    }
+   
+  }
+  for (let permTip of permTipArr) {
+    console.log(red(`\nWarning: fun nas init: ${permTip}`));
   }
 
-  console.log(green('\nFun nas init Success'));
-  if (!service) { tips.showInitNextTips(); }
+  console.log(green('fun nas init Success\n'));
 }
 
 module.exports = { deployNasService };

--- a/lib/nas/ls.js
+++ b/lib/nas/ls.js
@@ -7,7 +7,7 @@ function generateLsCmd(nasPath, isAllOpt, isLongOpt) {
 }
 
 async function ls(serviceName, nasPath, isAllOpt, isLongOpt) {
-  const nasHttpTriggerPath = await getNasHttpTriggerPath(serviceName);
+  const nasHttpTriggerPath = getNasHttpTriggerPath(serviceName);
 
   const lsCmd = generateLsCmd(nasPath, isAllOpt, isLongOpt);
 

--- a/lib/nas/request.js
+++ b/lib/nas/request.js
@@ -3,11 +3,16 @@
 const { getFcClient } = require('../client');
 const { readFileChunk } = require('./cp/file');
 const constants = require('./constants');
-
+const { getServiceMeta } = require('../import/service');
 const PROXY = 'proxy';
 
 function getNasHttpTriggerPath(serviceName) {
-  const nasServiceName = constants.FUN_NAS_SERVICE_PREFIX + serviceName;
+  let nasServiceName;
+  if (serviceName.indexOf(constants.FUN_NAS_SERVICE_PREFIX) !== 0) {
+    nasServiceName = constants.FUN_NAS_SERVICE_PREFIX + serviceName;
+  } else {
+    nasServiceName = serviceName;
+  }
 
   return `/${PROXY}/${nasServiceName}/${constants.FUN_NAS_FUNCTION}/`;
 }
@@ -123,6 +128,14 @@ async function checkRemoteNasTmpDir(nasHttpTriggerPath, remoteNasTmpDir) {
   return await getRequest(urlPath, query);
 }
 
+async function getVersion(nasHttpTriggerPath) {
+  const urlPath = nasHttpTriggerPath + 'version';
+  return await getRequest(urlPath);
+}
+async function getNasConfig(serviceName) {
+  const serviceMeta = await getServiceMeta(serviceName);
+  return serviceMeta.nasConfig;
+}
 module.exports = {
   statsRequest,
   checkFileHash,
@@ -132,5 +145,7 @@ module.exports = {
   sendCleanRequest, 
   createSizedNasFile, 
   uploadChunkFile,
-  checkRemoteNasTmpDir
+  checkRemoteNasTmpDir, 
+  getVersion, 
+  getNasConfig
 };

--- a/lib/nas/rm.js
+++ b/lib/nas/rm.js
@@ -10,7 +10,7 @@ function generateRmCmd(nasPath, isRecursiveOpt, isForceOpt) {
 
 async function rm(serviceName, nasPath, isRecursiveOpt, isForceOpt, nasId) {
   console.log('Removing...');
-  const nasHttpTriggerPath = await getNasHttpTriggerPath(serviceName);
+  const nasHttpTriggerPath = getNasHttpTriggerPath(serviceName);
   const statsRes = await statsRequest(nasPath, nasHttpTriggerPath);
 
   const stats = statsRes.data;

--- a/lib/nas/support.js
+++ b/lib/nas/support.js
@@ -1,6 +1,7 @@
 'use strict';
 const { findServices } = require('../definition');
 const { red } = require('colors');
+const { getVersion, getNasHttpTriggerPath, getNasConfig } = require('./request');
 const _ = require('lodash');
 
 function getDefaultService(tpl) {
@@ -9,7 +10,7 @@ function getDefaultService(tpl) {
   if (services.length === 1) {
     return services[0].serviceName;
   }
-  throw new Error(red('There should be one and only one service in your template.[yml|yaml].'));
+  throw new Error(red('There should be one and only one service in your template.[yml|yaml] when ignoring service in nas path.'));
 }
 function chunk(arr, size) {
   if (size < 1) {
@@ -50,6 +51,7 @@ function checkWritePerm(stats, nasId, nasPath) {
   }
   
   // permStirng 为 ‘777’ 形式的权限形式 
+  
   let permString = (mode & parseInt('777', 8)).toString(8);
   const [ ownerCanWrite, groupCanWrite, otherCanWrite ] = _.map(permString, (perm) => hasWritePerm(parseInt(perm), stats, nasPath));
 
@@ -82,8 +84,54 @@ function hasWritePerm(num, stats, nasPath) {
   }
 }
 
+async function isNasServerStale(serviceName, nasConfig, version) {
+  
+  return !(await isSameVersion(serviceName, version) && await isSameNasConfig(serviceName, nasConfig));
+}
+
+async function isSameVersion(serviceName, version) {
+  const nasHttpTriggerPath = getNasHttpTriggerPath(serviceName);
+  let getVersionRes;
+  let curNasServerVersion;
+  try {
+    getVersionRes = await getVersion(nasHttpTriggerPath);
+    curNasServerVersion = (getVersionRes.data).curVersionId;
+  } catch (error) {
+    curNasServerVersion = -1;
+  }
+
+  return _.isEqual(curNasServerVersion, version);
+}
+
+async function isSameNasConfig(serviceName, nasConfig) {
+  let curNasServerNasConfig;
+  try {
+    curNasServerNasConfig = await getNasConfig(serviceName);
+    curNasServerNasConfig = {
+      UserId: curNasServerNasConfig.userId,
+      GroupId: curNasServerNasConfig.groupId,
+      MountPoints: curNasServerNasConfig.mountPoints.map(p => ({ ServerAddr: p.serverAddr, MountDir: p.mountDir }))
+    };
+  } catch (error) {
+    curNasServerNasConfig = {};
+  }
+  
+  return _.isEqual(nasConfig, curNasServerNasConfig);
+}
+
+function toBeUmountedDirs(configuredMountDirs, mountedDirs) {
+  
+  const toUnmountDirs = mountedDirs.filter((mountedDir) => !configuredMountDirs.includes(mountedDir));
+
+  return toUnmountDirs;
+}
 module.exports = { 
   getDefaultService, 
   chunk, 
   splitRangeBySize, 
-  checkWritePerm };
+  checkWritePerm, 
+  isNasServerStale,
+  toBeUmountedDirs,
+  isSameNasConfig, 
+  isSameVersion
+};

--- a/lib/utils/fun-nas-server/Makefile
+++ b/lib/utils/fun-nas-server/Makefile
@@ -24,7 +24,8 @@ build: clean install
 	npm run build
 	mkdir -p ./dist/.fun/root
 	cp -r ./.fun/root/ ./dist/.fun/root
-
+	git log -n 1 --pretty="format:%h" -- . > ./dist/VERSION
+	
 dev: 
 	npm run dev
 	$(FUN) local start

--- a/lib/utils/fun-nas-server/index.js
+++ b/lib/utils/fun-nas-server/index.js
@@ -7,6 +7,7 @@ const fs = require('fs-extra');
 const getRawBody = require('raw-body');
 const execute = require('./lib/execute');
 const rimraf = require('rimraf');
+const path = require('path');
 const { makeTmpDir } = require('./lib/path');
 const { 
   getFileHash,
@@ -15,6 +16,19 @@ const {
 const app = express();
 app.use(bodyParser.raw({ limit: '6mb' }));
 app.use(bodyParser.json());
+
+app.get('/version', (req, res) => {
+  console.log('received version request');
+
+  const versionFilePath = path.posix.join('/', 'code', 'VERSION');
+  fs.readFile(versionFilePath, (err, data) => {
+    if (err) { res.send({ curVersionId: err }); }
+    const curVersionId = data.toString();
+    res.send({
+      curVersionId
+    });
+  });
+});
 
 app.get('/tmp/check', async(req, res) => {
   console.log('received tmp/check request, query is: ' + req.query);

--- a/test/commands/nas/ls.test.js
+++ b/test/commands/nas/ls.test.js
@@ -15,11 +15,14 @@ const tpl = {
   detectTplPath: sandbox.stub(), 
   getTpl: sandbox.stub()
 };
-
+const init = {
+  deployNasService: sandbox.stub()
+};
 const lsStub = proxyquire('../../../lib/commands/nas/ls', {
   '../../validate/validate': validate,
   '../../nas/ls': lsNasFile,
-  '../../tpl': tpl
+  '../../tpl': tpl, 
+  '../../nas/init': init
 });
 
 describe('command ls test', () => {

--- a/test/commands/nas/rm.test.js
+++ b/test/commands/nas/rm.test.js
@@ -16,11 +16,14 @@ const tpl = {
   detectTplPath: sandbox.stub(), 
   getTpl: sandbox.stub()
 };
-
+const init = {
+  deployNasService: sandbox.stub()
+};
 const rmStub = proxyquire('../../../lib/commands/nas/rm', {
   '../../validate/validate': validate,
   '../../nas/rm': rmNasFile,
-  '../../tpl': tpl
+  '../../tpl': tpl, 
+  '../../nas/init': init
 });
 
 describe('command rm test', () => {

--- a/test/commands/nas/sync.test.js
+++ b/test/commands/nas/sync.test.js
@@ -48,7 +48,7 @@ describe('fun nas sync test', () => {
     
     const options = {
       service: undefined, 
-      mntDirs: undefined
+      mountDir: undefined
     };
 
     await syncStub(options);
@@ -59,7 +59,7 @@ describe('fun nas sync test', () => {
   it('sync test with service', async () => {
     const options = {
       service: mockdata.serviceName, 
-      mntDirs: undefined
+      mountDir: ['/mnt']
     };
     await syncStub(options);
     const localNasDir = path.join('/', 'demo', '.fun', 'nas', '359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com', '/');

--- a/test/nas/init.test.js
+++ b/test/nas/init.test.js
@@ -21,16 +21,21 @@ describe('test fun nas init', () => {
     convertNasConfigToNasMappings: sandbox.stub()
   };
   const fs = {
-    pathExists: sandbox.stub()
+    pathExists: sandbox.stub(),
+    readFile: sandbox.stub()
   };
   const request = {
     statsRequest: sandbox.stub()
+  };
+  const support = {
+    isNasServerStale: sandbox.stub()
   };
   const nasInitStub = proxyquire('../../lib/nas/init', {
     '../deploy/deploy-by-tpl': deploy, 
     '../nas': nas, 
     'fs-extra': fs, 
-    './request': request
+    './request': request, 
+    './support': support
   });
   beforeEach(() => {
 
@@ -52,6 +57,9 @@ describe('test fun nas init', () => {
         mode: 123
       }
     });
+    support.isNasServerStale.returns(true);
+    fs.pathExists.returns(true);
+    fs.readFile.returns(Buffer.from('123'));
   }); 
 
   afterEach(() => {
@@ -65,7 +73,6 @@ describe('test fun nas init', () => {
     const nasServiceName = constants.FUN_NAS_SERVICE_PREFIX + serviceName;
     const nasFunctionName = constants.FUN_NAS_FUNCTION;
     
-    fs.pathExists.returns(true);
     const zipCodePath = path.resolve(__dirname, '../../lib/utils/fun-nas-server/dist/fun-nas-server.zip');
     
     const nasServiceRes = {

--- a/test/nas/ls.test.js
+++ b/test/nas/ls.test.js
@@ -37,7 +37,7 @@ describe('ls test', () => {
 
   it('ls function test', async () => {
     await ls(serviceName, nasPath, isAllOpt, isLongOpt);
-    const nasHttpTriggerPath = await getNasHttpTriggerPath(serviceName);
+    const nasHttpTriggerPath = getNasHttpTriggerPath(serviceName);
     const cmd = `ls -a -l ${nasPath}`;
     assert.calledWith(request.sendCmdRequest, nasHttpTriggerPath, cmd);
     

--- a/test/nas/rm.test.js
+++ b/test/nas/rm.test.js
@@ -47,7 +47,7 @@ describe('ls test', () => {
 
   it('rm function test', async () => {
     await rm(serviceName, nasPath, isRecursiveOpt, isForceOpt, mockdata.nasId);
-    const nasHttpTriggerPath = await getNasHttpTriggerPath(serviceName);
+    const nasHttpTriggerPath = getNasHttpTriggerPath(serviceName);
     const cmd = `rm -R -f ${nasPath}`;
     assert.calledWith(request.sendCmdRequest, nasHttpTriggerPath, cmd);
     


### PR DESCRIPTION
1. 实现差异 fun nas init
2. 在 fun nas sync/rm/ls 操作前增加了差异 fun nas init 操作
3. 增加了 nas-dir-checker 在创建远端 NAS 文件夹出现权限问题后的提示信息
4. fun nas sync -s serviceName -m mountDir，增加 mountDir 不在 serviceName 中的 Warning
5. 交互效果: 
```
$ fun deploy
using template: template.yml
using region: cn-shanghai
using accountId: ***********1670
using accessKeyId: ***********N87x
using timeout: 10

Waiting for service test to be deployed...
        make sure role 'aliyunfcgeneratedrole-cn-shanghai-test' is exist
        role 'aliyunfcgeneratedrole-cn-shanghai-test' is already exist
        attaching policies AliyunECSNetworkInterfaceManagementAccess,AliyunLogReadOnlyAccess to role: aliyunfcgeneratedrole-cn-shanghai-test
        attached policies AliyunECSNetworkInterfaceManagementAccess,AliyunLogReadOnlyAccess to role: aliyunfcgeneratedrole-cn-shanghai-test
        attaching police 'AliyunECSNetworkInterfaceManagementAccess' to role: aliyunfcgeneratedrole-cn-shanghai-test
        attached police 'AliyunECSNetworkInterfaceManagementAccess' to role: aliyunfcgeneratedrole-cn-shanghai-test
        Checking if nas directories /test/demo-m exists, if not, it will be created automatically
fc utils function nas_dir_checker invoke error, error message is: FC Invoke Start RequestId: 26ff72ac-3e30-411f-b673-4fe8967fd99c
load code for handler:index.handler
2019-09-10T06:42:36.725Z 26ff72ac-3e30-411f-b673-4fe8967fd99c [error] error:  { Error: EACCES: permission denied, mkdir '/mnt/nas/cvi67/test/demo-m'
    at fs.mkdirSync (fs.js:885:18)
    at mkdirPSync (/code/index.js:10:8)
    at module.exports.handler (/code/index.js:39:5)
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdir',
  path: '/mnt/nas/cvi67/test/demo-m' }
2019-09-10T06:42:36.731Z 26ff72ac-3e30-411f-b673-4fe8967fd99c [error] Error: EACCES: permission denied, mkdir '/mnt/nas/cvi67/test/demo-m'
    at fs.mkdirSync (fs.js:885:18)
    at mkdirPSync (/code/index.js:10:8)
    at module.exports.handler (/code/index.js:39:5)

FC Invoke End RequestId: 26ff72ac-3e30-411f-b673-4fe8967fd99c
Duration: 36.02 ms, Billed Duration: 100 ms, Memory Size: 128 MB, Max Memory Used: 20.75 MB
May be UserId and GroupId in NasConfig don't have enough permission, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md
```
```
$ fun nas ls -al nas://test/mnt/nas/cvi67
using template: template.yml

start fun nas init...
checking if _FUN_NAS_test needs to be deployed...
Waiting for service _FUN_NAS_test to be deployed...
        make sure role 'aliyunfcgeneratedrole-cn-shanghai--FUN-NAS-test' is exist
        role 'aliyunfcgeneratedrole-cn-shanghai--FUN-NAS-test' is already exist
        attaching police 'AliyunECSNetworkInterfaceManagementAccess' to role: aliyunfcgeneratedrole-cn-shanghai--FUN-NAS-test
        attached police 'AliyunECSNetworkInterfaceManagementAccess' to role: aliyunfcgeneratedrole-cn-shanghai--FUN-NAS-test
        Checking if nas directories /test/test-demo exists, if not, it will be created automatically
        Checking nas directories done ["/test/test-demo"]
        Waiting for function fun-nas-function to be deployed...
                Waiting for packaging function fun-nas-function code...
                The function fun-nas-function has been packaged.
                Waiting for HTTP trigger httpTrigger to be deployed...
                methods: POST,GET
                url: https://1613958610541670.cn-shanghai.fc.aliyuncs.com/2016-08-15/proxy/_FUN_NAS_test/fun-nas-function/
                function httpTrigger deploy success
        function fun-nas-function deploy success
service _FUN_NAS_test deploy success

Create local NAS directory of service test:
        /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/386314add4-cvi67.cn-shanghai.nas.aliyuncs.com/test/test-demo

Warning: fun nas init: UserId: 100 and GroupId: 10 in your NasConfig are mismatched with UserId: 10 and GroupId: 10 of /mnt/nas/cvi67, which may cause permission problem, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md
fun nas init Success

total 5
drwxr-xr-x 2 uucp uucp 4096 Sep 10 03:49 .
drwxr-xr-x 3 root root 4096 Sep 10 03:49 ..
```
```
$ fun nas sync -s poetry -m /mnt/nas/cvi67
using template: template.yml
Warning: /mnt/nas/cvi67 are not configured by service: poetry

start fun nas init...
checking if _FUN_NAS_poetry needs to be deployed...
skip deploying _FUN_NAS_poetry, which has been deployed
Fun nas init Success


Tips for next step
======================
$ fun nas info      # Show NAS info
$ fun nas ls        # List NAS files
$ fun nas sync      # Synchronize files to nas
$ fun deploy        # Deploy Resources
```
```
$ fun nas sync                             
using template: template.yml
start fun nas init...
checking if _FUN_NAS_poetry needs to be deployed...
skip deploying _FUN_NAS_poetry, which has been deployed
checking if _FUN_NAS_test needs to be deployed...
skip deploying _FUN_NAS_test, which has been deployed
Fun nas init Success

Starting upload /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/372784bc17-hlf61.cn-shanghai.nas.aliyuncs.com/ to nas://poetry/mnt/nas/hlf61/
NAS path checking...
zipping /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/372784bc17-hlf61.cn-shanghai.nas.aliyuncs.com/
✔ /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/tmp/nas/sync/Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/.fun-nas-generated-372784bc17-hlf61.cn-shanghai.nas.aliyuncs.com.zip - zipped
checking NAS tmp dir
✔ check done
Creating 1420105 bytes size file: /mnt/nas/hlf61/.fun_nas_tmp/.fun-nas-generated-372784bc17-hlf61.cn-shanghai.nas.aliyuncs.com.zip
✔ create done
✔ upload done
checking uploaded NAS zip file hash
✔ hash unchanged
unzipping file

✔ unzip done
cleaning
✔ clean done
✔ upload completed!
Starting upload /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com/permission to nas://poetry/mnt/nas/lwl67/
NAS path checking...
Warning: fun nas sync: UserId: 10003 and GroupId: 10003 in your NasConfig are mismatched with UserId: 100 and GroupId: 100 of /mnt/nas/lwl67/, which may cause permission problem, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md
zipping /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com/permission
✔ /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/tmp/nas/sync/Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com/.fun-nas-generated-permission.zip - zipped
checking NAS tmp dir
start fun nas init...
checking if _FUN_NAS_poetry needs to be deployed...
skip deploying _FUN_NAS_poetry, which has been deployed
checking if _FUN_NAS_test needs to be deployed...
skip deploying _FUN_NAS_test, which has been deployed
Fun nas init Success

Starting upload /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/386314add4-cvi67.cn-shanghai.nas.aliyuncs.com/test to nas://test/mnt/nas/cvi67/
NAS path checking...
zipping /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/386314add4-cvi67.cn-shanghai.nas.aliyuncs.com/test
✔ /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/tmp/nas/sync/Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/386314add4-cvi67.cn-shanghai.nas.aliyuncs.com/.fun-nas-generated-test.zip - zipped
checking NAS tmp dir
✔ check done
Creating 67956691 bytes size file: /mnt/nas/cvi67/.fun_nas_tmp/.fun-nas-generated-test.zip
✔ create done
✔ upload done
checking uploaded NAS zip file hash
✔ hash unchanged
unzipping file
:unzipping █████████████████████ 5875/8851 213 files/s, 66% 27.6 s
✔ unzip done
cleaning
✔ clean done
✔ upload completed!

Upload /Users/zqf/Documents/fun-nas-test-case/tensorflow-server/poetry/.fun/nas/359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com/permission To nas://poetry/mnt/nas/lwl67/ Error: EACCES: permission denied, mkdir '/mnt/nas/lwl67/.fun_nas_tmp'


Tips for next step
======================
$ fun nas info      # Show NAS info
$ fun nas ls        # List NAS files
$ fun nas sync      # Synchronize files to nas
$ fun deploy        # Deploy Resources
```