### PR TITLE
feat(HTTP Trigger): 支持指定 HTTP Trigger 启动调试

### DIFF
--- a/bin/fun-local-start.js
+++ b/bin/fun-local-start.js
@@ -22,16 +22,16 @@ program
     For compiled languages such as java, we recommend you set CodeUri to the compiled or packaged location.
     Once compiled or packaged result changed, the modified code will take effect immediately without restarting the http server.`
   )
-  .usage('[options]')
+  .usage('[options] <[service/]function>')
   .option('-d, --debug-port <port>', 'specify the sandbox container starting in debug' +
     ' mode, and exposing this port on localhost')
   .option('-c, --config <ide/debugger>', 
     'select which IDE to use when debugging and output related debug config tips for the IDE. Options：\'vscode\', \'pycharm\'')
   .parse(process.argv);
 
-if (program.args.length) {
+if (program.args.length > 1) {
   console.error();
-  console.error("  error: unexpected argument `%s'", program.args[0]);
+  console.error("  error: unexpected argument `%s'", program.args[1]);
   program.help();
 }
 
@@ -40,7 +40,7 @@ notifier.notify();
 getVisitor().then(visitor => {
   visitor.pageview('/fun/local/start').send();
 
-  require('../lib/commands/local/start')(program)
+  require('../lib/commands/local/start')(program, program.args[0])
     .then(() => {
       visitor.event({
         ec: 'local start',

--- a/lib/commands/local/http-support.js
+++ b/lib/commands/local/http-support.js
@@ -9,7 +9,7 @@ const ApiInvoke = require('../../local/api-invoke');
 const fc = require('../../fc');
 const { red } = require('colors');
 
-function logsHttpTrigger(serverPort, serviceName, functionName, triggerName, endpoint, httpMethods, authType) {
+function printHttpTriggerTips(serverPort, serviceName, functionName, triggerName, endpoint, httpMethods, authType) {
   console.log(green(`http trigger ${triggerName} of ${serviceName}/${functionName} was registered`));
   console.log('\turl: ' + yellow(`http://localhost:${serverPort}${endpoint}/`));
   console.log(`\tmethods: ` + yellow(httpMethods));
@@ -17,53 +17,55 @@ function logsHttpTrigger(serverPort, serviceName, functionName, triggerName, end
 }
 
 async function registerHttpTriggers(app, serverPort, httpTriggers, debugPort, debugIde, baseDir) {
-  for (let { serviceName, serviceRes,
-    functionName, functionRes,
-    triggerName, triggerRes } of httpTriggers) {
-
-    debug('serviceName: ' + serviceName);
-    debug('functionName: ' + functionName);
-    debug('tiggerName: ' + triggerName);
-    debug('triggerRes: ' + triggerRes);
-
-    const endpointPrefix = `/2016-08-15/proxy/${serviceName}/${functionName}`;
-    const endpoint = `${endpointPrefix}*`;
-
-    const triggerProps = triggerRes.Properties;
-    const httpMethods = triggerProps.Methods;
-    const authType = triggerProps.AuthType;
-
-    const codeUri = functionRes.Properties.CodeUri;
-    const runtime = functionRes.Properties.Runtime;
-
-    debug('debug port: %d', debugPort);
-
-    if (debugPort && runtime === 'java8') {
-      console.error(red('debug for java8 http trigger is not supported now. If you really need it, please create an issue to https://github.com/alibaba/funcraft/issues .'));
-      continue;
-    }
-
-    const httpInvoke = new HttpInvoke(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, baseDir, authType, endpointPrefix);
-
-    await fc.detectLibrary(codeUri, runtime, baseDir, functionName);
-
-    for (let method of httpMethods) {
-
-      app[method.toLowerCase()](endpoint, async (req, res) => {
-
-        if (req.get('Upgrade') === 'websocket') {
-          res.status(403).send('websocket not support');
-          return;
-        }
-        
-        await httpInvoke.invoke(req, res);
-      });
-    }
-
-    logsHttpTrigger(serverPort, serviceName, functionName, triggerName, endpointPrefix, httpMethods, authType);
+  for (let httpTrigger of httpTriggers) {
+    await registerSingleHttpTrigger(app, serverPort, httpTrigger, debugPort, debugIde, baseDir);
   }
 
   console.log();
+}
+
+async function registerSingleHttpTrigger(app, serverPort, httpTrigger, debugPort, debugIde, baseDir, eager = false) {
+  const { serviceName, serviceRes,
+    functionName, functionRes,
+    triggerName, triggerRes } = httpTrigger;
+  
+  debug('serviceName: ' + serviceName);
+  debug('functionName: ' + functionName);
+  debug('tiggerName: ' + triggerName);
+  debug('triggerRes: ' + triggerRes);
+
+  const endpointPrefix = `/2016-08-15/proxy/${serviceName}/${functionName}`;
+  const endpoint = `${endpointPrefix}*`;
+
+  const triggerProps = triggerRes.Properties;
+  const httpMethods = triggerProps.Methods;
+  const authType = triggerProps.AuthType;
+
+  const codeUri = functionRes.Properties.CodeUri;
+  const runtime = functionRes.Properties.Runtime;
+
+  debug('debug port: %d', debugPort);
+
+  if (debugPort && runtime === 'java8') {
+    console.error(red('debug for java8 http trigger is not supported now. If you really need it, please create an issue to https://github.com/alibaba/funcraft/issues .'));
+    return;
+  }
+
+  await fc.detectLibrary(codeUri, runtime, baseDir, functionName);
+  const httpInvoke = new HttpInvoke(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, baseDir, authType, endpointPrefix);
+  if (eager) {
+    await httpInvoke.initAndStartRunner();
+  }
+  for (let method of httpMethods) {
+    app[method.toLowerCase()](endpoint, async (req, res) => {
+      if (req.get('Upgrade') === 'websocket') {
+        res.status(403).send('websocket not support');
+        return;
+      }
+      await httpInvoke.invoke(req, res);
+    });
+  }
+  printHttpTriggerTips(serverPort, serviceName, functionName, triggerName, endpointPrefix, httpMethods, authType);
 }
 
 function logsApi(serverPort, serviceName, functionName, endpoint) {
@@ -94,5 +96,6 @@ async function registerApis(app, serverPort, functions, debugPort, debugIde, bas
 }
 
 module.exports = {
-  registerHttpTriggers, registerApis
+  registerHttpTriggers, registerApis,
+  registerSingleHttpTrigger
 };

--- a/lib/commands/local/start.js
+++ b/lib/commands/local/start.js
@@ -73,7 +73,7 @@ function startExpress(app) {
   registerSigintForExpress(server);
 }
 
-async function start(options) {
+async function start(options, invokeName = '') {
 
   const tplPath = await detectTplPath();
 
@@ -91,7 +91,26 @@ async function start(options) {
 
     const baseDir = path.dirname(tplPath);
 
-    const httpTriggers = definition.findHttpTriggersInTpl(tpl);
+    let httpTriggers = definition.findHttpTriggersInTpl(tpl);
+
+    const [ serviceName, functionName ] = definition.parseFunctionPath(invokeName);
+
+    if (functionName) {
+      const httpTrigger = httpTriggers.filter((trigger) => {
+        return serviceName ? serviceName === trigger.serviceName && functionName === trigger.functionName
+          : functionName === trigger.functionName;
+      });
+      if (httpTrigger.length === 0) {
+        throw new Error(`${invokeName} did not has http trigger`);
+      }
+      if (httpTrigger.length > 1) {
+        throw new Error(`${invokeName} is not unique`);
+      }
+      
+      await httpSupport.registerSingleHttpTrigger(app, serverPort, httpTrigger[0], debugPort, debugIde, baseDir, true);
+      startExpress(app);
+      return;
+    }
 
     await httpSupport.registerHttpTriggers(app, serverPort, httpTriggers, debugPort, debugIde, baseDir);
 

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -394,6 +394,7 @@ async function pullImageIfNeed(imageName) {
     await pullImage(imageName);
   } else {
     debug(`skip pulling image ${imageName}...`);
+    console.log(`skip pulling image ${imageName}...`);
   }
 }
 

--- a/lib/local/http-invoke.js
+++ b/lib/local/http-invoke.js
@@ -99,7 +99,7 @@ class HttpInvoke extends Invoke {
               });
             }
 
-            await this._generateRunner();
+            await this._startRunner();
           } else {
             debug('acquire invoke lock success, but runner already created, skipping...');
           }
@@ -108,7 +108,7 @@ class HttpInvoke extends Invoke {
     }
   }
 
-  async _generateRunner() {
+  async _startRunner() {
 
     const envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, null, this.nasConfig, true, this.debugIde);
 
@@ -121,6 +121,11 @@ class HttpInvoke extends Invoke {
       this.dockerUser);
 
     this.runner = await startContainer(opts, process.stdout, process.stderr);
+  }
+
+  async initAndStartRunner() {
+    await this.init();
+    await this._startRunner();
   }
 
   async doInvoke(req, res) {
@@ -137,7 +142,7 @@ class HttpInvoke extends Invoke {
 
       const envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, httpParams, this.nasConfig, true, this.debugIde);
 
-      if (this.debugPort) {
+      if (this.debugPort && !this.runner) {
         // don't reuse container
         const cmd = docker.generateDockerCmd(this.functionProps, true, event);
 

--- a/lib/local/invoke.js
+++ b/lib/local/invoke.js
@@ -55,7 +55,6 @@ class Invoke {
   async invoke() {
     if (!this.inited) {
       await this.init();
-      this.inited = true;
     }
 
     await this.beforeInvoke();
@@ -93,6 +92,8 @@ class Invoke {
     this.imageName = await dockerOpts.resolveRuntimeToDockerImage(this.runtime);
 
     await docker.pullImageIfNeed(this.imageName);
+
+    this.inited = true;
   }
 
   async beforeInvoke() {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@alicloud/cloudapi": "^1.0.0",
     "@alicloud/fc": "^1.2.3",
-    "@alicloud/fc-builders": "git+https://github.com/aliyun/fc-builders.git",
+    "@alicloud/fc-builders": "git://github.com/aliyun/fc-builders.git",
     "@alicloud/fc2": "^2.1.1",
     "@alicloud/log": "^1.1.0",
     "@alicloud/mns": "^1.0.0",


### PR DESCRIPTION
local start 的时候，之前的行为逻辑是先启动 express，监听到请求了某个函数，再启动该函数的 container。
如今改为如果指定了某个具体的函数，则先启动 express 以及相应 runtime 的 container。原先在 vscode 插件上，每次调试都是直接打开一个浏览器进入调试流程，用户无法决定本次调试的参数以及请求方式。现在变为先 attach 住 Debugger，然后由用户来决定调试 http trigger 时的参数以及请求方式。