### PR TITLE
add fun install funfile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ output
 event.dat
 __pycache__/
 dist/
+template.packaged.yml

--- a/bin/fun-build.js
+++ b/bin/fun-build.js
@@ -12,7 +12,7 @@ program
   .name('fun build')
   .usage('[options] [[service/]function]')
   .description('Build the dependencies.')
-  .option('-u, --use-docker', 'Use docker container to build functions')
+  .option('-d, --use-docker', 'Use docker container to build functions')
   .option('-t, --template [template]', 'path of fun template file.')
   .parse(process.argv);
 

--- a/bin/fun-install.js
+++ b/bin/fun-install.js
@@ -40,7 +40,7 @@ program
   .option('-f, --function <[service/]function>', `Specify which function to execute installation task.`)
   .option('-r, --runtime <runtime>', `function runtime, avaliable choice is: ${getSupportedRuntimesAsString(['dotnetcore2.1'])}`)
   .option('-e, --env <env>', 'environment variable, ex. -e PATH=/code/bin', (e, envs) => (envs.push(e), envs), [])
-  .option('-d, --use-docker', 'Use docker container to build functions')
+  .option('-d, --use-docker', 'Use docker container to install function dependencies')
   .option('--save', 'add task to fun.yml file.')
   .option('-p, --package-type <type>', 'avaliable package type option: pip, apt.')
   .arguments('[packageNames...]')

--- a/bin/fun-install.js
+++ b/bin/fun-install.js
@@ -40,6 +40,7 @@ program
   .option('-f, --function <[service/]function>', `Specify which function to execute installation task.`)
   .option('-r, --runtime <runtime>', `function runtime, avaliable choice is: ${getSupportedRuntimesAsString(['dotnetcore2.1'])}`)
   .option('-e, --env <env>', 'environment variable, ex. -e PATH=/code/bin', (e, envs) => (envs.push(e), envs), [])
+  .option('-d, --use-docker', 'Use docker container to build functions')
   .option('--save', 'add task to fun.yml file.')
   .option('-p, --package-type <type>', 'avaliable package type option: pip, apt.')
   .arguments('[packageNames...]')
@@ -56,14 +57,9 @@ program
     opts.verbose = parseInt(process.env.FUN_VERBOSE) > 0;
     opts.env = convertEnvs(options.env);
 
-
     install(packageNames, opts).then(() => {
-
       autoExitOnWindows();
-
     }).catch(handler);
-
-
   });
 
 program
@@ -74,25 +70,21 @@ program
 
       visitor.pageview('/fun/install/init').send();
       init().then((runtime) => {
-
         visitor.event({
           ec: 'install',
           ea: `init ${runtime}`,
           el: 'success',
           dp: '/fun/install/init'
         }).send();
-
       }).catch((error) => {
-
         visitor.event({
           ec: 'install',
           ea: `init`,
           el: 'error',
           dp: '/fun/install/init'
         }).send();
-
+        
         handler(error);
-
       });
     });
   });
@@ -214,7 +206,8 @@ if (!program.args.length) {
     visitor.pageview('/fun/installAll').send();
 
     installAll(program.function, {
-      verbose: parseInt(process.env.FUN_VERBOSE) > 0
+      verbose: parseInt(process.env.FUN_VERBOSE) > 0,
+      useDocker: program.useDocker
     }).then(() => {
       visitor.event({
         ec: 'installAll',

--- a/lib/build/build-opts.js
+++ b/lib/build/build-opts.js
@@ -5,7 +5,7 @@ const dockerOpts = require('../docker-opts');
 const definition = require('../definition');
 const path = require('path');
 
-async function generateBuildContainerBuildOpts(serviceName, serviceRes, functionName, functionRes, baseDir, codeUri, funcArtifactDir, verbose, preferredImage) {
+async function generateBuildContainerBuildOpts(serviceName, serviceRes, functionName, functionRes, baseDir, codeUri, funcArtifactDir, verbose, preferredImage, stages) {
   const functionProps = functionRes.Properties;
   const runtime = functionProps.Runtime;
 
@@ -35,7 +35,7 @@ async function generateBuildContainerBuildOpts(serviceName, serviceRes, function
     functionName,
     sourceDir: '/code',
     runtime,
-    artifactDir: funcArtifactMountDir,
+    artifactDir: codeUri === funcArtifactDir ? '/code' : funcArtifactMountDir,
     verbose
   };
 

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -81,7 +81,7 @@ async function copyNasArtifact(serviceName, serviceRes, imageTag, rootArtifactsD
 async function getOrConvertFunfile(codeUri) {
   const funfilePath = path.join(codeUri, 'Funfile');
   const funymlPath = path.join(codeUri, 'fun.yml');
-
+  
   let funfileExist = await fs.pathExists(funfilePath);
   const funymlExist = await fs.pathExists(funymlPath);
 

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -177,7 +177,7 @@ async function buildFunction(buildName, tpl, baseDir, useDocker, stages, verbose
 
     // if no manifest file and no Funfile, dont need compile function
     if (!funfilePath && (_.isEmpty(taskFlows) || taskflow.isOnlyDefaultTaskFlow(taskFlows))) {
-      console.log(`could not find any manifest file for ${func.serviceName}/${func.functionName}, building will be skipped`);
+      console.log(`could not find any manifest file for ${func.serviceName}/${func.functionName}, [${stages}] stage will be skipped`);
       skippedBuildFuncs.push(func);
       continue;
     }

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -96,9 +96,8 @@ async function getOrConvertFunfile(codeUri) {
 
   if (funfileExist) {
     return funfilePath;
-  } else {
-    return null;
-  }
+  } 
+  return null;
 }
 
 async function processFunfile(serviceName, serviceRes, codeUri, funfilePath, rootArtifactsDir, funcArtifactDir) {

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -8,7 +8,7 @@ const fcBuilders = require('@alicloud/fc-builders');
 const _ = require('lodash');
 const { green } = require('colors');
 const taskflow = require('./taskflow');
-const { showBuildNextTips } = require('./tips');
+const { showBuildNextTips, showInstallNextTips } = require('./tips');
 const template = require('./template');
 const artifact = require('./artifact');
 const docker = require('../docker');
@@ -74,26 +74,76 @@ async function copyNasArtifact(serviceName, serviceRes, imageTag, rootArtifactsD
       } catch (e) {
         debug(`copy from image ${imageTag} directory ${remoteNasDir} to ${localNasDir} error`, e);
       }
-    } 
+    }
   }
 }
 
-async function buildFunction(buildName, tpl, baseDir, useDocker, verbose) {
-  if (useDocker) {
-    console.log(green('start building functions using docker'));
-  } else {
-    console.log(green('start building functions without docker'));
+async function getOrConvertFunfile(codeUri) {
+  const funfilePath = path.join(codeUri, 'Funfile');
+  const funymlPath = path.join(codeUri, 'fun.yml');
+
+  let funfileExist = await fs.pathExists(funfilePath);
+  const funymlExist = await fs.pathExists(funymlPath);
+
+  // convert funyml to Funfile if funyml exist and Funfile dont exist
+  if (!funfileExist && funymlExist) {
+    console.log('detecting fun.yml but no Funfile, Fun will convert fun.yml to Funfile');
+
+    await convertFunYmlToFunfile(funymlPath, funfilePath);
+
+    funfileExist = true;
   }
 
-  debug(`buildName: ${buildName}`);
+  if (funfileExist) {
+    return funfilePath;
+  } else {
+    return null;
+  }
+}
+
+async function processFunfile(serviceName, serviceRes, codeUri, funfilePath, rootArtifactsDir, funcArtifactDir) {
+  console.log(yellow('Funfile exist, Fun will use container to build forcely'));
+
+  const dockerfilePath = path.join(codeUri, '.Funfile.generated.dockerfile');
+
+  await convertFunfileToDockerfile(funfilePath, dockerfilePath);
+
+  const tag = `fun-cache-${uuid.v4()}`;
+
+  const imageTag = await docker.buildImage(codeUri, dockerfilePath, tag);
+
+  // copy fun install generated artifact files to artifact dir
+  console.log(`copying function artifact to ${funcArtifactDir}`);
+  await docker.copyFromImage(imageTag, '/code/.', funcArtifactDir);
+
+  // process nas folder
+  await copyNasArtifact(serviceName, serviceRes, imageTag, rootArtifactsDir, funcArtifactDir);
+
+  return imageTag;
+}
+
+async function buildFunction(buildName, tpl, baseDir, useDocker, stages, verbose) {
+  const buildStage = _.includes(stages, 'build');
+
+  if (useDocker) {
+    console.log(green(`start ${buildStage ? 'building' : 'installing'} functions using docker`));
+  } else {
+    console.log(green(`start ${buildStage ? 'building' : 'installing'} function dependencies without docker`));
+  }
+
+  debug(`${buildStage ? 'buildName' : 'installName'}: ${buildName}`);
 
   const buildFuncs = template.findBuildFuncs(buildName, tpl);
 
   const skippedBuildFuncs = [];
 
-  const rootArtifactsDir = await artifact.generateRootArtifactDirectory(baseDir);
-
-  await artifact.cleanDirectory(rootArtifactsDir);
+  let rootArtifactsDir;
+  if (buildStage) {
+    rootArtifactsDir = await artifact.generateRootArtifactDirectory(baseDir);
+    await artifact.cleanDirectory(rootArtifactsDir);
+  } else {
+    rootArtifactsDir = baseDir;
+  }
 
   for (let func of buildFuncs) {
     const { functionName, serviceName, serviceRes, functionRes } = func;
@@ -106,79 +156,56 @@ async function buildFunction(buildName, tpl, baseDir, useDocker, verbose) {
 
     await assertCodeUriExist(codeUri);
 
-    const funcArtifactDir = await artifact.generateArtifactDirectory(rootArtifactsDir, serviceName, functionName);
-
-    await artifact.cleanDirectory(funcArtifactDir);
+    let funcArtifactDir;
+    if (buildStage) {
+      funcArtifactDir = await artifact.generateArtifactDirectory(rootArtifactsDir, serviceName, functionName);
+      await artifact.cleanDirectory(funcArtifactDir);
+    } else {
+      funcArtifactDir = codeUri;
+    }
 
     const Builder = fcBuilders.Builder;
     const taskFlows = await Builder.detectTaskFlow(runtime, codeUri);
 
-    const funfilePath = path.join(codeUri, 'Funfile');
-    const funymlPath = path.join(codeUri, 'fun.yml');
+    const funfilePath = await getOrConvertFunfile(codeUri);
 
     let imageTag;
 
-    let funfileExist = await fs.pathExists(funfilePath);
-    const funymlExist = await fs.pathExists(funymlPath);
-
-    const forceDocker = funymlExist || funfileExist;
-
-    // convert funyml to Funfile if funyml exist and Funfile dont exist
-    if (!funfileExist && funymlExist) {
-      console.log('detecting fun.yml but no Funfile, Fun will convert fun.yml to Funfile');
-
-      await convertFunYmlToFunfile(funymlPath, funfilePath);
-
-      funfileExist = true;
-    }
-
     // convert Funfile to dockerfile if Funfile exist
-    if (funfileExist) {
-      console.log(yellow('Funfile exist, Fun will use container to build forcely'));
-
-      const dockerfilePath = path.join(codeUri, '.Funfile.generated.dockerfile');
-
-      await convertFunfileToDockerfile(funfilePath, dockerfilePath);
-
-      const tag = `fun-build-cache-${uuid.v4()}`;
-
-      imageTag = await docker.buildImage(codeUri, dockerfilePath, tag);
-
-      // copy fun install generated artifact files to artifact dir
-      console.log(`copying function build artifact to ${funcArtifactDir}`);
-      await docker.copyFromImage(imageTag, '/code/.', funcArtifactDir);
-
-      // process nas folder
-      await copyNasArtifact(serviceName, serviceRes, imageTag, rootArtifactsDir, funcArtifactDir);
+    if (funfilePath) {
+      imageTag = await processFunfile(serviceName, serviceRes, codeUri, funfilePath, rootArtifactsDir, funcArtifactDir);
     }
 
     // if no manifest file and no Funfile, dont need compile function
-    if (!funfileExist && (_.isEmpty(taskFlows) || taskflow.isOnlyDefaultTaskFlow(taskFlows))) {
+    if (!funfilePath && (_.isEmpty(taskFlows) || taskflow.isOnlyDefaultTaskFlow(taskFlows))) {
       console.log(`could not find any manifest file for ${func.serviceName}/${func.functionName}, building will be skipped`);
       skippedBuildFuncs.push(func);
       continue;
     }
 
-    if (useDocker || forceDocker) {
-      await builder.buildInDocker(serviceName, serviceRes, functionName, functionRes, baseDir, codeUri, funcArtifactDir, verbose, imageTag);
+    if (useDocker || funfilePath) { // force docker if funfilePath exist
+      await builder.buildInDocker(serviceName, serviceRes, functionName, functionRes, baseDir, codeUri, funcArtifactDir, verbose, imageTag, stages);
     } else {
-      await builder.buildInProcess(serviceName, functionName, codeUri, runtime, funcArtifactDir, verbose);
+      await builder.buildInProcess(serviceName, functionName, codeUri, runtime, funcArtifactDir, verbose, stages);
     }
   }
 
-  const updatedTemplateContent = template.updateTemplateResources(tpl, buildFuncs, skippedBuildFuncs, baseDir, rootArtifactsDir);
+  if (buildStage) {
+    const updatedTemplateContent = template.updateTemplateResources(tpl, buildFuncs, skippedBuildFuncs, baseDir, rootArtifactsDir);
 
-  await fs.writeFile(path.join(rootArtifactsDir, 'template.yml'), yaml.dump(updatedTemplateContent));
+    await fs.writeFile(path.join(rootArtifactsDir, 'template.yml'), yaml.dump(updatedTemplateContent));
 
-  console.log(green('\nBuild Success\n'));
+    console.log(green('\nBuild Success\n'));
 
-  console.log('Built artifacts: ' + path.relative(baseDir, rootArtifactsDir));
+    console.log('Built artifacts: ' + path.relative(baseDir, rootArtifactsDir));
+    console.log('Built template: ' + path.relative(baseDir, path.join(rootArtifactsDir, 'template.yml')));
 
-  console.log('Built template: ' + path.relative(baseDir, path.join(rootArtifactsDir, 'template.yml')));
-
-  showBuildNextTips();
+    showBuildNextTips();
+  } else {
+    showInstallNextTips();
+  }
 }
 
 module.exports = {
-  buildFunction, copyNasArtifact
+  buildFunction, copyNasArtifact, getOrConvertFunfile
 };

--- a/lib/build/builder.js
+++ b/lib/build/builder.js
@@ -5,8 +5,7 @@ const docker = require('../docker');
 const buildOpts = require('./build-opts');
 const fcBuilders = require('@alicloud/fc-builders');
 
-async function buildInDocker(serviceName, serviceRes, functionName, functionRes, baseDir, codeUri, funcArtifactDir, verbose, preferredImage) {
-
+async function buildInDocker(serviceName, serviceRes, functionName, functionRes, baseDir, codeUri, funcArtifactDir, verbose, preferredImage, stages) {
   const opts = await buildOpts.generateBuildContainerBuildOpts(serviceName, 
     serviceRes, 
     functionName,
@@ -15,7 +14,8 @@ async function buildInDocker(serviceName, serviceRes, functionName, functionRes,
     codeUri,
     funcArtifactDir,
     verbose, 
-    preferredImage);
+    preferredImage,
+    stages);
 
   const usedImage = opts.Image;
   console.log('\nbuild function using image: ' + usedImage);
@@ -29,8 +29,8 @@ async function buildInDocker(serviceName, serviceRes, functionName, functionRes,
   }
 }
 
-async function buildInProcess(serviceName, functionName, codeUri, runtime, funcArtifactDir, verbose) {
-  const builder = new fcBuilders.Builder(serviceName, functionName, codeUri, runtime, funcArtifactDir, verbose);
+async function buildInProcess(serviceName, functionName, codeUri, runtime, funcArtifactDir, verbose, stages) {
+  const builder = new fcBuilders.Builder(serviceName, functionName, codeUri, runtime, funcArtifactDir, verbose, stages);
   await builder.build();
 }
 

--- a/lib/build/parser.js
+++ b/lib/build/parser.js
@@ -31,6 +31,7 @@ function funymlToFunfile(funymlPath) {
 
   const funModule = FunModule.load(funymlPath);
   const runtime = funModule.runtime;
+  let firstAptCmd = true;
 
   const content = [];
 
@@ -74,8 +75,14 @@ function funymlToFunfile(funymlPath) {
       if (t.attrs.local) {
         content.push(`RUN${cwdCmd}${env} fun-install apt-get install ${t.attrs.apt}${targetParameter}`);
       } else {
+        if (firstAptCmd) {
+          content.push(`RUN apt-get update`);
+        }
+        
         content.push(`RUN${cwdCmd}${env} apt-get install ${t.attrs.apt}`);
       }
+
+      firstAptCmd = false;
       break;
     }
     case 'shell': {
@@ -142,4 +149,4 @@ If you have a requirement, you can submit the issue at https://github.com/alibab
   return dockerfile.join('\n');
 }
 
-module.exports = { funymlToFunfile, funfileToDockerfile };
+module.exports = { funymlToFunfile, funfileToDockerfile, resolveEnv };

--- a/lib/build/template.js
+++ b/lib/build/template.js
@@ -15,7 +15,6 @@ function findBuildFuncs(buildName, tpl) {
     return [func];
   } 
   return definition.findFunctionsInTpl(tpl);
-  
 }
 
 function updateTemplateResources(originTplContent, buildFuncs, skippedBuildFuncs, baseDir, rootArtifactsDir) {

--- a/lib/build/tips.js
+++ b/lib/build/tips.js
@@ -14,6 +14,20 @@ function showBuildNextTips() {
 * Deploy Resources: ${deployTip}`));
 }
 
+function showInstallNextTips() {
+  const eventInvokeTip = 'fun local invoke';
+  const httpInvokeTip = 'fun local start';
+  const deployTip = 'fun deploy';
+  const buildTip = 'fun build';
+
+  console.log(yellow(`\nTips for next step
+======================
+* Invoke Event Function: ${eventInvokeTip}
+* Invoke Http Function: ${httpInvokeTip}
+* Build Http Function: ${buildTip}
+* Deploy Resources: ${deployTip}`));
+}
+
 module.exports = {
-  showBuildNextTips
+  showBuildNextTips, showInstallNextTips
 };

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -26,7 +26,7 @@ async function build(buildName, options) {
 
     const baseDir = path.dirname(tplPath);
 
-    await buildFunction(buildName, tpl, baseDir, useDocker, options.verbose);
+    await buildFunction(buildName, tpl, baseDir, useDocker, ['install', 'build'], options.verbose);
   } else {
     throw new Error(red('The template file name must be template.[yml|yaml].'));
   }

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -68,7 +68,6 @@ async function getCodeUri(functionRes) {
   return process.cwd();
 }
 
-// todo: support Funfile
 function getRuntime(codeUri, functionRes, options) {
   console.log('codeUri', codeUri, 'runtime', functionRes);
   let moduleRuntime;
@@ -183,8 +182,9 @@ async function init() {
     choices: getSupportedRuntimes()
   }]);
 
-  const funModule = new FunModule(answers.runtime);
-  FunModule.store('./fun.yml', funModule);
+  const funfilePath = path.join(process.cwd(), 'Funfile');
+
+  await fs.writeFile(funfilePath, `RUNTIME ${answers.runtime}`);
 
   return answers.runtime;
 }

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const findit = require('findit2');
 const debug = require('debug')('fun:install');
 const inquirer = require('inquirer');
 const fs = require('fs-extra');
@@ -127,9 +126,9 @@ function convertPackageToCmd(pkgType, pkg) {
     return `fun-install apt-get install ${pkg}`;
   } else if (pkgType === 'pip') {
     return `fun-install pip install ${pkg}`;
-  } else {
-    throw new Error(`unknow package type %${pkgType}`);
-  }
+  } 
+  throw new Error(`unknow package type %${pkgType}`);
+  
 }
 
 async function install(packages, options) {
@@ -154,7 +153,7 @@ async function install(packages, options) {
       cmd,
       envs: env,
       interactive: false,
-      runtime,
+      runtime
     });
   }
 

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -22,10 +22,6 @@ async function installAll(funcPath, { verbose, useDocker }) {
 
   if (!tplPath) {
     throw new Error(red('Current folder not a fun project\nThe folder must contains template.[yml|yaml] or faas.[yml|yaml] .'));
-  }
-
-  if (!tplPath) {
-    throw new Error(red('Current folder not a fun project\nThe folder must contains template.[yml|yaml] or faas.[yml|yaml] .'));
   } else if (path.basename(tplPath).startsWith('template')) {
 
     await validate(tplPath);

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -3,66 +3,44 @@
 const findit = require('findit2');
 const debug = require('debug')('fun:install');
 const inquirer = require('inquirer');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const { red, green, cyan } = require('colors');
-
-const { installPackage, installFromYaml } = require('../install/install');
-const { FunModule, FunTask } = require('../install/module');
+const { buildFunction, getOrConvertFunfile } = require('../build/build');
+const { resolveEnv } = require('../build/parser');
+const { FunModule } = require('../install/module');
 const { addEnv } = require('../install/env');
 const getVisitor = require('../visitor').getVisitor;
 const { getSupportedRuntimes } = require('../common/model/runtime');
 const sbox = require('../install/sbox');
 const { findFunctionInTpl } = require('../definition');
-const { detectTplPath, getTpl} = require('../tpl');
+const { detectTplPath, getTpl } = require('../tpl');
 const validate = require('../validate/validate');
+const _ = require('lodash');
 
-async function findYamlFiles(dir) {
-  return new Promise((resolve, reject) => {
-    let yamlFiles = [];
-    findit(dir).on('directory', (subdir, stat, stop, linkPath) => {
-      var base = path.basename(subdir);
-      if (['.git', 'node_modules', '.fun', '.vscode'].includes(base)) {
-        stop();
-      } else {
-        let ymlPath = path.join(subdir, 'fun.yml');
-        if (fs.existsSync(ymlPath)) {
-          yamlFiles.push(ymlPath);
-        }
-      }
-    }).on('end', () => resolve(yamlFiles))
-      .on('error', (err) => reject(err));
-  });
-}
+async function installAll(funcPath, { verbose, useDocker }) {
+  const tplPath = await detectTplPath(false);
 
-async function installAll(funcPath, { verbose }) {
+  if (!tplPath) {
+    throw new Error(red('Current folder not a fun project\nThe folder must contains template.[yml|yaml] or faas.[yml|yaml] .'));
+  }
 
-  if (!funcPath) {
-    const dir = process.cwd();
-    const yamlFiles = await findYamlFiles(dir);
-    for (let ymlPath of yamlFiles) {
-      console.log();
-      console.log('Installing recursively on %s', cyan(path.relative(dir, ymlPath)));
-      console.log();
-      await installFromYaml(ymlPath, verbose);
-    }
+  if (!tplPath) {
+    throw new Error(red('Current folder not a fun project\nThe folder must contains template.[yml|yaml] or faas.[yml|yaml] .'));
+  } else if (path.basename(tplPath).startsWith('template')) {
+
+    await validate(tplPath);
+
+    const tpl = await getTpl(tplPath);
+    const baseDir = path.dirname(tplPath);
+
+    await buildFunction(funcPath, tpl, baseDir, useDocker, ['install'], verbose);
   } else {
-    const functionRes = await getFunctionRes(funcPath);
-    const dir = await getCodeUri(functionRes);
-    const ymlPath = path.join(dir, 'fun.yml');
-    if (fs.existsSync(ymlPath)) {
-      console.log();
-      console.log(`Installing '${cyan(ymlPath)}' for function '${green(funcPath)}'`);
-      console.log();
-      await installFromYaml(ymlPath, verbose);
-    } else {
-      throw new Error('Can\'t find \'fun.yml\' in current dir.');
-    }
+    throw new Error(red('The template file name must be template.[yml|yaml].'));
   }
 }
 
 async function getFunctionRes(funcPath) {
-
   if (funcPath) {
     const tplPath = await detectTplPath(false);
     if (!tplPath || !path.basename(tplPath).startsWith('template')) {
@@ -72,35 +50,28 @@ async function getFunctionRes(funcPath) {
     await validate(tplPath);
 
     const tpl = await getTpl(tplPath);
-
-    const {functionRes} = findFunctionInTpl(funcPath, tpl);
-
+    const { functionRes } = findFunctionInTpl(funcPath, tpl);
     if (!functionRes) {
       throw new Error(`Error: function ${funcPath} not found in ${tplPath}`);
     }
-
     return functionRes;
   }
-
   return undefined;
 }
 
 async function getCodeUri(functionRes) {
-
   if (functionRes) {
-
     if (functionRes.Properties && functionRes.Properties.CodeUri) {
       return path.resolve(functionRes.Properties.CodeUri);
     }
-
     throw new Error(`Error: can not find CodeUri in function`);
   }
-
   return process.cwd();
 }
 
-
+// todo: support Funfile
 function getRuntime(codeUri, functionRes, options) {
+  console.log('codeUri', codeUri, 'runtime', functionRes);
   let moduleRuntime;
 
   if (fs.existsSync(path.join(codeUri, 'fun.yml'))) {
@@ -113,7 +84,6 @@ function getRuntime(codeUri, functionRes, options) {
     }
     return options.runtime;
   } else if (options.function) {
-
     if (functionRes && functionRes.Properties && functionRes.Properties.Runtime) {
       if (moduleRuntime) {
         if (functionRes.Properties.Runtime !== moduleRuntime) {
@@ -126,45 +96,40 @@ function getRuntime(codeUri, functionRes, options) {
     return moduleRuntime;
   }
   throw new Error(red('\'runtime\' is missing, you should specify it by --runtime option.'));
-
-
 }
 
 async function save(runtime, codeUri, pkgType, packages, env) {
+  let funfilePath = await getOrConvertFunfile(codeUri);
+  let cmds = [];
 
-  const ymlPath = path.join(codeUri, 'fun.yml');
-
-  var funModule;
-  if (fs.existsSync(ymlPath)) {
-    funModule = FunModule.load(ymlPath);
-  } else {
-    funModule = new FunModule(runtime);
+  if (!funfilePath) {
+    funfilePath = path.join(codeUri, 'Funfile');
+    cmds.push(`RUNTIME ${runtime}`);
   }
+
+  let resolvedEnv = resolveEnv(env).join(' ');
+  if (!_.isEmpty(resolvedEnv)) {
+    resolvedEnv = ' ' + resolvedEnv;
+  }
+
+  console.log(`\nsave package install commnad to ${funfilePath}`);
 
   for (const pkg of packages) {
-    switch (pkgType) {
-    case 'pip':
-      funModule.addTask(new FunTask('pip', {
-        pip: pkg,
-        local: true,
-        env
-      }));
-      break;
-    case 'apt':
-      funModule.addTask(new FunTask('apt', {
-        apt: pkg,
-        local: true,
-        env
-      }));
-      break;
-    default:
-      console.error('unknown task %s => %s', pkgType, pkg);
-    }
+    const cmd = await convertPackageToCmd(pkgType, pkg);
+    cmds.push(`RUN${resolvedEnv} ${cmd}`);
   }
 
-  FunModule.store(ymlPath, funModule);
-  debug(`save to ${ymlPath}`);
+  await fs.appendFile(funfilePath, `\n${cmds.join('\n')}\n`);
+}
 
+function convertPackageToCmd(pkgType, pkg) {
+  if (pkgType === 'apt') {
+    return `fun-install apt-get install ${pkg}`;
+  } else if (pkgType === 'pip') {
+    return `fun-install pip install ${pkg}`;
+  } else {
+    throw new Error(`unknow package type %${pkgType}`);
+  }
 }
 
 async function install(packages, options) {
@@ -177,14 +142,24 @@ async function install(packages, options) {
   const runtime = getRuntime(codeUri, functionRes, options);
   debug(`runtime: ${runtime}`);
   const pkgType = options.packageType;
+
+  const env = options.env;
+
   debug(`packageType: ${pkgType}`);
 
   for (const pkg of packages) {
-    await installPackage(runtime, codeUri, pkgType, pkg, options);
+    const cmd = convertPackageToCmd(pkgType, pkg);
+    await sbox({
+      function: options.function,
+      cmd,
+      envs: env,
+      interactive: false,
+      runtime,
+    });
   }
 
   if (options.save) {
-    await save(runtime, codeUri, pkgType, packages, options.env);
+    await save(runtime, codeUri, pkgType, packages, env);
   }
 
   visitor.event({
@@ -227,6 +202,5 @@ module.exports = {
   install,
   installAll,
   init,
-  env,
-  sbox
+  env
 };

--- a/lib/exception-handler.js
+++ b/lib/exception-handler.js
@@ -2,6 +2,7 @@
 
 const debug = require('debug');
 const unrefTimeout = require('./unref-timeout');
+const { red } = require('colors');
 
 const handler = function (err) {
   // If the verbose option is true, in addition to the message,
@@ -9,7 +10,7 @@ const handler = function (err) {
   if (debug.enabled('*') && err.stack) {
     console.error(err.stack);
   } else if (err.message) {
-    console.error(err.message);
+    console.error(red(err.message));
   } else {
     console.error(err);
   }

--- a/lib/install/install.js
+++ b/lib/install/install.js
@@ -8,7 +8,7 @@ const path = require('path');
 async function installPackage(runtime, codeUri, pkgType, pkgName, options) {
 
   const ctx = await new Context(runtime, codeUri);
-
+  
   try {
     switch (pkgType) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2463,11 +2463,6 @@
         "locate-path": "^3.0.0"
       }
     },
-    "findit2": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
-      "integrity": "sha1-WKRmaX34piBc39vzlVNri9d3pfY="
-    },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "dockerode": "^2.5.8",
     "dotenv": "^6.0.0",
     "express": "^4.16.4",
-    "findit2": "^2.2.3",
     "fs-extra": "^8.1.0",
     "get-stdin": "^6.0.0",
     "git-ignore-parser": "0.0.2",

--- a/test/build/build.test.js
+++ b/test/build/build.test.js
@@ -256,35 +256,20 @@ describe('test buildFunction', () => {
     const funfilePath = path.join(codeUri, 'Funfile');
     const funymlPath = path.join(codeUri, 'fun.yml');
     const dockerFilePath = path.join(codeUri, '.Funfile.generated.dockerfile');
-    const artifactDir = path.join(projectRoot, '.fun', 'build', 'artifacts', serviceName, functionName);
 
     const pathExistsStub = sandbox.stub(fs, 'pathExists');
     pathExistsStub.withArgs(codeUri).resolves(true);
     pathExistsStub.withArgs(funymlPath).resolves(true);
     pathExistsStub.withArgs(funfilePath).resolves(false);
 
-
     const useDocker = false;
-
-    const buildFunc = {
-      functionName,
-      functionRes,
-      serviceName,
-      serviceRes
-    };
-
-    const buildFuncs = [buildFunc];
-    const skippedBuildFuncs = [];
-
     const Builder = fcBuilders.Builder;
-
     const mockedTaskFlowConstructor = sandbox.stub();
-
     const taskFlowStartStub = sandbox.stub();
+
     mockedTaskFlowConstructor.returns({
       start: taskFlowStartStub
     });
-
     sandbox.stub(Builder, 'detectTaskFlow').resolves([mockedTaskFlowConstructor]);
     sandbox.stub(builder, 'buildInDocker').resolves({});
     sandbox.stub(taskflow, 'isOnlyDefaultTaskFlow').returns(true);

--- a/test/build/build.test.js
+++ b/test/build/build.test.js
@@ -15,14 +15,13 @@ let build = require('../../lib/build/build');
 const uuid = require('uuid');
 const util = require('util');
 const nas = require('../../lib/nas');
-
 const assert = sandbox.assert;
-
+const expect = require('expect.js');
 const os = require('os');
 const path = require('path');
 const yaml = require('js-yaml');
 
-const { tpl, 
+const { tpl,
   serviceName,
   functionName,
   serviceRes,
@@ -110,7 +109,7 @@ describe('test buildFunction', () => {
       start: taskFlowStartStub
     });
 
-    sandbox.stub(Builder, 'detectTaskFlow').resolves([ mockedTaskFlowConstructor ]);
+    sandbox.stub(Builder, 'detectTaskFlow').resolves([mockedTaskFlowConstructor]);
     sandbox.stub(builder, 'buildInProcess').resolves({});
 
     await build.buildFunction(buildName, tpl, projectRoot, useDocker, ['install', 'build'], verbose);
@@ -147,7 +146,7 @@ describe('test buildFunction', () => {
       start: taskFlowStartStub
     });
 
-    sandbox.stub(Builder, 'detectTaskFlow').resolves([ mockedTaskFlowConstructor ]);
+    sandbox.stub(Builder, 'detectTaskFlow').resolves([mockedTaskFlowConstructor]);
     sandbox.stub(builder, 'buildInProcess').resolves({});
 
     await build.buildFunction(buildName, tpl, projectRoot, useDocker, ['install', 'build'], verbose);
@@ -184,7 +183,7 @@ describe('test buildFunction', () => {
       start: taskFlowStartStub
     });
 
-    sandbox.stub(Builder, 'detectTaskFlow').resolves([ mockedTaskFlowConstructor ]);
+    sandbox.stub(Builder, 'detectTaskFlow').resolves([mockedTaskFlowConstructor]);
     sandbox.stub(builder, 'buildInDocker').resolves({});
 
     await build.buildFunction(buildName, tpl, projectRoot, useDocker, ['install', 'build'], verbose);
@@ -233,12 +232,12 @@ describe('test buildFunction', () => {
       start: taskFlowStartStub
     });
 
-    sandbox.stub(Builder, 'detectTaskFlow').resolves([ mockedTaskFlowConstructor ]);
+    sandbox.stub(Builder, 'detectTaskFlow').resolves([mockedTaskFlowConstructor]);
     sandbox.stub(builder, 'buildInDocker').resolves({});
     sandbox.stub(taskflow, 'isOnlyDefaultTaskFlow').returns(true);
 
     await build.buildFunction(buildName, tpl, projectRoot, useDocker, ['install', 'build'], verbose);
-    
+
     assert.calledWith(artifact.cleanDirectory, path.join(projectRoot, '.fun', 'build', 'artifacts'));
     assert.calledWith(template.updateTemplateResources, tpl, buildFuncs, skippedBuildFuncs, projectRoot, rootArtifactsDir);
     assert.calledWith(yaml.dump, updatedContent);
@@ -249,6 +248,55 @@ describe('test buildFunction', () => {
     assert.calledWith(docker.buildImage, codeUri, dockerFilePath, sinon.match.string);
     assert.calledWith(docker.copyFromImage, 'imageTag', '/code/.', artifactDir);
     assert.calledWith(builder.buildInDocker, serviceName, serviceRes, functionName, functionRes, projectRoot, codeUri, path.join(rootArtifactsDir, serviceName, functionName), verbose);
+  });
+
+  it.only('test with buildFunction with install stage and only fun.yml, but force using docker', async function () {
+
+    const codeUri = path.resolve(projectRoot, functionRes.Properties.CodeUri);
+    const funfilePath = path.join(codeUri, 'Funfile');
+    const funymlPath = path.join(codeUri, 'fun.yml');
+    const dockerFilePath = path.join(codeUri, '.Funfile.generated.dockerfile');
+    const artifactDir = path.join(projectRoot, '.fun', 'build', 'artifacts', serviceName, functionName);
+
+    const pathExistsStub = sandbox.stub(fs, 'pathExists');
+    pathExistsStub.withArgs(codeUri).resolves(true);
+    pathExistsStub.withArgs(funymlPath).resolves(true);
+    pathExistsStub.withArgs(funfilePath).resolves(false);
+
+
+    const useDocker = false;
+
+    const buildFunc = {
+      functionName,
+      functionRes,
+      serviceName,
+      serviceRes
+    };
+
+    const buildFuncs = [buildFunc];
+    const skippedBuildFuncs = [];
+
+    const Builder = fcBuilders.Builder;
+
+    const mockedTaskFlowConstructor = sandbox.stub();
+
+    const taskFlowStartStub = sandbox.stub();
+    mockedTaskFlowConstructor.returns({
+      start: taskFlowStartStub
+    });
+
+    sandbox.stub(Builder, 'detectTaskFlow').resolves([mockedTaskFlowConstructor]);
+    sandbox.stub(builder, 'buildInDocker').resolves({});
+    sandbox.stub(taskflow, 'isOnlyDefaultTaskFlow').returns(true);
+
+    await build.buildFunction(buildName, tpl, projectRoot, useDocker, ['install'], verbose);
+
+    assert.notCalled(taskflow.isOnlyDefaultTaskFlow);
+    assert.calledWith(parser.funymlToFunfile, funymlPath);
+    assert.calledWith(parser.funfileToDockerfile, funfilePath);
+    assert.calledWith(docker.buildImage, codeUri, dockerFilePath, sinon.match.string);
+    assert.calledWith(docker.copyFromImage, 'imageTag', '/code/.', codeUri);
+    assert.calledWith(builder.buildInDocker, serviceName, serviceRes, functionName, functionRes, projectRoot, codeUri, codeUri, verbose);
   });
 });
 
@@ -301,6 +349,60 @@ describe('test copyNasArtifact', () => {
     assert.calledWith(nas.convertNasConfigToNasMappings, rootArtifactsDir, serviceResWithNasConfig.Properties.NasConfig, serviceName);
 
     assert.calledWith(docker.copyFromImage, 'imageTag', 'remoteNasDir/.', 'localNasDir');
-    
+  });
+});
+
+describe('test getOrConvertFunfile', () => {
+  let randomDir;
+
+  beforeEach(async () => {
+    randomDir = path.join(tempDir, uuid.v4());
+    await fs.mkdirp(randomDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(randomDir);
+  });
+
+  it('test no funyml', async () => {
+    const funfilePath = await build.getOrConvertFunfile(randomDir);
+    expect(funfilePath).to.be(null);
+  });
+
+  it('test exist funyml', async () => {
+    const funymlPath = path.join(randomDir, 'fun.yml');
+    const funfilePath = path.join(randomDir, 'Funfile');
+
+    await fs.writeFile(funymlPath, `runtime: python3
+tasks:
+  - apt: libzbar0
+  - shell: ln -sf libzbar.so.0.2.0 libzbar.so
+    cwd: /code/.fun/root/usr/lib
+  - pip: Pillow
+  - pip: pyzbar`);
+
+    const p = await build.getOrConvertFunfile(randomDir);
+
+    expect(p).to.eql(funfilePath);
+
+    expect(await fs.exists(funfilePath)).to.be(true);
+    const funfileContent = await fs.readFile(funfilePath, 'utf8');
+    expect(funfileContent).to.eql(`RUNTIME python3
+COPY . /code
+WORKDIR /code
+RUN fun-install apt-get install libzbar0
+RUN cd /code/.fun/root/usr/lib && ln -sf libzbar.so.0.2.0 libzbar.so
+RUN fun-install pip install Pillow
+RUN fun-install pip install pyzbar`);
+  });
+
+  it('test exist funfile', async () => {
+    const funfilePath = path.join(randomDir, 'Funfile');
+
+    await fs.writeFile(funfilePath, `RUNTIME python3`);
+
+    const p = await build.getOrConvertFunfile(randomDir);
+
+    expect(p).to.eql(funfilePath);
   });
 });

--- a/test/build/build.test.js
+++ b/test/build/build.test.js
@@ -78,7 +78,7 @@ describe('test buildFunction', () => {
 
     sandbox.stub(taskflow, 'isOnlyDefaultTaskFlow').returns(false);
 
-    await build.buildFunction(buildName, tpl, projectRoot, useDocker, verbose);
+    await build.buildFunction(buildName, tpl, projectRoot, useDocker, ['install', 'build'], verbose);
 
     assert.calledWith(artifact.cleanDirectory, path.join(projectRoot, '.fun', 'build', 'artifacts'));
     assert.calledWith(template.updateTemplateResources, tpl, buildFuncs, skippedBuildFuncs, projectRoot, rootArtifactsDir);
@@ -113,7 +113,7 @@ describe('test buildFunction', () => {
     sandbox.stub(Builder, 'detectTaskFlow').resolves([ mockedTaskFlowConstructor ]);
     sandbox.stub(builder, 'buildInProcess').resolves({});
 
-    await build.buildFunction(buildName, tpl, projectRoot, useDocker, verbose);
+    await build.buildFunction(buildName, tpl, projectRoot, useDocker, ['install', 'build'], verbose);
 
     assert.calledWith(artifact.cleanDirectory, path.join(projectRoot, '.fun', 'build', 'artifacts'));
     assert.calledWith(template.updateTemplateResources, tpl, buildFuncs, skippedBuildFuncs, projectRoot, rootArtifactsDir);
@@ -150,7 +150,7 @@ describe('test buildFunction', () => {
     sandbox.stub(Builder, 'detectTaskFlow').resolves([ mockedTaskFlowConstructor ]);
     sandbox.stub(builder, 'buildInProcess').resolves({});
 
-    await build.buildFunction(buildName, tpl, projectRoot, useDocker, verbose);
+    await build.buildFunction(buildName, tpl, projectRoot, useDocker, ['install', 'build'], verbose);
 
     assert.calledWith(artifact.cleanDirectory, path.join(projectRoot, '.fun', 'build', 'artifacts'));
     assert.calledWith(template.updateTemplateResources, tpl, buildFuncs, skippedBuildFuncs, projectRoot, rootArtifactsDir);
@@ -187,7 +187,7 @@ describe('test buildFunction', () => {
     sandbox.stub(Builder, 'detectTaskFlow').resolves([ mockedTaskFlowConstructor ]);
     sandbox.stub(builder, 'buildInDocker').resolves({});
 
-    await build.buildFunction(buildName, tpl, projectRoot, useDocker, verbose);
+    await build.buildFunction(buildName, tpl, projectRoot, useDocker, ['install', 'build'], verbose);
 
     assert.calledWith(artifact.cleanDirectory, path.join(projectRoot, '.fun', 'build', 'artifacts'));
     assert.calledWith(template.updateTemplateResources, tpl, buildFuncs, skippedBuildFuncs, projectRoot, rootArtifactsDir);
@@ -237,7 +237,7 @@ describe('test buildFunction', () => {
     sandbox.stub(builder, 'buildInDocker').resolves({});
     sandbox.stub(taskflow, 'isOnlyDefaultTaskFlow').returns(true);
 
-    await build.buildFunction(buildName, tpl, projectRoot, useDocker, verbose);
+    await build.buildFunction(buildName, tpl, projectRoot, useDocker, ['install', 'build'], verbose);
     
     assert.calledWith(artifact.cleanDirectory, path.join(projectRoot, '.fun', 'build', 'artifacts'));
     assert.calledWith(template.updateTemplateResources, tpl, buildFuncs, skippedBuildFuncs, projectRoot, rootArtifactsDir);


### PR DESCRIPTION
pyzbar_exmaple fun install 示例

```shell
../../../bin/fun.js install                                                        
using template: template.yml
start installing function dependencies without docker

building pyzbar-srv/pyzbar-fun
detecting fun.yml but no Funfile, Fun will convert fun.yml to Funfile
Funfile exist, Fun will use container to build forcely
Step 1/7 : FROM aliyunfc/runtime-python3.6:build-1.6.1
 ---> 2110e9fa9393
Step 2/7 : COPY . /code
 ---> baa5158159e0
Step 3/7 : WORKDIR /code
 ---> Running in e23ed7a7f3f3
Removing intermediate container e23ed7a7f3f3
 ---> c156d6a758b8
Step 4/7 : RUN fun-install apt-get install libzbar0
 ---> Running in 864cb14de8c9
Task => [UNNAMED]
     => apt-get update (if need)
     => apt-get install -y -d -o=dir::cache=/code/.fun/tmp libzbar0 --reinstall
     => bash -c 
        for f in $(ls /code/.fun/tmp/archives/*.deb); do
          dpkg -x $f /code/.fun/root; 
          mkdir -p /code/.fun/tmp/deb-control/${f%.*}; 
          dpkg -e $f /code/.fun/tmp/deb-control/${f%.*}; 

          if [ -f "/code/.fun/tmp/deb-control/${f%.*}/postinst" ]; then 
            FUN_INSTALL_LOCAL=true /code/.fun/tmp/deb-control/${f%.*}/postinst configure;
          fi; 
        done;
     => bash -c 'rm -rf /code/.fun/tmp/archives'
Removing intermediate container 864cb14de8c9
 ---> 01c6d52a806b
Step 5/7 : RUN cd /code/.fun/root/usr/lib && ln -sf libzbar.so.0.2.0 libzbar.so
 ---> Running in b0a41e067635
Removing intermediate container b0a41e067635
 ---> b2ce376d86e0
Step 6/7 : RUN fun-install pip install Pillow
 ---> Running in 2788d28d99ec
Task => [UNNAMED]
     => PYTHONUSERBASE=/code/.fun/python pip install --user Pillow
Removing intermediate container 2788d28d99ec
 ---> 26bcbe967026
Step 7/7 : RUN fun-install pip install pyzbar
 ---> Running in 3a7ca2842354
Task => [UNNAMED]
     => PYTHONUSERBASE=/code/.fun/python pip install --user pyzbar
Removing intermediate container 3a7ca2842354
 ---> bb0ca1632471
sha256:bb0ca16324714142421abad9dcb9d112839948177c7f8a1b268eb440fca15a9a
Successfully built bb0ca1632471
Successfully tagged fun-cache-9d391f66-a0b7-4ea1-8f6e-90bcbf87fcf4:latest
copying function artifact to /Users/tan/code/fun/examples/install/pyzbar_example

build function using image: fun-cache-9d391f66-a0b7-4ea1-8f6e-90bcbf87fcf4
running task flow DefaultTaskFlow
running task: CopySource

Tips for next step
======================
* Invoke Event Function: fun local invoke
* Invoke Http Function: fun local start
* Build Http Function: fun build
* Deploy Resources: fun deploy
```

java demo build 的示例：

```
 ../../bin/fun.js build                 
using template: template.yml
start building function dependencies without docker

building java/helloworld
running task flow MavenTaskFlow
running task: CopySource
running task: MavenCompileTask
running task: MavenCopyDependencies
running task: MavenCopyDependencies

Build Success

Built artifacts: .fun/build/artifacts
Built template: .fun/build/artifacts/template.yml

Tips for next step
======================
* Invoke Event Function: fun local invoke
* Invoke Http Function: fun local start
* Deploy Resources: fun deploy
```