### PR TITLE
docker file sharing: modify settings.defaultFileSharingPaths to settings.filesharingDirectories

### DIFF
--- a/lib/docker-support.js
+++ b/lib/docker-support.js
@@ -17,8 +17,8 @@ async function getSharedPathsOfDockerForMac() {
   
   const settings = JSON.parse(fileData);
   
-  if (settings.hasOwnProperty('defaultFileSharingPaths')) {
-    return settings.defaultFileSharingPaths;
+  if (settings.hasOwnProperty('filesharingDirectories')) {
+    return settings.filesharingDirectories;
   }
   return defaultFileSharingPaths;
 }

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -114,7 +114,7 @@ async function resolveNasConfigToMounts(serviceName, nasConfig, baseDir) {
   const nasMappings = await nas.convertNasConfigToNasMappings(baseDir, nasConfig, serviceName);
 
   for (let { localNasDir, remoteNasDir } of nasMappings) {
-    console.log('mouting local nas mock dir %s into container %s\n', localNasDir, remoteNasDir);
+    console.log('mounting local nas mock dir %s into container %s\n', localNasDir, remoteNasDir);
 
     mounts.push({
       Type: 'bind',


### PR DESCRIPTION
```
$ node ~/Documents/git-qfzhang/fun/bin/fun-local-invoke.js 
using template: template.yml
invokeName is: docker-test/docker-test

Missing invokeName argument, Fun will use the first function docker-test/docker-test as invokeName

mouting local nas mock dir /docker-test/.fun/nas/auto-default/docker-test into container /mnt/auto

skip pulling image aliyunfc/runtime-nodejs8:1.6.1...

Please add directory '/docker-test,/docker-test/.fun/nas/auto-default/docker-test,/docker-test/.fun/tmp/invoke/docker-test/docker-test' to Docker File sharing list, more information please refer to https://github.com/alibaba/funcraft/blob/master/docs/usage/faq-zh.md
```