### PR TITLE
feat(Event Trigger Func): 支持 Event Trigger 启动长驻容器

### DIFF
--- a/bin/fun-local-invoke.js
+++ b/bin/fun-local-invoke.js
@@ -29,7 +29,7 @@ program
   .option('--debugger-path <debuggerPath>', 'the path of the debugger on the host')
   .option('--debug-args <debugArgs>', 'additional parameters that will be passed to the debugger')
   .option('--tmp-dir <tmpDir>', `The temp directory mounted to /tmp , default to './.fun/tmp/invoke/{service}/{function}/'`)
-
+  .option('--no-reuse', `Do not reuse the container which was started by the 'fun local start {service}/{function}' command.`)
   .parse(process.argv);
 
 if (program.args.length > 1) {

--- a/lib/commands/local/invoke.js
+++ b/lib/commands/local/invoke.js
@@ -14,7 +14,7 @@ const { detectTplPath, getTpl } = require('../../tpl');
 const { getEvent } = require('../../utils/file');
 const { red, yellow } = require('colors');
 
-async function localInvoke(invokeName, tpl, debugPort, event, debugIde, baseDir, tmpDir, debuggerPath, debugArgs) {
+async function localInvoke(invokeName, tpl, debugPort, event, debugIde, baseDir, tmpDir, debuggerPath, debugArgs, reuse = true) {
   debug(`invokeName: ${invokeName}`);
 
   if (!invokeName) {
@@ -41,7 +41,7 @@ async function localInvoke(invokeName, tpl, debugPort, event, debugIde, baseDir,
 
   // Lazy loading to avoid stdin being taken over twice.
   const LocalInvoke = require('../../local/local-invoke');
-  const localInvoke = new LocalInvoke(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, baseDir, absTmpDir, debuggerPath, debugArgs);
+  const localInvoke = new LocalInvoke(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, baseDir, absTmpDir, debuggerPath, debugArgs, reuse);
 
   await localInvoke.invoke(event);
 }
@@ -88,8 +88,10 @@ async function invoke(invokeName, options) {
     const debugArgs = options.debugArgs;
 
     const baseDir = path.resolve(path.dirname(tplPath));
+    const reuse = options.reuse;
 
-    await localInvoke(invokeName, tpl, debugPort, event, debugIde, baseDir, options.tmpDir, debuggerPath, debugArgs);
+
+    await localInvoke(invokeName, tpl, debugPort, event, debugIde, baseDir, options.tmpDir, debuggerPath, debugArgs, reuse);
   } else {
     throw new Error(red('The template file name must be template.[yml|yaml].'));
   }

--- a/lib/commands/local/start.js
+++ b/lib/commands/local/start.js
@@ -8,6 +8,7 @@ var app = express();
 const { red } = require('colors');
 
 const httpSupport = require('./http-support');
+const EventStart = require('../../local/event-start');
 
 const { detectTplPath, getTpl } = require('../../tpl');
 const validate = require('../../validate/validate');
@@ -101,7 +102,16 @@ async function start(options, invokeName = '') {
           : functionName === trigger.functionName;
       });
       if (httpTrigger.length === 0) {
-        throw new Error(`${invokeName} did not has http trigger`);
+        // if specify event trigger function, then directly start container
+        const {
+          serviceName,
+          serviceRes,
+          functionName,
+          functionRes
+        } = definition.findFunctionInTpl(invokeName, tpl);
+        const eventStart = new EventStart(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, baseDir);
+        await eventStart.init();
+        return;
       }
       if (httpTrigger.length > 1) {
         throw new Error(`${invokeName} is not unique`);

--- a/lib/docker-opts.js
+++ b/lib/docker-opts.js
@@ -122,6 +122,11 @@ function generateInstallOpts(imageName, mounts, envs) {
   };
 }
 
+function generateContainerName(serviceName, functionName, debugPort) {
+  return `fun-local-${serviceName}-${functionName}`.replace(/ /g, '')
+    + (debugPort ? '-debug' : '-run');
+}
+
 function generateSboxOpts({imageName, hostname, mounts, envs, cmd = [], isTty, isInteractive}) {
   return {
     Image: imageName,
@@ -256,7 +261,7 @@ function resolveMockScript(runtime) {
   return `/var/fc/runtime/${runtime}/mock.sh`;
 }
 
-async function generateLocalStartRunOpts(runtime, name, mounts, cmd, debugPort, envs, dockerUser, debugIde) {
+async function generateLocalStartOpts(runtime, name, mounts, cmd, debugPort, envs, dockerUser, debugIde) {
 
   const hostOpts = {
     HostConfig: {
@@ -293,9 +298,9 @@ async function generateLocalStartRunOpts(runtime, name, mounts, cmd, debugPort, 
 module.exports = {
   generateLocalInvokeOpts, resolveRuntimeToDockerImage, 
   generateInstallOpts, generateSboxOpts,
-  generateLocalStartRunOpts,
+  generateLocalStartOpts,
   resolveMockScript, resolveDockerEnv, transformPathForVirtualBox,
   resolveDockerRegistry, transformMountsForToolbox, transformSourcePathOfMount,
   isFromChinaMotherland, ALIYUN_REGISTRY, generateContainerBuildOpts,
-  IMAGE_VERSION, resolveImageNameForPull
+  IMAGE_VERSION, resolveImageNameForPull, generateContainerName
 };

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -205,6 +205,20 @@ async function imageExist(imageName) {
   return images.length > 0;
 }
 
+async function listContainers(options) {
+  return await docker.listContainers(options);
+}
+
+async function getContainer(containerId) {
+  return await docker.getContainer(containerId);
+}
+
+async function renameContainer(container, name) {
+  return await container.rename({
+    name
+  });
+}
+
 // dockerode exec 在 windows 上有问题，用 exec 的 stdin 传递事件，当调用 stream.end() 时，会直接导致 exec 退出，且 ExitCode 为 null
 function generateDockerCmd(functionProps, httpMode, invokeInitializer = true, event = null) {
   const cmd = ['-h', functionProps.Handler];
@@ -571,6 +585,56 @@ async function createContainer(opts) {
   return container;
 }
 
+async function createAndRunContainer(opts) {
+  const container = await createContainer(opts);
+  containers.add(container.id);
+  await container.start({});
+  return container;
+}
+
+async function execContainer(container, opts, outputStream, errorStream) {
+  outputStream = process.stdout;
+  errorStream = process.stderr;
+  const logStream = await container.logs({
+    stdout: true,
+    stderr: true,
+    follow: true,
+    since: (new Date().getTime() / 1000)
+  });
+  container.modem.demuxStream(logStream, outputStream, errorStream);
+  const exec = await container.exec(opts);
+  const stream = (await exec.start()).output;
+  // have to wait, otherwise stdin may not be readable
+  await new Promise(resolve => setTimeout(resolve, 30));
+  container.modem.demuxStream(stream, outputStream, errorStream);
+
+  await waitForExec(exec);
+  logStream.destroy();
+}
+
+async function waitForExec(exec) {
+  return await new Promise((resolve, reject) => {
+    // stream.on('end') could not receive end event on windows.
+    // so use inspect to check exec exit
+    function waitContainerExec() {
+      exec.inspect((err, data) => {
+        if (data.Running) {
+          setTimeout(waitContainerExec, 100);
+          return;
+        }
+        if (err) {
+          reject(err);
+        } else if (data.ExitCode !== 0) {
+          reject(`${data.ProcessConfig.entrypoint} exited with code ${data.ExitCode}`);
+        } else {
+          resolve(data.ExitCode);
+        }
+      });
+    }
+    waitContainerExec();
+  });
+} 
+
 // outputStream, errorStream used for http invoke
 // because agent is started when container running and exec could not receive related logs
 async function startContainer(opts, outputStream, errorStream) {
@@ -647,32 +711,7 @@ async function startContainer(opts, outputStream, errorStream) {
         container.modem.demuxStream(stream, devnull(), errorStream);
       }
 
-      return new Promise((resolve, reject) => {
-
-        // stream.on('end') could not receive end event on windows.
-        // so use inspect to check exec exit
-        function waitContainerExec() {
-          exec.inspect((err, data) => {
-
-            if (data.Running) {
-              setTimeout(waitContainerExec, 100);
-              return;
-            }
-
-            if (err) {
-              debug('docker exec inspect err', err);
-              reject(err);
-            } else if (data.ExitCode !== 0) {
-              reject(red(`${data.ProcessConfig.entrypoint} exited with code ${data.ExitCode}`));
-            } else {
-              resolve(data.ExitCode);
-            }
-          });
-
-        }
-
-        waitContainerExec();
-      });
+      return await waitForExec(exec);
     }
   };
 }
@@ -948,5 +987,7 @@ module.exports = {
   showDebugIdeTipsForVscode, resolveDockerUser, resolveNasConfigToMounts,
   startInstallationContainer, startContainer, isDockerToolBox,
   conventInstallTargetsToMounts, startSboxContainer, buildImage, copyFromImage,
-  resolveTmpDirToMount, showDebugIdeTipsForPycharm, resolveDebuggerPathToMount
+  resolveTmpDirToMount, showDebugIdeTipsForPycharm, resolveDebuggerPathToMount,
+  listContainers, getContainer, createAndRunContainer, execContainer,
+  renameContainer
 };

--- a/lib/local/event-start.js
+++ b/lib/local/event-start.js
@@ -1,0 +1,33 @@
+'use strict';
+const Invoke = require('./invoke');
+const docker = require('../docker');
+const dockerOpts = require('../docker-opts');
+
+class EventStart extends Invoke {
+  constructor(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, baseDir, tmpDir, debuggerPath, debugArgs) {
+    super(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, baseDir, tmpDir, debuggerPath, debugArgs);
+  }
+
+  async init() {
+    await super.init();
+    this.envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, null, this.nasConfig, false, this.debugIde, this.debugArgs);
+    this.containerName = dockerOpts.generateContainerName(this.serviceName, this.functionName, this.debugPort);
+    this.opts = await dockerOpts.generateLocalStartOpts(this.runtime,
+      this.containerName,
+      this.mounts,
+      ['--server'],
+      this.debugPort,
+      this.envs,
+      this.dockerUser,
+      this.debugIde);
+    const container = await docker.createAndRunContainer(this.opts);
+    await container.logs({
+      stdout: true,
+      stderr: true,
+      follow: true,
+      since: (new Date().getTime() / 1000)
+    });
+  }
+}
+
+module.exports = EventStart;

--- a/lib/local/http-invoke.js
+++ b/lib/local/http-invoke.js
@@ -112,7 +112,7 @@ class HttpInvoke extends Invoke {
 
     const envs = await docker.generateDockerEnvs(this.baseDir, this.functionProps, this.debugPort, null, this.nasConfig, true, this.debugIde, this.debugArgs);
 
-    const opts = await dockerOpts.generateLocalStartRunOpts(this.runtime,
+    const opts = await dockerOpts.generateLocalStartOpts(this.runtime,
       this.containerName,
       this.mounts,
       ['--server'],

--- a/lib/local/local-invoke.js
+++ b/lib/local/local-invoke.js
@@ -5,8 +5,9 @@ const docker = require('../docker');
 const dockerOpts = require('../docker-opts');
 
 class LocalInvoke extends Invoke {
-  constructor(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, baseDir, tmpDir, debuggerPath, debugArgs) {
+  constructor(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, baseDir, tmpDir, debuggerPath, debugArgs, reuse) {
     super(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, baseDir, tmpDir, debuggerPath, debugArgs);
+    this.reuse = reuse;
   }
 
   async init() {
@@ -25,10 +26,47 @@ class LocalInvoke extends Invoke {
   }
 
   async doInvoke(event, { outputStream, errorStream } = {}) {
+    if (this.reuse) {
+      const containerName = dockerOpts.generateContainerName(this.serviceName, this.functionName, this.debugPort);
+      let invokeInitializer = true;
+      let filters = this.generateContainerNameFilter(containerName, true);
+      let containers = await docker.listContainers({ filters });
+      if (containers && containers.length) {
+        invokeInitializer = false;
+      } else {
+        filters = this.generateContainerNameFilter(containerName);
+        containers = await docker.listContainers({ filters });
+      }
+      if (containers && containers.length) {
+        const container = await docker.getContainer(containers[0].Id);
+        const cmd = [dockerOpts.resolveMockScript(this.runtime), ...docker.generateDockerCmd(this.functionProps, false, invokeInitializer, event)];
+        const opts = await dockerOpts.generateLocalInvokeOpts(this.runtime,
+          this.containerName,
+          this.mounts,
+          cmd,
+          this.debugPort,
+          this.envs,
+          this.dockerUser,
+          this.debugIde);
+        await docker.execContainer(container, opts, outputStream, errorStream);
+        if (invokeInitializer) {
+          await docker.renameContainer(container, containerName + '-inited');
+        }
+        return;
+      }
+    }
     await docker.run(this.opts,
       event,
       outputStream,
-      errorStream);
+      errorStream
+    );
+  }
+
+  generateContainerNameFilter(containerName, inited) {
+    if (inited) {
+      return `{"name": ["${containerName}-inited"]}`;
+    }
+    return `{"name": ["${containerName}"]}`;
   }
 }
 

--- a/test/local/event-start.test.js
+++ b/test/local/event-start.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const expect = require('expect.js');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const assert = sandbox.assert;
+
+const Invoke = require('../../lib/local/invoke');
+
+let EventStart = require('../../lib/local/event-start');
+
+const { functionName, functionRes,
+  serviceName, serviceRes,
+  debugPort, debugIde,
+  codeMount } = require('./mock-data');
+
+const docker = require('../../lib/docker');
+const dockerOpts = require('../../lib/docker-opts');
+
+const proxyquire = require('proxyquire');
+
+describe('test event start init', async () => {
+
+  beforeEach(() => {
+    const container = {
+      logs: () => {}
+    };
+
+    sandbox.stub(docker, 'resolveCodeUriToMount').resolves(codeMount);
+    sandbox.stub(docker, 'pullImageIfNeed').resolves({});
+    sandbox.stub(docker, 'generateDockerEnvs').resolves({});
+    sandbox.stub(docker, 'createAndRunContainer').resolves(container);
+
+    sandbox.stub(Invoke.prototype, 'init').resolves({});
+
+    EventStart = proxyquire('../../lib/local/event-start', {
+      '../docker': docker,
+      '../docker-opts': dockerOpts
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('test init', async () => {
+
+    const invoke = new EventStart(serviceName,
+      serviceRes,
+      functionName,
+      functionRes,
+      debugPort,
+      debugIde,
+      '.');
+
+    await invoke.init();
+
+    expect(invoke.opts.Cmd).to.eql([ '--server' ]);
+    
+    assert.calledWith(docker.generateDockerEnvs,
+      '.', invoke.functionProps, invoke.debugPort, null,
+      invoke.nasConfig, false, invoke.debugIde, invoke.debugArgs
+    );
+
+    assert.calledWith(docker.createAndRunContainer, invoke.opts);
+  });
+});


### PR DESCRIPTION
支持 Event Trigger 启动长驻容器，Local Invoke 将会复用该容器。这种情况下 Initializer 只会被启动一次。Local Invoke 提供了 --no-reuse 参数，强制使用新容器。启动长驻容器的好处是避免冷启动，可以快速进行多次调用。

![fun](https://user-images.githubusercontent.com/19430792/65312408-07f44500-dbc5-11e9-8c46-8bdbd7fcfd93.gif)

