### PR TITLE
windows 上 fun nas sync 操作并未成功上传文件问题修复

### DIFF
--- a/lib/nas/path.js
+++ b/lib/nas/path.js
@@ -58,11 +58,16 @@ function endWithSlash(inputPath) {
   return false;
 }
 
-
 async function readDirRecursive(dirPath) {
   const files = await readdirp.promise(dirPath);
   const fileRelativePaths = [];
-  files.map(file => fileRelativePaths.push(file.path));
+  // windows 下需要将压缩文件路径住转换为 POXIS 路径
+  if (process.platform === 'win32') {
+    files.map(file => fileRelativePaths.push((file.path).split(path.sep).join('/')));
+  } else {
+    files.map(file => fileRelativePaths.push(file.path));
+  }
+  
   return fileRelativePaths;
 }
 

--- a/test/nas/path.test.js
+++ b/test/nas/path.test.js
@@ -1,5 +1,11 @@
 'use strict';
+const os = require('os');
+const fs = require('fs');
+const util = require('util');
 
+const mkdirp = require('mkdirp-promise');
+const rimraf = require('rimraf');
+const writeFile = util.promisify(fs.writeFile);
 const expect = require('expect.js');
 const USER_HOME = require('os').homedir();
 const sinon = require('sinon');
@@ -8,7 +14,8 @@ const sandbox = sinon.createSandbox();
 
 const { 
   parseNasUri,
-  resolveLocalPath} = require('../../lib/nas/path');
+  resolveLocalPath, 
+  readDirRecursive } = require('../../lib/nas/path');
 
 describe('parseNasUri test', () => {
   const validNasPathResultMap = new Map();
@@ -61,4 +68,25 @@ describe('resolveLocalPath test', () => {
     sandbox.restore();
   });
 
+});
+
+describe('readDirRecursive test', () => {
+  const parentDir = path.join(os.tmpdir(), '.readDirRecursiveDir');
+  const localDir = path.join(parentDir, 'tmp'); 
+  const filePath = path.join(localDir, 'test.txt');
+  
+  beforeEach(async () => {
+    await mkdirp(localDir);
+    await writeFile(`${filePath}`, 'this is a test');
+  });
+
+  afterEach(() => {
+    rimraf.sync(localDir);
+    sandbox.restore();
+  });
+
+  it('normal path test', async() => {
+    const res = await readDirRecursive(parentDir);
+    expect(res).to.eql(['tmp/test.txt']);
+  });
 });


### PR DESCRIPTION
1. 问题原因：由于采取并行解压策略，在 windows 上获取的待解压文件路径列别为 windows 路径格式，无法在函数计算端的机器上解压，因此在处理带解压文件路径时将其转换为 POXIS 路径即可