### PR TITLE
fun nas cp 从本地到远端 NAS 的文件夹/文件传输

### DIFF
--- a/bin/fun-nas-cp.js
+++ b/bin/fun-nas-cp.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/* eslint-disable quotes */
+
+'use strict';
+
+const program = require('commander');
+const getVisitor = require('../lib/visitor').getVisitor;
+const notifier = require('../lib/update-notifier');
+
+program
+  .name('fun nas cp')
+  .description('Copy file/folder between remote NAS and local path.')
+  .usage('[options] <src_path> <dst_path>')
+  .option('-r, --recursive', 'copy folders recursively')
+  .option('-n, --no-clobber', 'Do not overwrite an existing file')
+  .parse(process.argv);
+
+if (program.args.length < 2) {
+  console.error();
+  console.error("  error: too few arguments");
+  program.help();
+} else if (program.args.length < 2) {
+  console.error();
+  console.error("  error: too many arguments");
+  program.help();
+}
+
+notifier.notify();
+
+getVisitor(true).then((visitor) => {
+  visitor.pageview('/fun/nas/cp').send();
+
+  require('../lib/commands/nas/cp')(program.args[0], program.args[1], program)
+    .then(() => {
+      visitor.event({
+        ec: 'cp',
+        ea: `cp`,
+        el: 'success',
+        dp: '/fun/nas/cp'
+      }).send();
+    })
+    .catch(error => {
+      visitor.event({
+        ec: 'cp',
+        ea: `cp`,
+        el: 'error',
+        dp: '/fun/nas/cp'
+      }).send();
+
+      require('../lib/exception-handler')(error);
+    });
+    
+});

--- a/lib/commands/nas/cp.js
+++ b/lib/commands/nas/cp.js
@@ -1,31 +1,31 @@
 'use strict';
 
-const lsNasFile = require('../../nas/ls');
+const nasCp = require('../../nas/cp');
 const { detectTplPath, getTpl, validateYmlName, getBaseDir } = require('../../tpl');
-const { getNasPathAndServiceFromNasUri } = require('../../nas/support');
 const validate = require('../../validate/validate');
+const path = require('path');
 const { red } = require('colors');
-const { deployNasService } = require('../../nas/init');
 
-async function ls(nasDir, options) {
-
+async function cp(srcPath, dstPath, options) {
   const tplPath = await detectTplPath(false);
-  
+
   if (!tplPath) {
     throw new Error(red('Current folder not a fun project\nThe folder must contains template.[yml|yaml] or faas.[yml|yaml] .'));
   }
 
   validateYmlName(tplPath);
-
+  
   await validate(tplPath);
+
   const tpl = await getTpl(tplPath);
-  const isAll = options.all;
-  const isLong = options.long;
   const baseDir = getBaseDir(tplPath);
 
-  const { nasPath, serviceName } = getNasPathAndServiceFromNasUri(nasDir, tpl);
-  await deployNasService(baseDir, tpl, serviceName);
-  await lsNasFile(serviceName, nasPath, isAll, isLong);
+  const recursive = options.recursive || false;
+  const noClobber = !options.clobber || false;
+
+  const localNasTmpDir = path.join(baseDir, '.fun', 'tmp', 'nas', 'cp');
+  
+  await nasCp(srcPath, dstPath, recursive, noClobber, localNasTmpDir, tpl, baseDir, false);
 }
 
-module.exports = ls;
+module.exports = cp;

--- a/lib/commands/nas/init.js
+++ b/lib/commands/nas/init.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const { getTpl, detectTplPath, validateYmlName } = require('../../tpl');
+const { getTpl, detectTplPath, validateYmlName, getBaseDir } = require('../../tpl');
 const { deployNasService } = require('../../nas/init');
-const path = require('path');
 const { red } = require('colors');
 const validate = require('../../validate/validate');
 
@@ -18,7 +17,7 @@ async function init() {
   await validate(tplPath);
 
   const tpl = await getTpl(tplPath);
-  const baseDir = path.dirname(tplPath);
+  const baseDir = getBaseDir(tplPath);
   
   await deployNasService(baseDir, tpl);
 }

--- a/lib/commands/nas/rm.js
+++ b/lib/commands/nas/rm.js
@@ -1,11 +1,8 @@
 'use strict';
 
 const rmNasFile = require('../../nas/rm');
-const { convertTplToServiceNasIdMappings } = require('../../nas');
-const { parseNasUri } = require('../../nas/path');
-const { detectTplPath, getTpl, validateYmlName } = require('../../tpl');
-const { getDefaultService } = require('../../nas/support');
-const path = require('path');
+const { detectTplPath, getTpl, validateYmlName, getBaseDir } = require('../../tpl');
+const { getNasId, getNasPathAndServiceFromNasUri } = require('../../nas/support');
 const validate = require('../../validate/validate');
 const { red } = require('colors');
 const { deployNasService } = require('../../nas/init');
@@ -24,16 +21,12 @@ async function rm(nasDir, options) {
 
   const isRecursive = options.recursive;
   const isForce = options.force;
-  const baseDir = path.dirname(tplPath);
-  var { nasPath, serviceName } = await parseNasUri(nasDir); 
+  const baseDir = getBaseDir(tplPath);
   
-  if (serviceName === '') {
-    serviceName = getDefaultService(tpl);
-  }
+  const { nasPath, serviceName } = getNasPathAndServiceFromNasUri(nasDir, tpl);
   await deployNasService(baseDir, tpl, serviceName);
-  const serviceNasIdMappings = convertTplToServiceNasIdMappings(tpl);
-  const nasId = serviceNasIdMappings[serviceName];
   
+  const nasId = getNasId(tpl, serviceName);
   await rmNasFile(serviceName, nasPath, isRecursive, isForce, nasId);
 }
 

--- a/lib/commands/nas/sync.js
+++ b/lib/commands/nas/sync.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const { detectTplPath, getTpl, validateYmlName, detectNasBaseDir } = require('../../tpl');
-const cp = require('../../nas/cp');
+const { detectTplPath, getTpl, validateYmlName, detectNasBaseDir, getBaseDir } = require('../../tpl');
+const nasCp = require('../../nas/cp');
 const nas = require('../../nas');
 const path = require('path');
 const validate = require('../../validate/validate');
 const { red } = require('colors');
 const tips = require('../../nas/tips');
-const { deployNasService } = require('../../nas/init');
 const { toBeUmountedDirs } = require('../../nas/support');
 const _ = require('lodash');
 
@@ -23,7 +22,7 @@ async function sync(options) {
   await validate(tplPath);
 
   const tpl = await getTpl(tplPath);
-  const baseDir = path.dirname(tplPath);
+  const baseDir = getBaseDir(tplPath);
 
   var service = options.service;
   var mountedDirs = options.mountDir;
@@ -38,8 +37,6 @@ async function sync(options) {
     if (!_.isEmpty(toUnmountDirs)) { console.log(red(`Warning: ${toUnmountDirs} are not configured by service: ${service}`)); }
   }
   
-  const serviceNasIdMappings = nas.convertTplToServiceNasIdMappings(tpl);
-
   const localNasTmpDir = path.join(baseDir, '.fun', 'tmp', 'nas', 'sync');
   var errors = [];
   for (const serviceName in serviceNasMappings) {
@@ -48,20 +45,17 @@ async function sync(options) {
       continue; 
     }
     
-    //对 service 进行 fun nas init 操作
-    await deployNasService(baseDir, tpl, service);
-    const nasId = serviceNasIdMappings[serviceName];
-    
     for (const { localNasDir, remoteNasDir } of serviceNasMappings[serviceName]) {
       if (mountedDirs && !mountedDirs.includes(remoteNasDir)) { continue; }
-
+      
+      if (!localNasDir || !remoteNasDir) { continue; }
       const srcPath = localNasDir;
 
       const dstPath = `nas://${serviceName}${remoteNasDir}/`;
 
       console.log(`starting upload ${srcPath} to ${dstPath}`);
       try {
-        await cp(srcPath, dstPath, true, localNasTmpDir, nasId);
+        await nasCp(srcPath, dstPath, true, false, localNasTmpDir, tpl, baseDir, true);
       } catch (error) {
         errors.push(`Upload ${srcPath} To ${dstPath} ${error}`);
       }

--- a/lib/nas/cp.js
+++ b/lib/nas/cp.js
@@ -1,53 +1,181 @@
 'use strict';
 
-const { resolveLocalPath, parseNasUri, isNasProtocol } = require('./path');
+const { resolveLocalPath, isNasProtocol, endWithSlash } = require('./path');
 const debug = require('debug')('fun:nas:cp');
 const { isDir, isFile, isEmptyDir } = require('./cp/file');
-const upload = require('./cp/upload');
-const { getNasHttpTriggerPath } = require('./request');
-const { green } = require('colors');
+const { uploadFolder, uploadFile } = require('./cp/upload');
+const { getNasHttpTriggerPath, statsRequest } = require('./request');
+const { checkWritePerm, getNasId, getNasPathAndServiceFromNasUri } = require('./support');
+const { red } = require('colors');
+const fs = require('fs-extra');
+const path = require('path');
+const { deployNasService } = require('./init');
 
-async function cp(srcPath, dstPath, recursive, localNasTmpDir, nasId) {
+async function cp(srcPath, dstPath, recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync) {
   if (srcPath === undefined || dstPath === undefined) {
     console.log('Input path empty error, please input again!');
     return;
   }
 
-
-  debug('cp ' + (recursive ? '-R ' : '') + srcPath + ' to ' + dstPath);
+  debug('cp ' + (recursive ? '-r ' : '') + srcPath + ' to ' + dstPath);
 
   if (isNasProtocol(srcPath) && !isNasProtocol(dstPath)) {
     //nas => local
     throw new Error('Not support NAS file download now!');
   } else if (!isNasProtocol(srcPath) && isNasProtocol(dstPath)) {
     //local => nas
-    if (await isDir(srcPath) && !recursive) {
-      throw new Error('Can not copy folder without option -R/--recursive');
+    const { nasPath: resolvedDst, serviceName } = getNasPathAndServiceFromNasUri(dstPath, tpl);
+    // fun nas init 操作
+    await deployNasService(baseDir, tpl, serviceName);
+    debug(`checking src path ${srcPath}`);
+
+    // 这里将 path.resolve(srcPath) 传进去, 是因为在 windows 平台上利用 git bash 输入的本地路径问题
+    // git bash 读取 windows 本地路径是以 '/' 作为分隔符的, 因此在此处需要将其转换为以 '\'作为分隔符
+    const resolvedSrc = resolveLocalPath(path.resolve(srcPath));
+  
+    const srcPathExists = fs.existsSync(resolvedSrc);
+    let srcPathIsDir;
+    let srcPathIsFile;
+    if (srcPathExists) {
+      srcPathIsDir = await isDir(resolvedSrc);
+      srcPathIsFile = await isFile(resolvedSrc);
     }
-
-    if (await isFile(srcPath) && recursive) {
-      throw new Error('Can not copy file with option -R/--recursive');
+    var srcPathIsEmpthDir;
+    if (srcPathIsDir) {
+      srcPathIsEmpthDir = await isEmptyDir(resolvedSrc);
     }
+    const srcStats = {
+      srcPath, 
+      resolvedSrc, 
+      srcPathExists, 
+      srcPathIsDir, 
+      srcPathIsFile, 
+      srcPathIsEmpthDir
+    };
+    checkCpSrcPath(srcStats, recursive);
 
-    if (await isDir(srcPath) && await isEmptyDir(srcPath)) {
-      console.log(green(`${srcPath} is empty, skip uploading`));
-      return;
-    }
-
-    const resolvedSrc = resolveLocalPath(srcPath);
-
-    const { nasPath: resolvedDst, serviceName } = parseNasUri(dstPath);
-
+    const nasId = getNasId(tpl, serviceName);
     const nasHttpTriggerPath = getNasHttpTriggerPath(serviceName);
 
-    await upload(resolvedSrc, resolvedDst, nasHttpTriggerPath, recursive, localNasTmpDir, nasId);
+    debug(`checking dst path ${dstPath}...`);
 
+    const statsRes = await statsRequest(resolvedDst, nasHttpTriggerPath);
+    const stats = statsRes.data;
+    const dstPathEndWithSlash = endWithSlash(resolvedDst);
+
+    const dstStats = { 
+      dstPath, 
+      resolvedDst, 
+      dstPathEndWithSlash, 
+      dstPathExists: stats.exists, 
+      parentDirOfDstPathExists: stats.parentDirExists, 
+      dstPathIsDir: stats.isDir, 
+      dstPathIsFile: stats.isFile
+    };
+    
+    var actualDstPath = await checkCpDstPath(srcStats, dstStats, recursive, noClobber, nasHttpTriggerPath);
+
+    if (isSync) { actualDstPath = resolvedDst; }
+    
+    const permTip = checkWritePerm(stats, nasId, resolvedDst);
+    if (permTip) {
+      console.log(red(`Warning: ${permTip}`));
+    }
+    
+    if (srcStats.srcPathIsDir) {
+      await uploadFolder(resolvedSrc, actualDstPath, nasHttpTriggerPath, localNasTmpDir, noClobber);
+    } else if (srcStats.srcPathIsFile) {
+      await uploadFile(resolvedSrc, actualDstPath, nasHttpTriggerPath);
+    } else {
+      throw new Error(`${srcStats.srcPath} has the same file stat and folder stat`);
+    }
+    
   } else if (isNasProtocol(srcPath) && isNasProtocol(dstPath)) {
     //nas => nas
     throw new Error('Not support copy NAS files to another NAS!');
   } else {
     throw new Error('Format of path not support');
   }
+}
+
+function checkCpSrcPath(srcStats, recursive) {
+  const { srcPath, srcPathExists, srcPathIsDir, srcPathIsEmpthDir } = srcStats;
+
+  if (!srcPathExists) {
+    throw new Error(`${srcPath} not exist`);
+  }
+  
+  if (srcPathIsDir && !recursive) {
+    throw new Error('Can not copy folder without option -r/--recursive');
+  }
+
+  if (srcPathIsDir && srcPathIsEmpthDir) {
+    throw new Error(`${srcPath} is empty, skip uploading`);
+  }
+}
+
+async function checkCpDstPath(srcStats, dstStats, recursive, noClobber, nasHttpTriggerPath) {
+  const { resolvedDst, dstPath, dstPathExists, parentDirOfDstPathExists, dstPathIsDir, dstPathIsFile, dstPathEndWithSlash } = dstStats;
+  const { resolvedSrc, srcPath } = srcStats;
+
+  var errorInf;
+  if (!recursive && dstPathExists) {
+    
+    if (dstPathIsFile && !dstPathEndWithSlash) {
+      if (!noClobber) { return resolvedDst; }
+      errorInf = `${dstPath} already exists.`;
+    }
+
+    if (dstPathIsFile && dstPathEndWithSlash) { 
+      errorInf = `${dstPath} : Not a directory`; 
+    }
+    
+    if (dstPathIsDir && isNasProtocol(dstPath)) {
+      const newDstPath = path.posix.join(resolvedDst, path.basename(resolvedSrc));
+      const statsRes = await statsRequest(newDstPath, nasHttpTriggerPath);
+      const stats = statsRes.data;
+      const newDstStats = {
+        dstPath: `${dstPath}/${path.basename(resolvedSrc)}`,
+        resolvedDst: newDstPath,
+        dstPathEndWithSlash: false,
+        dstPathExists: stats.exists,
+        parentDirOfDstPathExists: stats.parentDirExists,
+        dstPathIsDir: stats.isDir,
+        dstPathIsFile: stats.isFile
+      };
+      
+      return await checkCpDstPath(srcStats, newDstStats, recursive, noClobber, nasHttpTriggerPath);
+    }
+
+    if (dstPathIsDir && !isNasProtocol(dstPath)) {
+      // TO DO: 目标路径是本地路径
+      return path.join(resolvedDst, path.basename(resolvedSrc));
+    }
+  } else if (!recursive && !dstPathExists) {
+    if (dstPathEndWithSlash) { errorInf = `nas cp: cannot create regular file ${dstPath}: Not a directory`; }
+    else if (parentDirOfDstPathExists) { return resolvedDst; }
+    else { errorInf = `nas cp: cannot create regular file ${dstPath}: No such file or directory`; }
+
+  } else if (recursive && dstPathExists) {
+    if (dstPathIsDir && isNasProtocol(dstPath)) {
+      return path.posix.join(resolvedDst, path.basename(resolvedSrc));
+    }
+    if (dstPathIsDir && !isNasProtocol(dstPath)) {
+      return path.join(resolvedDst, path.basename(resolvedSrc));
+    }
+    if (dstPathIsFile && dstPathEndWithSlash) {
+      errorInf = `nas cp: failed to access ${dstPath}: Not a directory`;
+    }
+    if (dstPathIsFile && !dstPathEndWithSlash) {
+      errorInf = `nas cp: cannot overwrite non-directory ${dstPath} with directory ${srcPath}`;
+    }
+  } else if (recursive && !dstPathExists) {
+    if (parentDirOfDstPathExists) {
+      return resolvedDst;
+    }
+    errorInf = `nas cp: cannot create directory ${dstPath}: No such file or directory`;
+  }
+  throw new Error(errorInf);
 }
 
 module.exports = cp;

--- a/lib/nas/cp/file.js
+++ b/lib/nas/cp/file.js
@@ -22,16 +22,12 @@ async function zipWithArchiver(inputPath, localNasTmpDir) {
   return new Promise(async (resolve, reject) => {
 
     const targetName = path.basename(inputPath);
-    let parentDir = path.dirname(inputPath);
-    // 在 Windows 环境下，对 parentDir 进行处理
-    // 如 parentDir 为 C:\tmp ,则将 : 去除，以便后续 tmp 目录的递归创建 
-    if (parentDir.indexOf(':\\') !== -1) {
-      const pos = parentDir.indexOf(':\\');
-      parentDir = parentDir.substr(0, pos) + parentDir.substr(pos + 1, parentDir.length);
-    }
-    
-    const zipDstDir = path.join(localNasTmpDir, parentDir);
+
+    //以当前操作的 unix 时间戳作为临时目录名称
+    const curTime = new Date().getTime().toString();
+    const zipDstDir = path.join(localNasTmpDir, curTime);
     await mkdirp(zipDstDir);
+    
     const zipDst = path.join(zipDstDir, `.fun-nas-generated-${targetName}.zip`);
     
     const bar = createProgressBar(`${green(':zipping')} :bar :current/:total :rate files/s, :percent :elapsed s`, { total: 0 } );

--- a/lib/nas/cp/upload.js
+++ b/lib/nas/cp/upload.js
@@ -5,10 +5,10 @@ const rimraf = require('rimraf');
 const async = require('async');
 const { green, red } = require('colors');
 const constants = require('../constants');
+const debug = require('debug')('fun:nas:upload');
 const { 
   chunk,  
-  splitRangeBySize, 
-  checkWritePerm } = require('../support');
+  splitRangeBySize } = require('../support');
 
 const {
   getFileHash,
@@ -21,7 +21,6 @@ const {
 } = require('../path');
 
 const {
-  statsRequest,
   sendUnzipRequest,
   sendCleanRequest, 
   createSizedNasFile, 
@@ -32,26 +31,8 @@ const {
 
 const { createProgressBar } = require('../../import/utils');
 
-async function upload(srcPath, dstPath, nasHttpTriggerPath, recursive, localNasTmpDir, nasId) {
-  console.log('NAS path checking...');
-
-  const statsRes = await statsRequest(dstPath, nasHttpTriggerPath);
-
-  const stats = statsRes.data;
-
-  if (!stats.isExist) {
-    throw new Error(`${dstPath} not exist`);
-  }
-
-  if (stats.isFile && !stats.isDir) {
-    throw new Error(`Check error : ${dstPath} is a file, but ${srcPath} is a folder`);
-  }
-  const permTip = checkWritePerm(stats, nasId, dstPath);
-  if (permTip) {
-    const warningInfo = `fun nas sync: ${permTip}`;
-    console.log(red(`Warning: ${warningInfo}`));
-  }
-
+async function uploadFolder(srcPath, dstPath, nasHttpTriggerPath, localNasTmpDir, noClobber) {
+  
   console.log('zipping ' + srcPath);
   const zipFilePath = await zipWithArchiver(srcPath, localNasTmpDir);
   const zipFileSize = await getFileSize(zipFilePath);
@@ -61,41 +42,57 @@ async function upload(srcPath, dstPath, nasHttpTriggerPath, recursive, localNasT
   const fileName = path.basename(zipFilePath);
 
   const remoteNasTmpDir = path.posix.join(dstPath, '.fun_nas_tmp');
-  console.log('checking NAS tmp dir');
+  debug(`checking NAS tmp dir ${remoteNasTmpDir}`);
   await checkRemoteNasTmpDir(nasHttpTriggerPath, remoteNasTmpDir);
-  console.log(`${green('✔')} check done`);
+  debug(`${green('✔')} check done`);
   const nasZipFile = path.posix.join(remoteNasTmpDir, fileName);
-
+  debug(`Creating ${zipFileSize} bytes size file: ${nasZipFile}`);
   await createSizedNasFile(nasHttpTriggerPath, nasZipFile, zipFileSize);
   
-  console.log(`${green('✔')} create done`);
+  debug(`${green('✔')} create done`);
 
   await uploadFileByChunk(nasHttpTriggerPath, nasZipFile, zipFilePath, fileOffSetCutByChunkSize);
 
-  console.log('checking uploaded NAS zip file hash');
+  debug(`checking uploaded NAS zip file ${nasZipFile} hash`);
   await checkFileHash(nasHttpTriggerPath, nasZipFile, zipHash);
-  console.log(`${green('✔')} hash unchanged`);
+  debug(`${green('✔')} hash unchanged`);
 
   console.log('unzipping file');
   const srcPathFiles = await readDirRecursive(srcPath);
   const unzipFilsCount = srcPathFiles.length;
   const filesArrSlicedBySize = chunk(srcPathFiles, constants.FUN_NAS_FILE_COUNT_PER_REQUEST);
-  await unzipNasFileParallel(nasHttpTriggerPath, dstPath, nasZipFile, filesArrSlicedBySize, unzipFilsCount);
-  console.log('cleaning');
+  await unzipNasFileParallel(nasHttpTriggerPath, dstPath, nasZipFile, filesArrSlicedBySize, unzipFilsCount, noClobber);
+  debug('cleaning');
   await sendCleanRequest(nasHttpTriggerPath, nasZipFile);
-  console.log(`${green('✔')} clean done`);
+  debug(`${green('✔')} clean done`);
 
   rimraf.sync(zipFilePath);
   console.log(`${green('✔')} upload completed!`);
 }
+async function uploadFile(resolvedSrc, actualDstPath, nasHttpTriggerPath) {
+  const fileSize = await getFileSize(resolvedSrc);
+  const fileOffSetCutByChunkSize = splitRangeBySize(0, fileSize, constants.FUN_NAS_CHUNK_SIZE);
+  const fileHash = await getFileHash(resolvedSrc);
+  debug(`Creating ${fileSize} bytes size file: ${actualDstPath}`);
+  await createSizedNasFile(nasHttpTriggerPath, actualDstPath, fileSize);
+  
+  debug(`${green('✔')} create done`);
 
+  await uploadFileByChunk(nasHttpTriggerPath, actualDstPath, resolvedSrc, fileOffSetCutByChunkSize);
 
-function unzipNasFileParallel(nasHttpTriggerPath, dstDir, nasZipFile, filesArrQueue, unzipFilsCount) {
+  debug(`checking uploaded file ${actualDstPath} hash`);
+  await checkFileHash(nasHttpTriggerPath, actualDstPath, fileHash);
+  debug(`${green('✔')} hash unchanged`);
+
+  console.log(`${green('✔')} upload completed!`);
+}
+
+function unzipNasFileParallel(nasHttpTriggerPath, dstDir, nasZipFile, filesArrQueue, unzipFilsCount, noClobber) {
   return new Promise((resolve, reject) => {
     const bar = createProgressBar(`${green(':unzipping')} :bar :current/:total :rate files/s, :percent :elapsed s`, { total: unzipFilsCount });
     let unzipQueue = async.queue(async (unzipFiles, callback) => {
       try {
-        await sendUnzipRequest(nasHttpTriggerPath, dstDir, nasZipFile, unzipFiles);
+        await sendUnzipRequest(nasHttpTriggerPath, dstDir, nasZipFile, unzipFiles, noClobber);
         bar.tick(unzipFiles.length);
       } catch (error) {
         // 出现这样的错误是因为待解压文件列表不在上传的 NAS 端压缩文件
@@ -164,4 +161,7 @@ function uploadFileByChunk(nasHttpTriggerPath, nasZipFile, zipFilePath, fileOffS
   });
 }
 
-module.exports = upload;
+module.exports = {
+  uploadFolder, 
+  uploadFile
+};

--- a/lib/nas/request.js
+++ b/lib/nas/request.js
@@ -78,8 +78,14 @@ async function checkFileHash(nasHttpTriggerPath, nasFile, fileHash) {
 }
 
 
-async function sendUnzipRequest(nasHttpTriggerPath, dstDir, nasZipFile, unzipFiles) {
-  let cmd = `unzip -q -o ${nasZipFile} -d ${dstDir}`;
+async function sendUnzipRequest(nasHttpTriggerPath, dstDir, nasZipFile, unzipFiles, noClobber) {
+  var cmd;
+  if (noClobber) {
+    cmd = `unzip -q -n ${nasZipFile} -d ${dstDir}`;
+  } else {
+    cmd = `unzip -q -o ${nasZipFile} -d ${dstDir}`;
+  }
+  
   for (let unzipFile of unzipFiles) {
     cmd = cmd + ` "${unzipFile}"`;
   }
@@ -96,7 +102,6 @@ async function sendCleanRequest(nasHttpTriggerPath, nasZipFile) {
 }
 
 async function createSizedNasFile(nasHttpTriggerPath, nasZipFile, fileSize) {
-  console.log(`Creating ${fileSize} bytes size file: ${nasZipFile}`);
 
   const cmd = `dd if=/dev/zero of=${nasZipFile} count=0 bs=1 seek=${fileSize}`;
 

--- a/lib/nas/rm.js
+++ b/lib/nas/rm.js
@@ -15,7 +15,7 @@ async function rm(serviceName, nasPath, isRecursiveOpt, isForceOpt, nasId) {
 
   const stats = statsRes.data;
 
-  if (!stats.isExist) {
+  if (!stats.exists) {
     throw new Error(`${nasPath} not exist`);
   }
 

--- a/lib/nas/support.js
+++ b/lib/nas/support.js
@@ -1,8 +1,10 @@
 'use strict';
-const { findServices } = require('../definition');
+const { findServices, isNasAutoConfig } = require('../definition');
 const { red } = require('colors');
+const { parseNasUri } = require('./path');
 const { getVersion, getNasHttpTriggerPath, getNasConfig } = require('./request');
 const _ = require('lodash');
+const { convertTplToServiceNasIdMappings } = require('../nas');
 
 function getDefaultService(tpl) {
   const services = findServices(tpl.Resources);
@@ -37,8 +39,8 @@ function splitRangeBySize(start, end, chunkSize) {
 // 检查nasId 是否有 nasPath 的写权限
 // 返回相关字符串信息,undefined 表示有权限，否则无权限且返回相应 tip
 function checkWritePerm(stats, nasId, nasPath) {
-  if (!stats.isExist) {
-    return `${nasPath} not exist`;
+  if (!stats.exists) {
+    return undefined;
   }
   const userId = nasId.UserId;
   const groupId = nasId.GroupId;
@@ -115,7 +117,16 @@ async function isSameNasConfig(serviceName, nasConfig) {
   } catch (error) {
     curNasServerNasConfig = {};
   }
-  
+  if (isNasAutoConfig(nasConfig)) {
+    // 当线上函数计算端的 NasConfig 包含如下几个选项时，对应本地 NasConfig: Auto
+    // UserId: 10003,
+    // GroupId: 10003, 
+    // MountDir: /mnt/auto
+    // 当本地 NasConfig 为 Auto 时，认为 nas 配置未变  
+    return _.isEqual(curNasServerNasConfig.UserId, 10003) && 
+          _.isEqual(curNasServerNasConfig.GroupId, 10003) &&
+          _.isEqual(curNasServerNasConfig.MountPoints[0].MountDir, '/mnt/auto');
+  }
   return _.isEqual(nasConfig, curNasServerNasConfig);
 }
 
@@ -125,6 +136,20 @@ function toBeUmountedDirs(configuredMountDirs, mountedDirs) {
 
   return toUnmountDirs;
 }
+
+function getNasId(tpl, serviceName) {
+  const serviceNasIdMappings = convertTplToServiceNasIdMappings(tpl);
+  return serviceNasIdMappings[serviceName];
+}
+
+function getNasPathAndServiceFromNasUri(nasUri, tpl) {
+  var { nasPath, serviceName } = parseNasUri(nasUri); 
+  // 此时 nasDir 的格式应为 nas://${ serviceName }${ mountDir }
+  if (serviceName === '') {
+    serviceName = getDefaultService(tpl);
+  }
+  return { nasPath, serviceName };
+}
 module.exports = { 
   getDefaultService, 
   chunk, 
@@ -133,5 +158,7 @@ module.exports = {
   isNasServerStale,
   toBeUmountedDirs,
   isSameNasConfig, 
-  isSameVersion
+  isSameVersion, 
+  getNasId, 
+  getNasPathAndServiceFromNasUri
 };

--- a/lib/tpl.js
+++ b/lib/tpl.js
@@ -94,5 +94,5 @@ function detectNasBaseDir(tplPath) {
 module.exports = {
   getTpl, detectTplPath, validateYmlName, 
   detectNasBaseDir, DEFAULT_BUILD_ARTIFACTS_PATH_SUFFIX, DEFAULT_NAS_PATH_SUFFIX,
-  detectTmpDir, DEFAULT_TMP_INVOKE_PATH_SUFFIX
+  detectTmpDir, DEFAULT_TMP_INVOKE_PATH_SUFFIX, getBaseDir
 };

--- a/lib/utils/fun-nas-server/index.js
+++ b/lib/utils/fun-nas-server/index.js
@@ -11,7 +11,9 @@ const path = require('path');
 const { makeTmpDir } = require('./lib/path');
 const { 
   getFileHash,
-  writeBufToFile } = require('./lib/file');
+  writeBufToFile,
+  exists, 
+  isDir } = require('./lib/file');
 
 const app = express();
 app.use(bodyParser.raw({ limit: '6mb' }));
@@ -105,12 +107,15 @@ app.get('/stats', async (req, res) => {
 
   if (!dstPath) { throw new Error('missing dstPath parameter'); }
 
-  if (await fs.pathExists(dstPath)) {
+  const parentDirExists = await isDir(path.dirname(dstPath));
+  
+  if (await exists(dstPath)) {
     const stats = await fs.lstat(dstPath);
 
     res.send({
       path: dstPath,
-      isExist: true,
+      exists: true,
+      parentDirExists: parentDirExists, 
       isDir: stats.isDirectory(),
       isFile: stats.isFile(), 
       UserId: stats.uid, 
@@ -120,7 +125,8 @@ app.get('/stats', async (req, res) => {
   } else {
     res.send({
       path: dstPath,
-      isExist: false,
+      exists: false,
+      parentDirExists: parentDirExists, 
       isDir: false,
       isFile: false
     });

--- a/lib/utils/fun-nas-server/lib/file.js
+++ b/lib/utils/fun-nas-server/lib/file.js
@@ -3,16 +3,32 @@
 const fs = require('fs-extra');
 const md5File = require('md5-file/promise');
 
+async function pathJudge(inputPath, type) {
+  try {
+    const stats = await fs.lstat(inputPath);
+    switch (type) {
+    case 'exists': return true;
+    case 'isFile': return stats.isFile();
+    case 'isDir': return stats.isDirectory();
+    default: throw new Error('unsupported type in pathJudge function.');
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
 async function isDir(inputPath) {
-  const stats = await fs.lstat(inputPath);
-
-  return stats.isDirectory();
+  return await pathJudge(inputPath, 'isDir');
 }
 
 async function isFile(inputPath) {
-  const stats = await fs.lstat(inputPath);
+  return await pathJudge(inputPath, 'isFile');
+}
 
-  return stats.isFile();
+async function exists(inputPath) {
+  return await pathJudge(inputPath, 'exists');
 }
 
 async function getFileHash(filePath) {
@@ -43,6 +59,7 @@ function writeBufToFile(dstPath, buf, start) {
 module.exports = {
   isDir,
   isFile,
+  exists,
   getFileHash,
   writeBufToFile
 };

--- a/lib/utils/fun-nas-server/test/file.test.js
+++ b/lib/utils/fun-nas-server/test/file.test.js
@@ -46,5 +46,29 @@ describe('file.js test', () => {
       expect(error).to.be.an(Error);
     }
   });
-
+  it('function isDir true test', async() => {
+    const res = await file.isDir(dirName);
+    expect(res).to.eql(true);
+  });
+  it('function isDir false test', async() => {
+    const res = await file.isDir(filePath);
+    expect(res).to.eql(false);
+  });
+  it('function isFile true test', async() => {
+    const res = await file.isFile(filePath);
+    expect(res).to.eql(true);
+  });
+  it('function isFile false test', async() => {
+    const res = await file.isFile(dirName);
+    expect(res).to.eql(false);
+  });
+  it('function exists true test', async() => {
+    const res = await file.exists(dirName);
+    expect(res).to.eql(true);
+  });
+  it('function exists false test', async() => {
+    const localNotExistPath = path.join(dirName, '.not-exist-path');
+    const res = await file.exists(localNotExistPath);
+    expect(res).to.eql(false);
+  });
 });

--- a/lib/utils/fun-nas-server/test/index.test.js
+++ b/lib/utils/fun-nas-server/test/index.test.js
@@ -110,8 +110,9 @@ describe('GET /stats test', () => {
       .expect(
         {
           path: dirPath,
-          isExist: true,
+          exists: true,
           isDir: true,
+          parentDirExists: true,
           isFile: false, 
           UserId: uid, 
           GroupId: gid, 
@@ -128,8 +129,9 @@ describe('GET /stats test', () => {
       .expect(
         {
           path: notExistPath,
-          isExist: false,
+          exists: false,
           isDir: false,
+          parentDirExists: true, 
           isFile: false
         }, done);
   });

--- a/test/commands/nas/cp.test.js
+++ b/test/commands/nas/cp.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const os = require('os');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const sandbox = sinon.createSandbox();
+const assert = sinon.assert;
+const path = require('path');
+const mockdata = require('./mock-data');
+const validate = sandbox.stub();
+const { getBaseDir } = require('../../../lib/tpl');
+const tpl = {
+  detectTplPath: sandbox.stub(), 
+  getTpl: sandbox.stub()
+};
+const nasCp = sandbox.stub();
+const cpStub = proxyquire('../../../lib/commands/nas/cp', {
+  '../../validate/validate': validate,
+  '../../nas/cp': nasCp,
+  '../../tpl': tpl
+});
+
+describe('command cp test', () => {
+  const options = 
+    {
+      recursive: true, 
+      clobber: true
+    };
+  const srcPath = 'src path';
+  const dstPath = 'dst path';
+  const tplPath = path.join(os.tmpdir(), 'template.yml'); 
+  beforeEach(() => {
+    tpl.detectTplPath.returns(tplPath);
+    tpl.getTpl.returns(mockdata.tpl);
+  });
+  
+  afterEach(() => {
+    sandbox.reset();
+  });
+    
+  it('normal test', async () => {
+
+    await cpStub(srcPath, dstPath, options);
+
+    const baseDir = getBaseDir(tplPath);
+    const localNasTmpDir = path.join(baseDir, '.fun', 'tmp', 'nas', 'cp');
+    assert.calledWith(nasCp, srcPath, dstPath, options.recursive, !options.clobber, localNasTmpDir, mockdata.tpl, baseDir, false);
+  });
+});

--- a/test/commands/nas/mock-data.js
+++ b/test/commands/nas/mock-data.js
@@ -1,12 +1,16 @@
 'use strict';
 
+const remoteNasDir = '/mnt/nas';
+const mountSource = 'demo';
+const serverPath = '359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com';
+const mountPoint = {
+  ServerAddr: `${serverPath}:/${mountSource}`,
+  MountDir: remoteNasDir
+}; 
 const nasConfig = {
   UserId: 1000,
   GroupId: 1000,
-  MountPoints: [{
-    ServerAddr: '359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com:/',
-    MountDir: '/mnt/nas'
-  }]
+  MountPoints: [mountPoint]
 };
 
 const vpcConfig = {
@@ -50,11 +54,15 @@ const nasId =
   UserId: 1000,
   GroupId: 1000
 };
+
 module.exports = {
   nasConfig, 
   tpl, 
   vpcConfig, 
   serviceName, 
   nasId, 
-  tplWithoutNasConfig
+  tplWithoutNasConfig, 
+  remoteNasDir, 
+  mountSource, 
+  serverPath
 };

--- a/test/commands/nas/sync.test.js
+++ b/test/commands/nas/sync.test.js
@@ -1,16 +1,15 @@
 'use strict';
 
+const os = require('os');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const mockdata = require('./mock-data');
 const fs = require('fs-extra');
 const path = require('path');
-const { DEFAULT_NAS_PATH_SUFFIX } = require('../../../lib/tpl');
+const { detectNasBaseDir, getBaseDir } = require('../../../lib/tpl');
 const sandbox = sinon.createSandbox();
 const assert = sinon.assert;
 
-const tplPath = path.resolve('/', 'demo', 'template.yml');
-const localNasTmpDir = path.join(path.dirname(tplPath), '.fun', 'tmp', 'nas', 'sync');
 const cp = sandbox.stub();
 const validate = sandbox.stub();
 
@@ -18,38 +17,81 @@ const tpl = {
   detectTplPath: sandbox.stub(), 
   getTpl: sandbox.stub()
 };
-const init = {
-  deployNasService: sandbox.stub().resolves()
-};
-const support = {
-  toBeUmountedDirs: sandbox.spy()
-};
+
 
 const syncStub = proxyquire('../../../lib/commands/nas/sync', {
   '../../validate/validate': validate,
   '../../nas/cp': cp,
-  '../../tpl': tpl,
-  '../../nas/init': init, 
-  '../../nas/support': support
+  '../../tpl': tpl
 });
+const tplPath = path.join(os.tmpdir(), 'nas', 'template.yml');
+const baseDir = getBaseDir(tplPath);
+const nasBaseDir = detectNasBaseDir(tplPath);
 
-describe('fun nas sync test', () => {
-  let fsPathExists;
+const localNasTmpDir = path.join(baseDir, '.fun', 'tmp', 'nas', 'sync');
+const localNasDir = path.join(nasBaseDir, mockdata.serverPath, mockdata.mountSource);
+const syncDstPath = `nas://${mockdata.serviceName}${mockdata.remoteNasDir}/`;
+const isSync = true;
+const recursive = true;
+const noClobber = false;
+
+
+describe('fun nas sync test with empty nas config', () => {
+  
   beforeEach(() => {
-    fsPathExists = sandbox.stub(fs, 'pathExists');
+    const fsPathExists = sandbox.stub(fs, 'pathExists');
     fsPathExists.onCall(0).resolves(true);
     fsPathExists.onCall(1).resolves(true);
+    tpl.detectTplPath.returns(tplPath);
+    tpl.getTpl.returns(mockdata.tplWithoutNasConfig);
+  });
 
+  afterEach(() => {
+    sandbox.restore();
+  });
+  it('sync test without service option and mountDir option, with empty nas config', async() => {
+    const options = {
+      service: undefined, 
+      mountDir: undefined
+    };
+    await syncStub(options);
+    assert.notCalled(cp);
+  });
+
+  it('sync test with service option but without mountDir option, with empty nas config ', async () => {
+    const options = {
+      service: mockdata.serviceName, 
+      mountDir: undefined
+    };
+    await syncStub(options);
+    assert.notCalled(cp);
+  });
+  it('sync test with service and mountDir option, with empty nas config', async () => {
+    const options = {
+      service: mockdata.serviceName, 
+      mountDir: [mockdata.remoteNasDir]
+    };
+    await syncStub(options);
+
+    assert.notCalled(cp);
+  });
+});
+
+describe('fun nas sync test with normal nas config', () => {
+  
+  beforeEach(() => {
+    const fsPathExists = sandbox.stub(fs, 'pathExists');
+    fsPathExists.onCall(0).resolves(true);
+    fsPathExists.onCall(1).resolves(true);
     tpl.detectTplPath.returns(tplPath);
     tpl.getTpl.returns(mockdata.tpl);
   });
 
   afterEach(() => {
     sandbox.restore();
-    sandbox.reset();
   });
 
-  it('sync test without service', async () => {
+  it('sync test without service option and mountDir option, with normal nas config', async () => {
     
     const options = {
       service: undefined, 
@@ -57,36 +99,29 @@ describe('fun nas sync test', () => {
     };
 
     await syncStub(options);
-    const localNasDir = path.join(path.resolve('/'), 'demo', DEFAULT_NAS_PATH_SUFFIX, '359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com', '/');
-    assert.notCalled(support.toBeUmountedDirs);
-    assert.calledWith(cp, localNasDir, 'nas://fun-nas-test/mnt/nas/', true, localNasTmpDir, mockdata.nasId);
+    
+    assert.calledWith(cp, localNasDir, syncDstPath, recursive, noClobber, localNasTmpDir, mockdata.tpl, baseDir, isSync);
   });
 
-  it('sync test with service', async () => {
+  it('sync test with service option but without mountDir option, with normal nas config ', async () => {
+    
     const options = {
       service: mockdata.serviceName, 
       mountDir: undefined
     };
     await syncStub(options);
-    const localNasDir = path.join(path.resolve('/'), 'demo', DEFAULT_NAS_PATH_SUFFIX, '359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com', '/');
-    const baseDir = path.dirname(tplPath);
-    assert.notCalled(support.toBeUmountedDirs);
-    assert.calledWith(cp, localNasDir, `nas://${mockdata.serviceName}/mnt/nas/`, true, localNasTmpDir, mockdata.nasId);
-    assert.calledWith(init.deployNasService, baseDir, mockdata.tpl, options.service);
+    
+    assert.calledWith(cp, localNasDir, syncDstPath, recursive, noClobber, localNasTmpDir, mockdata.tpl, baseDir, isSync);
   });
 
-  it('sync test with service', async () => {
+  
+  it('sync test with service and mountDir option, with normal nas config', async () => {
     const options = {
       service: mockdata.serviceName, 
-      mountDir: ['/mnt/nas']
+      mountDir: [mockdata.remoteNasDir]
     };
     await syncStub(options);
-    const localNasDir = path.join(path.resolve('/'), 'demo', DEFAULT_NAS_PATH_SUFFIX, '359414a1be-lwl67.cn-shanghai.nas.aliyuncs.com', '/');
-    const baseDir = path.dirname(tplPath);
-    
-    assert.calledWith(support.toBeUmountedDirs, ['/mnt/nas'], ['/mnt/nas']);
-    assert.calledWith(cp, localNasDir, `nas://${mockdata.serviceName}/mnt/nas/`, true, localNasTmpDir, mockdata.nasId);
-    assert.calledWith(init.deployNasService, baseDir, mockdata.tpl, options.service);
+    assert.calledWith(cp, localNasDir, syncDstPath, recursive, noClobber, localNasTmpDir, mockdata.tpl, baseDir, isSync);
   });
 
 });

--- a/test/nas/cp.test.js
+++ b/test/nas/cp.test.js
@@ -7,29 +7,53 @@ const mkdirp = require('mkdirp-promise');
 const rimraf = require('rimraf');
 const mockdata = require('../commands/nas/mock-data');
 const writeFile = util.promisify(fs.writeFile);
-
+const expect = require('expect.js');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const path = require('path');
-const constants = require('../../lib/nas/constants');
+const { getBaseDir } = require('../../lib/tpl');
+const { getNasHttpTriggerPath } = require('../../lib/nas/request');
 const sandbox = sinon.createSandbox();
 const assert = sinon.assert;
 
-const upload = sandbox.stub();
-
+const upload = {
+  uploadFolder: sandbox.stub(), 
+  uploadFile: sandbox.stub()
+};
+const request = {
+  statsRequest: sandbox.stub()
+};
+const init = {
+  deployNasService: sandbox.stub()
+};
 const cpStub = proxyquire('../../lib/nas/cp', {
-  './cp/upload': upload
+  './cp/upload': upload, 
+  './request': request, 
+  './init': init
 });
 
-describe('nas cp test', () => {
+const tplPath = path.join(os.tmpdir(), 'nas', 'template.yml');
+const baseDir = getBaseDir(tplPath);
+const localNasTmpDir = path.join(baseDir, '.fun', 'tmp', 'nas', 'sync');
+const tpl = mockdata.tpl; 
+const isSync = false;
+const resolvedDst = path.posix.join('/', 'mnt', 'nas');
+const nasHttpTriggerPath = getNasHttpTriggerPath(mockdata.serviceName);
+const dstPath = `nas://${mockdata.serviceName}${resolvedDst}`;
+const recursive = true;
+const noClobber = true;
+
+describe('nas cp src path check error', () => {
+  const localNotExistPath = path.join(os.tmpdir(), '.not-exist-path');
   const localNotEmptyPath = path.join(os.tmpdir(), '.not-empty-dir'); 
   const localEmptyPath = path.join(os.tmpdir(), '.empty-dir'); 
-  const filePath = path.join(localNotEmptyPath, 'test.txt');
-  const localNasTmpDir = 'nastmp';
+  const localFilePath = path.join(localNotEmptyPath, 'test.txt');
+
+
   beforeEach(async () => {
     await mkdirp(localEmptyPath);
     await mkdirp(localNotEmptyPath);
-    await writeFile(`${filePath}`, 'this is a test');
+    await writeFile(`${localFilePath}`, 'this is a test');
   });
 
   afterEach(() => {
@@ -37,36 +61,418 @@ describe('nas cp test', () => {
     rimraf.sync(localNotEmptyPath);
     sandbox.reset();
   });
+  it('src path not exist', async() => {
+    try {
+      await cpStub(localNotExistPath, dstPath, recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error(`${localNotExistPath} not exist`));
+    }
+    assert.notCalled(request.statsRequest);
+    assert.notCalled(upload.uploadFile);
+    assert.notCalled(upload.uploadFolder);
+  });
+  it('src path is empty dir', async() => {
+    try {
+      await cpStub(localEmptyPath, dstPath, recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error(`${localEmptyPath} is empty, skip uploading`));
+    }
+    assert.notCalled(request.statsRequest);
+    assert.notCalled(upload.uploadFile);
+    assert.notCalled(upload.uploadFolder);
+  });
+  it('cp localDir without recursive option', async() => {
+    try {
+      await cpStub(localNotEmptyPath, dstPath, !recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error('Can not copy folder without option -r/--recursive'));
+    }
+    assert.notCalled(request.statsRequest);
+    assert.notCalled(upload.uploadFile);
+    assert.notCalled(upload.uploadFolder);
+  });
+  
+});
 
-  it('local path cp to nas path test', async() => {
-    
-    const srcPath = filePath;
-    const dstPath = 'nas://fun-nas-test/mnt/nas';
-    
-    await cpStub(srcPath, dstPath, false, localNasTmpDir, mockdata.nasId);
-    const mntDir = path.posix.join('/', 'mnt', 'nas');
-    const nasHttpTriggerPath = `/proxy/${constants.FUN_NAS_SERVICE_PREFIX}fun-nas-test/fun-nas-function/`;
-    assert.calledWith(upload, srcPath, mntDir, nasHttpTriggerPath, false, localNasTmpDir, mockdata.nasId);
-    
+describe('nas cp local file to remote NAS', () => {
+
+  const localNotEmptyPath = path.join(os.tmpdir(), '.cp-file-not-empty-dir'); 
+  const localFilePath = path.join(localNotEmptyPath, 'test.txt');
+  
+  beforeEach(async () => {
+    await mkdirp(localNotEmptyPath);
+    await writeFile(`${localFilePath}`, 'this is a test');
   });
 
-  it('src path undefined test', async () => {
-    const srcPath = undefined;
-    const dstPath = 'nas://fun-nas-test/mnt/nas';
-
-    await cpStub(srcPath, dstPath, false, localNasTmpDir, mockdata.nasId);
-    
-    assert.notCalled(upload);
+  afterEach(() => {
+    rimraf.sync(localNotEmptyPath);
+    sandbox.reset();
   });
 
-  it('local src path is a empty dir test', async () => {
-    const srcPath = localEmptyPath;
-    const dstPath = 'nas://fun-nas-test/mnt/nas';
+  it('cp localFile nasExistedFile', async() => {
     
-    await cpStub(srcPath, dstPath, true, localNasTmpDir, mockdata.nasId);
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: true,
+        parentDirExists: true,
+        isDir: false,
+        isFile: true,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    await cpStub(localFilePath, dstPath, !recursive, !noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    assert.calledWith(request.statsRequest, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(upload.uploadFile, localFilePath, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.notCalled(upload.uploadFolder);
+  });
+  it('cp localFile nasExistedFile -n', async() => {
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: true,
+        parentDirExists: true,
+        isDir: false,
+        isFile: true,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    try {
+      await cpStub(localFilePath, dstPath, !recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error(`${dstPath} already exists.`));
+    }
+    assert.calledWith(request.statsRequest, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.notCalled(upload.uploadFolder);
+    assert.notCalled(upload.uploadFile);
+  });
+  it('cp localFile nasExistedFile/', async() => {
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: `${resolvedDst}/`,
+        exists: true,
+        parentDirExists: true,
+        isDir: false,
+        isFile: true,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    try {
+      await cpStub(localFilePath, `${dstPath}/`, !recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error(`${dstPath} : Not a directory`));
+    }
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.calledWith(request.statsRequest, `${resolvedDst}/`, nasHttpTriggerPath);
+    assert.notCalled(upload.uploadFolder);
+    assert.notCalled(upload.uploadFile);
+  });
+  it('cp localFile nasExistedDir, but nasExistedDir/path.basename(localFile) not exist', async() => {
+    request.statsRequest.onCall(0).returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: true,
+        parentDirExists: true,
+        isDir: true,
+        isFile: false,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    
+    const newResolvedDst = path.posix.join(resolvedDst, path.basename(localFilePath));
+    request.statsRequest.onCall(1).returns({
+      headers: 200,
+      data: {
+        path: newResolvedDst,
+        exists: false,
+        parentDirExists: true,
+        isDir: false,
+        isFile: false
+      }
+    });
+    const actualDst = newResolvedDst;
+    await cpStub(localFilePath, dstPath, !recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.calledWith(request.statsRequest.firstCall, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(request.statsRequest.secondCall, newResolvedDst, nasHttpTriggerPath);
+    assert.notCalled(upload.uploadFolder);
+    assert.calledWith(upload.uploadFile, localFilePath, actualDst, nasHttpTriggerPath);
+  });
+  it('cp localFile nasExistedDir, but nasExistedDir/path.basename(localFile) exists without -n option', async() => {
+    request.statsRequest.onCall(0).returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: true,
+        parentDirExists: true,
+        isDir: true,
+        isFile: false,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    
+    const newResolvedDst = path.posix.join(resolvedDst, path.basename(localFilePath));
+    request.statsRequest.onCall(1).returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: true,
+        parentDirExists: true,
+        isDir: false,
+        isFile: true,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    const actualDst = newResolvedDst;
+    await cpStub(localFilePath, dstPath, !recursive, !noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.calledWith(request.statsRequest.firstCall, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(request.statsRequest.secondCall, newResolvedDst, nasHttpTriggerPath);
+    assert.notCalled(upload.uploadFolder);
+    assert.calledWith(upload.uploadFile, localFilePath, actualDst, nasHttpTriggerPath);
+  });
+  it('cp localFile nasExistedDir, but nasExistedDir/path.basename(localFile) exists with -n option', async() => {
+    request.statsRequest.onCall(0).returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: true,
+        parentDirExists: true,
+        isDir: true,
+        isFile: false,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    const newDstPath = `${dstPath}/${path.basename(localFilePath)}`;
+    const newResolvedDst = path.posix.join(resolvedDst, path.basename(localFilePath));
+    request.statsRequest.onCall(1).returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: true,
+        parentDirExists: true,
+        isDir: false,
+        isFile: true,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    try {
+      await cpStub(localFilePath, dstPath, !recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error(`${newDstPath} already exists.`));
+    }
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.calledWith(request.statsRequest.firstCall, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(request.statsRequest.secondCall, newResolvedDst, nasHttpTriggerPath);
+    assert.notCalled(upload.uploadFolder);
+    assert.notCalled(upload.uploadFile);
+  });
+  it('cp localFile nasNotExistedPath/', async() => {
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: `${resolvedDst}/`,
+        exists: false,
+        parentDirExists: true,
+        isDir: false,
+        isFile: false
+      }
+    });
+    try {
+      await cpStub(localFilePath, `${dstPath}/`, !recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error(`nas cp: cannot create regular file ${dstPath}: Not a directory`));
+    }
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.calledWith(request.statsRequest, `${resolvedDst}/`, nasHttpTriggerPath);
+    assert.notCalled(upload.uploadFolder);
+    assert.notCalled(upload.uploadFile);
+  });
+  it('cp localFile nasNotExistedPath, parent dir of nasNotExistedPath not exists', async() => {
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: false,
+        parentDirExists: false,
+        isDir: false,
+        isFile: false
+      }
+    });
+    try {
+      await cpStub(localFilePath, dstPath, !recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error(`nas cp: cannot create regular file ${dstPath}: No such file or directory`));
+    }
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.calledWith(request.statsRequest, resolvedDst, nasHttpTriggerPath);
+    assert.notCalled(upload.uploadFolder);
+    assert.notCalled(upload.uploadFile);
+  });
+  it('cp localFile nasNotExistedPath, parent dir of nasNotExistedPath exists', async() => {
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: false,
+        parentDirExists: true,
+        isDir: false,
+        isFile: false
+      }
+    });
+    await cpStub(localFilePath, dstPath, !recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    assert.calledWith(request.statsRequest, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.notCalled(upload.uploadFolder);
+    assert.calledWith(upload.uploadFile, localFilePath, resolvedDst, nasHttpTriggerPath);
+  });
+  
+});
+describe('nas cp local folder to remote NAS', () => {
+  const localNotEmptyPath = path.join(os.tmpdir(), '.cp-folder-not-empty-dir'); 
+  const localFilePath = path.join(localNotEmptyPath, 'test.txt');
 
-    assert.notCalled(upload);
-    
+  beforeEach(async () => {
+    await mkdirp(localNotEmptyPath);
+    await writeFile(`${localFilePath}`, 'this is a test');
   });
 
+  afterEach(() => {
+    rimraf.sync(localNotEmptyPath);
+    sandbox.reset();
+  });
+  after(() => {
+    sandbox.restore();
+  });
+  it('cp localDir -r nasExistFile', async() => {
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: true,
+        parentDirExists: true,
+        isDir: false,
+        isFile: true,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    try {
+      await cpStub(localNotEmptyPath, dstPath, recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error(`nas cp: cannot overwrite non-directory ${dstPath} with directory ${localNotEmptyPath}`));
+    }
+    assert.calledWith(request.statsRequest, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.notCalled(upload.uploadFolder);
+    assert.notCalled(upload.uploadFile);
+  });
+  it('cp localDir -r nasExistFile/', async() => {
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: `${resolvedDst}/`,
+        exists: true,
+        parentDirExists: true,
+        isDir: false,
+        isFile: true,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    try {
+      await cpStub(localNotEmptyPath, `${dstPath}/`, recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error(`nas cp: failed to access ${dstPath}/: Not a directory`));
+    }
+    assert.calledWith(request.statsRequest, `${resolvedDst}/`, nasHttpTriggerPath);
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.notCalled(upload.uploadFolder);
+    assert.notCalled(upload.uploadFile);
+  });
+  it('cp localDir -r nasNotExistPath, parent dir of nasNotExistedPath not exist', async() => {
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: false,
+        parentDirExists: false,
+        isDir: false,
+        isFile: false
+      }
+    });
+    try {
+      await cpStub(localNotEmptyPath, dstPath, recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    } catch (error) {
+      expect(error).to.eql(new Error(`nas cp: cannot create directory ${dstPath}: No such file or directory`));
+    }
+    
+    assert.calledWith(request.statsRequest, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.notCalled(upload.uploadFolder);
+    assert.notCalled(upload.uploadFile);
+  });
+  it('cp localDir -r nasExistDir', async() => {
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: true,
+        parentDirExists: true,
+        isDir: true,
+        isFile: false,
+        UserId: 10003,
+        GroupId: 10003,
+        mode: 123
+      }
+    });
+    const actualDst = path.posix.join(resolvedDst, path.basename(localNotEmptyPath));
+    await cpStub(localNotEmptyPath, dstPath, recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    assert.calledWith(request.statsRequest, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.calledWith(upload.uploadFolder, localNotEmptyPath, actualDst, nasHttpTriggerPath, localNasTmpDir, noClobber);
+    assert.notCalled(upload.uploadFile);
+  });
+  it('cp localDir -r nasNotExistPath, parent dir of nasNotExistedPath exists', async() => {
+    request.statsRequest.returns({
+      headers: 200,
+      data: {
+        path: resolvedDst,
+        exists: false,
+        parentDirExists: true,
+        isDir: false,
+        isFile: false
+      }
+    });
+    await cpStub(localNotEmptyPath, dstPath, recursive, noClobber, localNasTmpDir, tpl, baseDir, isSync);
+    const actualDst = resolvedDst;
+    assert.calledWith(request.statsRequest, resolvedDst, nasHttpTriggerPath);
+    assert.calledWith(init.deployNasService, baseDir, tpl, mockdata.serviceName);
+    assert.calledWith(upload.uploadFolder, localNotEmptyPath, actualDst, nasHttpTriggerPath, localNasTmpDir, noClobber);
+    assert.notCalled(upload.uploadFile);
+  });
 });

--- a/test/nas/cp/file.test.js
+++ b/test/nas/cp/file.test.js
@@ -22,14 +22,6 @@ describe('function zipWithArchiver test', () => {
   let inputPath = path.join(os.tmpdir(), '.zip-test', '/');
   const localNasTmpDir = path.join(os.tmpdir(), '.nasTmp', '/');
 
-  let tmpInputPath = path.dirname(inputPath);
-  if (tmpInputPath.indexOf(':\\') !== -1) {
-    const pos = tmpInputPath.indexOf(':\\');
-    tmpInputPath = tmpInputPath.substr(0, pos) + tmpInputPath.substr(pos + 1, tmpInputPath.length);
-  }
-
-  const zipDir = path.join(localNasTmpDir, tmpInputPath);
-  const zipDst = path.join(zipDir, `.fun-nas-generated-${path.basename(inputPath)}.zip`);
   let fsExists;
   beforeEach(async () => {
     fsExists = sandbox.spy(fsExtra, 'exists');
@@ -46,11 +38,8 @@ describe('function zipWithArchiver test', () => {
     
   it('test zip file exist', async () => {
     
-    let res = await file.zipWithArchiver(inputPath, localNasTmpDir);
+    await file.zipWithArchiver(inputPath, localNasTmpDir);
     assert.calledWith(fsExists, inputPath);
-    
-    expect(res).to.eql(zipDst);
-
   });
 
   it('zip file not exist test', async () => {

--- a/test/nas/cp/upload.test.js
+++ b/test/nas/cp/upload.test.js
@@ -6,52 +6,45 @@ const fs = require('fs');
 
 const mkdirp = require('mkdirp-promise');
 const rimraf = require('rimraf');
-const mockdata = require('../../commands/nas/mock-data');
+const expect = require('expect.js');
 const writeFile = util.promisify(fs.writeFile);
 const { getFileHash } = require('../../../lib/nas/cp/file');
+const { readDirRecursive } = require('../../../lib/nas/path');
+const constants = require('../../../lib/nas/constants');
+const { chunk } = require('../../../lib/nas/support');
 const path = require('path');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const sandbox = sinon.createSandbox();
 const assert = sinon.assert;
 
+const dstPath = path.posix.join('/', 'mnt', 'nas');
+const nasHttpTriggerPath = '/proxy/';
+const noClobber = true;
+const request = {
+  sendUnzipRequest: sandbox.stub(),
+  sendCleanRequest: sandbox.stub(), 
+  createSizedNasFile: sandbox.stub(), 
+  uploadChunkFile: sandbox.stub(),
+  checkFileHash: sandbox.stub(), 
+  checkRemoteNasTmpDir: sandbox.stub()
+};
 
-describe('upload test', () => {
-  const srcPath = path.join(os.tmpdir(), 'local-nas-dir', '/');
-  const dstPath = path.posix.join('/', 'mnt', 'nas');
-  const nasHttpTriggerPath = '/proxy/';
-  const zipFilePath = path.join(path.dirname(srcPath), `.fun-nas-generated-${path.basename(srcPath)}.zip`);
-  const fileName = path.basename(zipFilePath);
+const uploadStub = proxyquire('../../../lib/nas/cp/upload', {
+  '../request': request
+});
+
+describe('upload folder test', () => {
+  const srcPath = path.join(os.tmpdir(), '.upload-folder-local-nas-dir');
+  const localNasTmpDir = path.join(os.tmpdir(), '.upload-folder-nas-tmp');
+  const zipFileName = `.fun-nas-generated-${path.basename(srcPath)}.zip`;
   const remoteNasTmpDir = path.posix.join(dstPath, '.fun_nas_tmp');
-  const nasZipFile = path.posix.join(remoteNasTmpDir, fileName);
-  const zipFileSize = 10 * 1024 * 1024;
-  const localNasTmpDir = 'nastmp';
+  const nasZipFile = path.posix.join(remoteNasTmpDir, zipFileName);
   const srcPathFile = path.join(srcPath, 'test-file');
-  let request;
-  let file;
-  let uploadStub;
-  let zipHash;
-  request = {
-    statsRequest: sandbox.stub(),
-    sendUnzipRequest: sandbox.stub(),
-    sendCleanRequest: sandbox.stub(),
-    createSizedNasFile: sandbox.stub(),
-    uploadChunkFile: sandbox.stub(),
-    checkFileHash: sandbox.stub(), 
-    checkRemoteNasTmpDir: sandbox.stub()
-  };
   
-  file = {
-    zipWithArchiver: sandbox.stub()
-  };
-  
-  uploadStub = proxyquire('../../../lib/nas/cp/upload', {
-    '../request': request, 
-    './file': file
-  });
-
   beforeEach(async () => {
     await mkdirp(srcPath);
+    await mkdirp(localNasTmpDir);
     await writeFile(srcPathFile, 'this is a test');
 
     request.createSizedNasFile.returns({
@@ -75,19 +68,6 @@ describe('upload test', () => {
       }
     });
 
-    request.statsRequest.returns({
-      headers: 200, 
-      data: {
-        path: '/mnt/nas',
-        isExist: true,
-        isDir: true,
-        isFile: false, 
-        UserId: 100, 
-        GroupId: 100, 
-        mode: 123
-      }
-    });
-
     request.sendUnzipRequest.returns({
       stdout: 'test',
       stderr: ''
@@ -98,28 +78,71 @@ describe('upload test', () => {
     request.checkRemoteNasTmpDir.returns({
       desc: 'check tmpDir done!'
     });
-    file.zipWithArchiver.returns(zipFilePath);
+    
   });
 
   afterEach(() => {
     sandbox.reset();
     rimraf.sync(srcPath);
+    rimraf.sync(localNasTmpDir);
   });
-
-  it('upload file', async() => { 
-    await writeFile(zipFilePath, Buffer.alloc(zipFileSize));
-    zipHash = await getFileHash(zipFilePath);
-    await uploadStub(srcPath, dstPath, nasHttpTriggerPath, true, localNasTmpDir, mockdata.nasId);
-
-    assert.calledWith(request.statsRequest, dstPath, nasHttpTriggerPath);
+  it('upload test', async() => {
+    await uploadStub.uploadFolder(srcPath, dstPath, nasHttpTriggerPath, localNasTmpDir, noClobber);
+    const subDirs = fs.readdirSync(localNasTmpDir);
+    expect(subDirs.length).to.eql(1);
+    const srcPathFiles = await readDirRecursive(srcPath);
     
-    assert.calledWith(file.zipWithArchiver, srcPath, localNasTmpDir);
-    assert.calledWith(request.createSizedNasFile, nasHttpTriggerPath, nasZipFile, zipFileSize);
-    assert.calledTwice(request.uploadChunkFile);
-    assert.calledWith(request.checkFileHash, nasHttpTriggerPath, nasZipFile, zipHash);
+    const filesArrSlicedBySize = chunk(srcPathFiles, constants.FUN_NAS_FILE_COUNT_PER_REQUEST);
+  
+    assert.calledOnce(request.createSizedNasFile);
+    assert.calledOnce(request.uploadChunkFile);
+    assert.calledOnce(request.checkFileHash);
 
-    assert.calledWith(request.sendUnzipRequest, nasHttpTriggerPath, dstPath, nasZipFile, ['test-file']);
+    assert.calledWith(request.sendUnzipRequest, nasHttpTriggerPath, dstPath, nasZipFile, filesArrSlicedBySize[0], noClobber);
     assert.calledWith(request.sendCleanRequest, nasHttpTriggerPath, nasZipFile);
     assert.calledWith(request.checkRemoteNasTmpDir, nasHttpTriggerPath, remoteNasTmpDir);
+  });
+});
+describe('upload file test', () => {
+  const srcPath = path.join(os.tmpdir(), '.upload-file-local-nas-dir');
+  const srcPathFile = path.join(srcPath, 'test-file');
+  const fileSize = 2 * constants.FUN_NAS_CHUNK_SIZE;
+  let fileHash;
+  beforeEach(async() => {
+    await mkdirp(srcPath);
+    await writeFile(srcPathFile, Buffer.alloc(fileSize));
+    fileHash = await getFileHash(srcPathFile);
+    request.createSizedNasFile.returns({
+      headers: 200,
+      data: {
+        stdout: 'stdout',
+        stderr: ''
+      }
+    });
+    request.uploadChunkFile.returns({
+      headers: 200,
+      data: {
+        desc: 'chunk file write done'
+      }
+    });
+    request.checkFileHash.returns({
+      headers: 200, 
+      data: {
+        stat: 1, 
+        desc: 'File saved'
+      }
+    });
+  });
+  afterEach(() => {
+    sandbox.reset();
+    rimraf.sync(srcPath);
+  });
+
+  it('upload test', async() => {
+    await uploadStub.uploadFile(srcPathFile, dstPath, nasHttpTriggerPath);
+    
+    assert.calledWith(request.createSizedNasFile, nasHttpTriggerPath, dstPath, fileSize);
+    assert.calledTwice(request.uploadChunkFile);
+    assert.calledWith(request.checkFileHash, nasHttpTriggerPath, dstPath, fileHash);
   });
 });

--- a/test/nas/init.test.js
+++ b/test/nas/init.test.js
@@ -49,7 +49,7 @@ describe('test fun nas init', () => {
       headers: 200, 
       data: {
         path: '/mnt/nas',
-        isExist: true,
+        exists: true,
         isDir: true,
         isFile: false, 
         UserId: 100, 

--- a/test/nas/rm.test.js
+++ b/test/nas/rm.test.js
@@ -32,7 +32,7 @@ describe('ls test', () => {
       headers: 200, 
       data: {
         path: '/mnt/nas',
-        isExist: true,
+        exists: true,
         isDir: true,
         isFile: false, 
         UserId: 100, 


### PR DESCRIPTION
**1. 实现 fun nas cp 从本地到远端 NAS 的文件/文件夹传输
2. fun nas sync/cp 的本地临时目录结构调整，改为使用时间戳作为临时目录
3. 测试后续补上
4. 交互效果**
  

- **传输文件**
```
$ fun nas cp test.js nas:///mnt/auto/10M.file
using template: template.yml

start fun nas init...
checking if _FUN_NAS_hello-world needs to be deployed...
skip deploying _FUN_NAS_hello-world, which has been deployed
fun nas init Success

src path checking...
dst path checking...
Creating 3934 bytes size file: /mnt/auto/10M.file
✔ create done
✔ upload done
checking uploaded file hash
✔ hash unchanged
✔ upload completed!
```

- **传输目录**
```
$ fun nas cp tmp-dir -r nas:///mnt/auto/
using template: template.yml

start fun nas init...
checking if _FUN_NAS_hello-world needs to be deployed...
skip deploying _FUN_NAS_hello-world, which has been deployed
fun nas init Success

src path checking...
dst path checking...
zipping C:\Users\zqf-pc\Documents\fcProj\hello-world\tmp-dir
✔ C:\Users\zqf-pc\Documents\fcProj\hello-world\.fun\tmp\nas\cp\1571660468013\.fun-nas-generated-tmp-dir.zip - zipped
checking NAS tmp dir
✔ check done
Creating 11743588 bytes size file: /mnt/auto/tmp-dir/.fun_nas_tmp/.fun-nas-generated-tmp-dir.zip
✔ create done
✔ upload done
checking uploaded NAS zip file hash
✔ hash unchanged
unzipping file

✔ unzip done
cleaning
✔ clean done
✔ upload completed!
```
