### PR TITLE
fix fun nas sync -s -m problem

### DIFF
--- a/lib/commands/nas/sync.js
+++ b/lib/commands/nas/sync.js
@@ -31,7 +31,7 @@ async function sync(options) {
   const nasBaseDir = detectNasBaseDir(tplPath);
   const serviceNasMappings = await nas.convertTplToServiceNasMappings(nasBaseDir, tpl);
   
-  if (service) {
+  if (service && mountedDirs) {
     const nasMappings = serviceNasMappings[service];
     const configuredMountDirs = _.map(nasMappings, (mapping) => mapping.remoteNasDir);
     const toUnmountDirs = toBeUmountedDirs(configuredMountDirs, mountedDirs);

--- a/lib/nas.js
+++ b/lib/nas.js
@@ -320,8 +320,12 @@ function convertTplToServiceNasIdMappings(tpl) {
 
   for (const { serviceName, serviceRes } of definition.findServices(tpl.Resources)) {    
     const nasConfig = (serviceRes.Properties || {}).NasConfig;
-
-    const nasId = getNasIdFromNasConfig(nasConfig);
+    var nasId;
+    if (nasConfig === undefined) {
+      nasId = {};
+    } else {
+      nasId = getNasIdFromNasConfig(nasConfig);
+    }
 
     serviceNasIdMappings[serviceName] = nasId;
   }

--- a/test/commands/nas/mock-data.js
+++ b/test/commands/nas/mock-data.js
@@ -32,6 +32,19 @@ const tpl = {
     }
   }
 };
+const tplWithoutNasConfig = {
+  ROSTemplateFormatVersion: '2015-09-01',
+  Transform: 'Aliyun::Serverless-2018-04-03',
+  Resources: {
+    [serviceName]: {
+      Type: 'Aliyun::Serverless::Service',
+      Properties: {
+        Policies: policies, 
+        VpcConfig: vpcConfig
+      }
+    }
+  }
+};
 const nasId = 
 {
   UserId: 1000,
@@ -42,5 +55,6 @@ module.exports = {
   tpl, 
   vpcConfig, 
   serviceName, 
-  nasId
+  nasId, 
+  tplWithoutNasConfig
 };

--- a/test/nas.test.js
+++ b/test/nas.test.js
@@ -609,6 +609,11 @@ describe('test convertTplToServiceNasIdMappings', () => {
     });
   });
 
+  it('tpl without NasConfig', () => {
+    const res = nas.convertTplToServiceNasIdMappings(mockdata.tplWithoutNasConfig);
+    expect(res).to.eql({[mockdata.serviceName]: {}});
+  });
+
   it('empty tpl resource', () => {
     const tpl = {
       ROSTemplateFormatVersion: '2015-09-01',


### PR DESCRIPTION
修复 fun nas sync 以下两个问题：

1. fun nas sync -s service 时出现 "filter of undefined" 报错问题

2. 当 template.yml 中存在多个 service 时候且部分 service 没有 NasConfig 的情况下，执行 fun nas sync 或者 fun nas sync -s service 时出现 "UserId if undefined" 问题解决