### PR TITLE
ellison/add-partial-deploy-after-fun-nas-cp

### DIFF
--- a/bin/fun-nas-cp.js
+++ b/bin/fun-nas-cp.js
@@ -8,12 +8,20 @@ const program = require('commander');
 const getVisitor = require('../lib/visitor').getVisitor;
 const notifier = require('../lib/update-notifier');
 
+let srcPath;
+let dstPath;
+
 program
   .name('fun nas cp')
   .description('Copy file/folder between remote NAS and local path.')
   .usage('[options] <src_path> <dst_path>')
   .option('-r, --recursive', 'copy folders recursively')
   .option('-n, --no-clobber', 'Do not overwrite an existing file')
+  .arguments("<srcPath> <dstPath>")
+  .action((srcPathValue, dstPathValue) => {
+    srcPath = dstPathValue;
+    dstPath = srcPathValue;
+  })
   .parse(process.argv);
 
 if (program.args.length < 2) {
@@ -31,7 +39,7 @@ notifier.notify();
 getVisitor(true).then((visitor) => {
   visitor.pageview('/fun/nas/cp').send();
 
-  require('../lib/commands/nas/cp')(program.args[0], program.args[1], program)
+  require('../lib/commands/nas/cp')(srcPath, dstPath, program)
     .then(() => {
       visitor.event({
         ec: 'cp',
@@ -50,5 +58,4 @@ getVisitor(true).then((visitor) => {
 
       require('../lib/exception-handler')(error);
     });
-    
 });

--- a/bin/fun-nas-cp.js
+++ b/bin/fun-nas-cp.js
@@ -17,10 +17,11 @@ program
   .usage('[options] <src_path> <dst_path>')
   .option('-r, --recursive', 'copy folders recursively')
   .option('-n, --no-clobber', 'Do not overwrite an existing file')
-  .arguments("<srcPath> <dstPath>")
+  .arguments("<srcPathValue> <dstPathValue>")
   .action((srcPathValue, dstPathValue) => {
-    srcPath = dstPathValue;
-    dstPath = srcPathValue;
+
+    srcPath = srcPathValue;
+    dstPath = dstPathValue;
   })
   .parse(process.argv);
 

--- a/lib/commands/nas/cp.js
+++ b/lib/commands/nas/cp.js
@@ -7,6 +7,7 @@ const path = require('path');
 const { red } = require('colors');
 
 async function cp(srcPath, dstPath, options) {
+
   const tplPath = await detectTplPath(false);
 
   if (!tplPath) {

--- a/lib/deploy/deploy-by-tpl.js
+++ b/lib/deploy/deploy-by-tpl.js
@@ -495,10 +495,7 @@ async function deployApigateway(name, { apiDefinition, template, tplPath }) {
   }
 }
 
-async function partialDeployment(context, tpl) {
-
-  const resourceName = context.resourceName;
-
+async function partialDeployment(resourceName, tpl) {
   if (!resourceName) { return {}; }
 
   let serviceName;
@@ -528,33 +525,15 @@ async function partialDeployment(context, tpl) {
   return { serviceName, serviceRes };
 }
 
-function replaceServiceforSources(resources, serviceName, serviceRes) {
-
-  let unMatchFuncArray = [];
-
-  for (const [name, resource] of Object.entries(resources)) {
-
-    if (resource.Type === 'Aliyun::Serverless::Service' && name !== serviceName) {
-
-      unMatchFuncArray.push(name);
-    }
-  }
-
-  resources = _.omit(resources, unMatchFuncArray);
-  resources[serviceName] = serviceRes;
-
-  return resources;
-}
-
 async function deployByApi(baseDir, tpl, tplPath, context) {
-  await deployLogs(tpl.Resources);
-
-  const { serviceName, serviceRes } = await partialDeployment(context, tpl);
+  const { serviceName, serviceRes } = await partialDeployment(context.resourceName, tpl);
 
   if (serviceName) {
-
-    tpl.Resources = replaceServiceforSources(tpl.Resources, serviceName, serviceRes);
+    await deployService(baseDir, serviceName, serviceRes, context.onlyConfig, tplPath);
+    return;
   }
+
+  await deployLogs(tpl.Resources);
 
   for (const [name, resource] of Object.entries(tpl.Resources)) {
     if (resource.Type === 'Aliyun::Serverless::Service') {
@@ -636,5 +615,5 @@ async function deploy(tplPath, context) {
 
 module.exports = {
   deploy, deployCustomDomain,
-  partialDeployment, deployService
+  partialDeployment, deployService, deployByApi
 };

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -385,7 +385,7 @@ async function nasAutomationConfigurationIfNecessary({
   codeUri
 }) {
   if (compressedSize > 52428800 && _.includes(NODE_RUNTIME, runtime)) { // 50M
-    console.log(red('\nFun detected that your function dependency exceed 50M. It is recommended that using the nas service to manage your function dependencies.'));
+    console.log(red(`\nFun detected that your function ${nasServiceName}/${nasFunctionName} sizes exceed 50M. It is recommended that using the nas service to manage your function dependencies.`));
     if (await promptForConfirmContinue(`Do you want to let fun to help you automate the configuration?`)) {
       if (definition.isNasAutoConfig(nasConfig)) {
         const yes = await promptForConfirmContinue(`You have already configured 'NasConfig: Auto’. We want to use this configuration to store your function dependencies.`);

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -352,11 +352,16 @@ async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtim
 
   const nasMappingsObj = await saveNasMappings(baseDir, nasMappings);
 
-  await updateEnvironmentInTpl(tplPath, tpl, nasFunctionName, envs);
+  const updatedTpl = await updateEnvironmentInTpl(tplPath, tpl, nasFunctionName, envs);
   // fun nas cp
   await nasCpFromlocalNasDirToremoteNasDir(tpl, tplPath, baseDir, nasServiceName, nasMappingsObj[nasServiceName]);
-  // TODO fun deploy
-  console.log(yellow(`\nFun has automatically uploaded your code dependency to NAS, please re execute ‘fun deploy’.`));
+
+  console.log(yellow(`\nFun has automatically uploaded your code dependency to NAS, then fun will use 'fun deploy ${nasServiceName}/${nasFunctionName}' to redeploy.`));
+
+  // todo 追溯用户自动化部署前的行为。
+  await require('./deploy/deploy-by-tpl').deployByApi(baseDir, updatedTpl, tplPath, {
+    resourceName: `${nasServiceName}/${nasFunctionName}`
+  });
 }
 
 async function backupTemplateFile(tplPath) {

--- a/test/deploy/deploy-by-tpl.test.js
+++ b/test/deploy/deploy-by-tpl.test.js
@@ -1302,9 +1302,7 @@ describe('custom domain', () => {
 
 
 describe('test partical deploy', () => {
-  
   beforeEach(() => {
-
     Object.keys(prompt).forEach(m => {
       if (m === 'promptForSameFunction') {
         sandbox.stub(prompt, m).resolves({
@@ -1324,9 +1322,7 @@ describe('test partical deploy', () => {
   async function partialDeployment(sourceName, tpl) {
     return await proxyquire('../../lib/deploy/deploy-by-tpl', {
       '../../lib/init/prompt': prompt
-    }).partialDeployment({
-      resourceName: sourceName
-    }, tpl);
+    }).partialDeployment(sourceName, tpl);
   }
 
   it('single functionName', async () => {


### PR DESCRIPTION
1.fun nas cp 后自动调用 fun deploy s/f ，使得自动化部署完成后，能正确的识别到 系统依赖以及语言依赖
2. 修复原 fun deploy 局部部署的行为
     原行为：会部署其他非 service 资源。
3.  修复 fun nas cp 时参数顺序问题。