### PR TITLE
ellison/non nas-auto support for automatic configuration

### DIFF
--- a/lib/definition.js
+++ b/lib/definition.js
@@ -413,11 +413,19 @@ function isVpcAutoConfig(vpcConfig) {
   return false;
 }
 
+// except Auto
+function onlyOneNASExists(nasConfig) {
+  if (_.isEmpty(nasConfig || nasConfig === 'Auto')) { return false; }
+  const mountPoints = nasConfig.MountPoints || [];
+  return mountPoints.length === 1;
+}
+
 module.exports = {
   findFunctionInTpl, findHttpTriggersInTpl,
   findFunctionsInTpl, findNasConfigInService,
   findHttpTriggersInFunction, findServices,
   findFunctions, findFirstFunctionName, matchingFuntionUnderServiceBySourceName,
   findServiceByCertainServiceAndFunctionName, deleteUnmatchFunctionsUnderServiceRes,
-  isNasAutoConfig, isVpcAutoConfig, parseFunctionPath, iterateFunctions, parseDomainRoutePath
+  isNasAutoConfig, isVpcAutoConfig, parseFunctionPath, iterateFunctions, parseDomainRoutePath,
+  onlyOneNASExists
 };

--- a/lib/deploy/deploy-by-tpl.js
+++ b/lib/deploy/deploy-by-tpl.js
@@ -109,7 +109,7 @@ async function deployFunction(baseDir, serviceName, functionName, functionRes, n
     environmentVariables: properties.EnvironmentVariables,
     nasConfig,
     vpcConfig
-  }, onlyConfig, tplPath);
+  }, onlyConfig, tplPath, properties);
   await deployTriggers(serviceName, functionName, functionRes.Events);
 }
 

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -245,35 +245,40 @@ async function generateNasMappingsAndEnvs({
   baseDir,
   serviceName,
   runtime,
-  codeUri
+  codeUri,
+  nasConfig
 }) {
   const envs = {};
 
   const nasMappings = {};
   const nasMapping = [];
+
+  const prefix = getRemoteNasDirPrefix(nasConfig);
   // used for log
   const nasMappingPath = path.resolve(baseDir, NAS_MAPPING_PATH);
   const localSystemDependency = path.resolve(codeUri, SYSTEM_DEPENDENCY_PATH);
 
   if (await fs.pathExists(localSystemDependency)) { // system dependence
+    const remoteNasDir = `${prefix}root`;
 
     nasMapping.push({
       localNasDir: localSystemDependency,
-      remoteNasDir: `/mnt/auto/root`
+      remoteNasDir
     });
 
     nasMappings[serviceName] = nasMapping;
 
-    Object.assign(envs, generateSystemNasEnvs());
+    Object.assign(envs, generateSystemNasEnvs(remoteNasDir));
 
     outputNasMappingLog(baseDir, nasMappingPath, localSystemDependency);
   }
+
   const languageDependencyDirName = runtimeDependency[runtime];
   const localDependencyPath = path.join(codeUri, languageDependencyDirName);
 
   if (await fs.pathExists(localDependencyPath)) { // language dependence
+    const remoteNasDir = `${prefix}${languageDependencyDirName}`;
 
-    const remoteNasDir = `/mnt/auto/${languageDependencyDirName}`;
     nasMapping.push({
       localNasDir: localDependencyPath,
       remoteNasDir
@@ -291,13 +296,24 @@ async function generateNasMappingsAndEnvs({
   };
 }
 
+function getRemoteNasDirPrefix(nasConfig) {
+  if (definition.isNasAutoConfig(nasConfig)) {
+    return '/mnt/auto/';
+  }
+  const mountPoint = _.head(nasConfig.MountPoints);
+
+  if (_.endsWith(mountPoint.MountDir, '/')) {
+    return mountPoint.MountDir;
+  }
+  return mountPoint.MountDir + '/';
+}
+
 // node_modules has been correctly added to /Users/ellison/fun/examples/datahub/.fun/nasMappings.json.
 function outputNasMappingLog(baseDir, nasMappingPath, localNasDir) {
   console.log(green(`${path.relative(baseDir, localNasDir)} has been correctly added to ${nasMappingPath}`));
 }
 
-function generateSystemNasEnvs() {
-  const rootEnvPrefix = '/mnt/auto/root';
+function generateSystemNasEnvs(rootEnvPrefix) {
   return {
     'LD_LIBRARY_PATH': `${rootEnvPrefix}/usr/lib:${rootEnvPrefix}/usr/lib/x86_64-linux-gnu`
   };
@@ -310,7 +326,7 @@ function generateLanguageNasEnvs(languageEnv) {
   };
 }
 
-async function nasCpFromlocalNasDirToremoteNasDir(tpl, tplPath, baseDir, nasServiceName, nasMappings) {
+async function nasCpFromlocalNasDirToRemoteNasDir(tpl, tplPath, baseDir, nasServiceName, nasMappings) {
   const localNasTmpDir = path.join(baseDir, '.fun', 'tmp', 'nas', 'cp');
 
   const errors = [];
@@ -335,7 +351,7 @@ async function nasCpFromlocalNasDirToremoteNasDir(tpl, tplPath, baseDir, nasServ
   }
 }
 
-async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri,
+async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri, nasConfig,
   nasServiceName,
   nasFunctionName
 }) {
@@ -347,14 +363,15 @@ async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtim
     baseDir,
     serviceName: nasServiceName,
     runtime,
-    codeUri
+    codeUri,
+    nasConfig
   });
 
   const nasMappingsObj = await saveNasMappings(baseDir, nasMappings);
 
   const updatedTpl = await updateEnvironmentInTpl(tplPath, tpl, nasFunctionName, envs);
   // fun nas cp
-  await nasCpFromlocalNasDirToremoteNasDir(tpl, tplPath, baseDir, nasServiceName, nasMappingsObj[nasServiceName]);
+  await nasCpFromlocalNasDirToRemoteNasDir(tpl, tplPath, baseDir, nasServiceName, nasMappingsObj[nasServiceName]);
 
   console.log(yellow(`\nFun has automatically uploaded your code dependency to NAS, then fun will use 'fun deploy ${nasServiceName}/${nasFunctionName}' to redeploy.`));
 
@@ -378,22 +395,46 @@ async function nasAutomationConfigurationIfNecessary({
   nasConfig,
   vpcConfig,
   nasServiceName,
-  tpl,
   tplPath,
   runtime,
   baseDir,
   codeUri
 }) {
+  let stop = false;
+
   if (compressedSize > 52428800 && _.includes(NODE_RUNTIME, runtime)) { // 50M
     console.log(red(`\nFun detected that your function ${nasServiceName}/${nasFunctionName} sizes exceed 50M. It is recommended that using the nas service to manage your function dependencies.`));
+
     if (await promptForConfirmContinue(`Do you want to let fun to help you automate the configuration?`)) {
+      const tpl = await getTpl(tplPath);
+      const onlyOneNas = definition.onlyOneNASExists(nasConfig);
+
       if (definition.isNasAutoConfig(nasConfig)) {
         const yes = await promptForConfirmContinue(`You have already configured 'NasConfig: Auto’. We want to use this configuration to store your function dependencies.`);
         if (yes) {
-          await processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri,
+          await processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri, nasConfig,
             nasServiceName,
             nasFunctionName
           });
+          stop = true;
+        }
+      } else if (!_.isEmpty(vpcConfig) && _.isEmpty(nasConfig)) {
+
+        console.log(red(`Fun has detected that you only have VPC configuration. This scenario is not supported at this time. You also need to manually configure the NAS service. You can refer to: https://github.com/alibaba/funcraft/blob/master/docs/specs/2018-04-03-zh-cn.md#nas-%E9%85%8D%E7%BD%AE%E5%AF%B9%E8%B1%A1 and https://nas.console.aliyun.com/`));
+      } else if (!_.isEmpty(vpcConfig) && !_.isEmpty(nasConfig)) {
+        if (onlyOneNas) {
+          const yes = await promptForConfirmContinue(`We have detected that you already have a NAS configuration. Do you directly use this NAS storage function dependencies.`);
+          if (yes) {
+
+            await processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri, nasConfig,
+              nasServiceName,
+              nasFunctionName
+            });
+            stop = true;
+          }
+        } else {
+          // 多个 NAS 配置 暂不支持
+          console.log(red('\nIt is detected that the configuration of multiple NAS is in your template.yml. Currently, fun does not support the automatic storage code dependencies of multiple NAS configurations. If you have any demand, please submit issue https://github.com/alibaba/funcraft/issues or add DingDing at 11721331'));
         }
       } else if (_.isEmpty(vpcConfig) && _.isEmpty(nasConfig)) {
         const yes = await promptForConfirmContinue(`We recommend using the 'NasConfig: Auto' configuration to manage your function dependencies.`);
@@ -404,13 +445,14 @@ async function nasAutomationConfigurationIfNecessary({
             nasServiceName,
             nasFunctionName
           });
+          stop = true;
         } else {
           console.log(red('\nYou need to handle function dependencies manually to reduce the size of the package. It is recommended that you use OSS or NAS.'));
         }
       }
     }
-    throw new Error(' ');
   }
+  return stop;
 }
 
 async function makeFunction(baseDir, {
@@ -453,12 +495,13 @@ async function makeFunction(baseDir, {
       console.log(`\t\tWaiting for packaging function ${functionName} code...`);
       const { base64, count, compressedSize } = await zipCode(baseDir, codeUri, runtime, functionName);
 
-      const tpl = await getTpl(tplPath);
-      await nasAutomationConfigurationIfNecessary({ compressedSize, tpl, tplPath, baseDir, runtime, nasConfig, vpcConfig,
+      const stop = await nasAutomationConfigurationIfNecessary({ compressedSize, tplPath, baseDir, runtime, nasConfig, vpcConfig,
         nasFunctionName: functionName,
         nasServiceName: serviceName,
         codeUri: path.resolve(baseDir, codeUri)
       });
+
+      if (stop) { return; }
 
       const convertedSize = bytes(compressedSize, {
         unitSeparator: ' '

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -376,6 +376,10 @@ async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtim
 
   console.log(yellow(`\nFun has automatically uploaded your code dependency to NAS, then fun will use 'fun deploy ${nasServiceName}/${nasFunctionName}' to redeploy.`));
 
+  console.log(`Waiting for service ${nasServiceName} to be deployed...`);
+
+  console.log(`\tWaiting for function ${nasFunctionName} to be deployed...`);
+
   await makeFunction(baseDir, {
     serviceName: nasServiceName,
     functionName: nasFunctionName,

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -351,7 +351,8 @@ async function nasCpFromlocalNasDirToRemoteNasDir(tpl, tplPath, baseDir, nasServ
   }
 }
 
-async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri, nasConfig,
+async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri, nasConfig, vpcConfig,
+  functionProp,
   nasServiceName,
   nasFunctionName
 }) {
@@ -369,16 +370,27 @@ async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtim
 
   const nasMappingsObj = await saveNasMappings(baseDir, nasMappings);
 
-  const updatedTpl = await updateEnvironmentInTpl(tplPath, tpl, nasFunctionName, envs);
+  await updateEnvironmentInTpl(tplPath, tpl, nasFunctionName, envs);
   // fun nas cp
   await nasCpFromlocalNasDirToRemoteNasDir(tpl, tplPath, baseDir, nasServiceName, nasMappingsObj[nasServiceName]);
 
   console.log(yellow(`\nFun has automatically uploaded your code dependency to NAS, then fun will use 'fun deploy ${nasServiceName}/${nasFunctionName}' to redeploy.`));
 
-  // todo 追溯用户自动化部署前的行为。
-  await require('./deploy/deploy-by-tpl').deployByApi(baseDir, updatedTpl, tplPath, {
-    resourceName: `${nasServiceName}/${nasFunctionName}`
-  });
+  await makeFunction(baseDir, {
+    serviceName: nasServiceName,
+    functionName: nasFunctionName,
+    description: functionProp.Description,
+    handler: functionProp.Handler,
+    initializer: functionProp.Initializer,
+    timeout: functionProp.Timeout,
+    initializationTimeout: functionProp.InitializationTimeout,
+    memorySize: functionProp.MemorySize,
+    runtime: functionProp.Runtime,
+    codeUri: functionProp.CodeUri,
+    environmentVariables: functionProp.EnvironmentVariables,
+    nasConfig,
+    vpcConfig
+  }, false, tplPath);
 }
 
 async function backupTemplateFile(tplPath) {
@@ -398,7 +410,8 @@ async function nasAutomationConfigurationIfNecessary({
   tplPath,
   runtime,
   baseDir,
-  codeUri
+  codeUri,
+  functionProp
 }) {
   let stop = false;
 
@@ -412,43 +425,42 @@ async function nasAutomationConfigurationIfNecessary({
       if (definition.isNasAutoConfig(nasConfig)) {
         const yes = await promptForConfirmContinue(`You have already configured 'NasConfig: Auto’. We want to use this configuration to store your function dependencies.`);
         if (yes) {
-          await processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri, nasConfig,
+          await processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri, nasConfig, vpcConfig,
+            functionProp,
             nasServiceName,
             nasFunctionName
           });
           stop = true;
-        }
+        } else { throw new Error(red(`\nIf 'NasConfig: Auto' is configured, only the configuration store function dependency is currently supported.`)); }
       } else if (!_.isEmpty(vpcConfig) && _.isEmpty(nasConfig)) {
 
-        console.log(red(`Fun has detected that you only have VPC configuration. This scenario is not supported at this time. You also need to manually configure the NAS service. You can refer to: https://github.com/alibaba/funcraft/blob/master/docs/specs/2018-04-03-zh-cn.md#nas-%E9%85%8D%E7%BD%AE%E5%AF%B9%E8%B1%A1 and https://nas.console.aliyun.com/`));
+        throw new Error(red(`\nFun has detected that you only have VPC configuration. This scenario is not supported at this time. You also need to manually configure the NAS service. You can refer to: https://github.com/alibaba/funcraft/blob/master/docs/specs/2018-04-03-zh-cn.md#nas-%E9%85%8D%E7%BD%AE%E5%AF%B9%E8%B1%A1 and https://nas.console.aliyun.com/`));
       } else if (!_.isEmpty(vpcConfig) && !_.isEmpty(nasConfig)) {
         if (onlyOneNas) {
           const yes = await promptForConfirmContinue(`We have detected that you already have a NAS configuration. Do you directly use this NAS storage function dependencies.`);
           if (yes) {
-
-            await processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri, nasConfig,
+            await processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtime, codeUri, nasConfig, functionProp,
               nasServiceName,
               nasFunctionName
             });
             stop = true;
-          }
+          } else { throw new Error(red('\nYou need to handle function dependencies manually to reduce the size of the package. It is recommended that you use OSS or NAS.')); }
+
         } else {
-          // 多个 NAS 配置 暂不支持
-          console.log(red('\nIt is detected that the configuration of multiple NAS is in your template.yml. Currently, fun does not support the automatic storage code dependencies of multiple NAS configurations. If you have any demand, please submit issue https://github.com/alibaba/funcraft/issues or add DingDing at 11721331'));
+          // 当前不支持配置了多个 NAS 的场景
+          throw new Error(red('\nCurrently, scenarios with multiple NAS configurations are not supported.\nIf you have any demand, please submit issue https://github.com/alibaba/funcraft/issues or add DingDing at 11721331.'));
         }
       } else if (_.isEmpty(vpcConfig) && _.isEmpty(nasConfig)) {
         const yes = await promptForConfirmContinue(`We recommend using the 'NasConfig: Auto' configuration to manage your function dependencies.`);
         if (yes) {
           // write back to yml
           const updatedTpl = updateNasAutoConfigureInTpl(tplPath, tpl, nasServiceName);
-          await processNasAutomationConfiguration({ tpl: updatedTpl, tplPath, baseDir, runtime, codeUri,
+          await processNasAutomationConfiguration({ tpl: updatedTpl, tplPath, baseDir, runtime, codeUri, functionProp,
             nasServiceName,
             nasFunctionName
           });
           stop = true;
-        } else {
-          console.log(red('\nYou need to handle function dependencies manually to reduce the size of the package. It is recommended that you use OSS or NAS.'));
-        }
+        } else { throw new Error(red(`\nYou need to handle function dependencies manually to reduce the size of the package. It is recommended that you use OSS or NAS.`)); }
       }
     }
   }
@@ -469,7 +481,7 @@ async function makeFunction(baseDir, {
   environmentVariables = {},
   nasConfig,
   vpcConfig
-}, onlyConfig, tplPath) {
+}, onlyConfig, tplPath, functionProp) {
   const fc = await getFcClient();
 
   var fn;
@@ -498,7 +510,8 @@ async function makeFunction(baseDir, {
       const stop = await nasAutomationConfigurationIfNecessary({ compressedSize, tplPath, baseDir, runtime, nasConfig, vpcConfig,
         nasFunctionName: functionName,
         nasServiceName: serviceName,
-        codeUri: path.resolve(baseDir, codeUri)
+        codeUri: path.resolve(baseDir, codeUri),
+        functionProp
       });
 
       if (stop) { return; }
@@ -582,7 +595,7 @@ async function makeService({
 
         if (ex.message.indexOf('the caller is not authorized to perform') !== -1) {
 
-          console.error(red(`\nMaybe you need grant AliyunRAMFullAccess policy to the subuser or use the primary account. You can refer to Chinese doc https://github.com/aliyun/fun/blob/master/docs/usage/faq-zh.md#nopermissionerror-you-are-not-authorized-to-do-this-action-resource-acsramxxxxxxxxxxrole-action-ramgetrole or English doc https://github.com/aliyun/fun/blob/master/docs/usage/faq.md#nopermissionerror-you-are-not-authorized-to-do-this-action-resource-acsramxxxxxxxxxxrole-action-ramgetrole for help.\n\nIf you don’t want use the AliyunRAMFullAccess policy or primary account, you can also specify the Role property for Service. You can refer to Chinease doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03-zh-cn.md#aliyunserverlessservice or Enaglish doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03.md#aliyunserverlessservice for help.\n`));
+          console.error(red(`\nMaybe you need grant AliyunRAMFullAccess policy to the subuser or use the primary account. You can refer to Chinese doc https://github.com/aliyun/fun/blob/master/docs/usage/faq-zh.md#nopermissionerror-you-are-not-authorized-to-do-this-action-resource-acsramxxxxxxxxxxrole-action-ramgetrole or English doc https://github.com/aliyun/fun/blob/master/docs/usage/faq.md#nopermissionerror-you-are-not-authorized-to-do-this-action-resource-acsramxxxxxxxxxxrole-action-ramgetrole for help.\n\nIf you don’t want use the AliyunRAMFullAccess policy or primary account, you can also specify the Role property for Service. You can refer to Chinese doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03-zh-cn.md#aliyunserverlessservice or English doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03.md#aliyunserverlessservice for help.\n`));
 
         } else if (ex.message.indexOf('FC service is not enabled for current user') !== -1) {
 

--- a/lib/local/http-invoke.js
+++ b/lib/local/http-invoke.js
@@ -95,7 +95,7 @@ class HttpInvoke extends Invoke {
 
             if (!this.watcher) {
               // add file ignore when auto reloading
-              const ign = ignore(this.baseDir);
+              const ign = await ignore(this.baseDir);
 
               this.watcher = watch(this.codeUri, { recursive: true, persistent: false, filter: (f) => {
                 return ign && !ign(f);

--- a/lib/ram.js
+++ b/lib/ram.js
@@ -165,7 +165,7 @@ async function makeRole(roleName, createRoleIfNotExist, description = 'FunctionC
         throw ex;
       } else if (ex.code && ex.code === 'NoPermission') {
         console.error(red(`\n${ex.message}\n\nMaybe you need grant AliyunRAMFullAccess policy to the sub-account or use the primary account. You can refer to Chinese doc https://github.com/aliyun/fun/blob/master/docs/usage/faq-zh.md#nopermissionerror-you-are-not-authorized-to-do-this-action-resource-acsramxxxxxxxxxxrole-action-ramgetrole or English doc https://github.com/aliyun/fun/blob/master/docs/usage/faq.md#nopermissionerror-you-are-not-authorized-to-do-this-action-resource-acsramxxxxxxxxxxrole-action-ramgetrole for help.\n\n` +
-        `If you don’t want use the AliyunRAMFullAccess policy or primary account, you can also specify the Role property for Service. You can refer to Chinease doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03-zh-cn.md#aliyunserverlessservice or Enaglish doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03.md#aliyunserverlessservice for help.\n`));
+        `If you don’t want use the AliyunRAMFullAccess policy or primary account, you can also specify the Role property for Service. You can refer to Chinese doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03-zh-cn.md#aliyunserverlessservice or English doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03.md#aliyunserverlessservice for help.\n`));
 
         throw ex;
       } else {
@@ -174,7 +174,7 @@ async function makeRole(roleName, createRoleIfNotExist, description = 'FunctionC
       }
     }
   });
-  
+
   return role;
 }
 


### PR DESCRIPTION
检查 yml 是否存在 vpc 或者 nas 的相关配置：
1.只有 vpc 的配置（是否需要检测配置正确）（提示用户手动配置 NAS， fun nas 规范文档发给用户，手动创建 nas（控制台链接））
2.有 vpc 和 nas 的配置
	▾	如果只有一个 NAS 配置
		▾	我们检测到您已经存在了 NAS 配置，是否直接使用这个 NAS 存储函数依赖
			▾	是
				自动配置
			▾	否
				•	提示当前的方案只支持配置一个 NAS 的场景，如果有更多需求，可以提 issue，加钉钉
       ▾	如果有多个 NAS 配置
               •	可以先不支持
```````````````````````````````````
添加 hot-reloading 中的 ignore 方法为 await（上次遗漏）
添加 re-deploy-function 完整部署日志。