### PR TITLE
ellison/support python model tips for NAS auto configuration

### DIFF
--- a/lib/deploy/deploy-by-tpl.js
+++ b/lib/deploy/deploy-by-tpl.js
@@ -559,8 +559,6 @@ async function deployByApi(baseDir, tpl, tplPath, context) {
     if (resource.Type === 'Aliyun::Serverless::Service') {
 
       await deployTplService(baseDir, name, resource, context.onlyConfig, tplPath);
-      const serviceNasMappings = await getNasMappingsFromNasYml(baseDir);
-      showTipsForNasYml(serviceNasMappings);
     } else if (resource.Type === 'Aliyun::Serverless::Api') {
       console.log(`Waiting for api gateway ${name} to be deployed...`);
       await deployApigateway(name, {
@@ -627,9 +625,10 @@ async function deploy(tplPath, context) {
     await deployByRos(baseDir, stackName, tpl, context.assumeYes, context.parameterOverride);
   } else {
     await deployByApi(baseDir, tpl, tplPath, context);
+    const serviceNasMappings = await getNasMappingsFromNasYml(baseDir);
+    showTipsForNasYml(serviceNasMappings);
   }
 }
-
 
 function showTipsForNasYml(serviceNasMappings) {
   if (_.isEmpty(serviceNasMappings)) { return; }
@@ -641,13 +640,14 @@ function showTipsForNasYml(serviceNasMappings) {
     }
   });
   console.log(yellow(`
-======================================= Tips for nas resources ===============================================
-Fun has detected the .nas.yml file in your directory, which contains the local directory:
+===================================== Tips for nas resources ==================================================
+Fun has detected the .nas.yml file in your working directory, which contains the local directory:
 
         ${localNasDir.join('\n\t')}
   `));
-  console.log(yellow(`If any content changes of above directories, you need to use 'fun nas sync' to sync local resources to remote.
-==============================================================================================================`));
+  console.log(yellow(`The above directories will be automatically ignored when 'fun deploy'.
+Any content of the above directories changes，you need to use 'fun nas sync' to sync local resources to remote.
+===============================================================================================================`));
 }
 
 module.exports = {

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -446,8 +446,7 @@ You can add the following configuration to ` + yellow(`'nasMapping.${serviceName
     `)
 + `
 After adding, fun is going to automatically synchronize the ` + yellow(`local`) + ` directory ${modelPath} to ` + yellow(`remote`) + ` ${remoteNasDir}.
-
-If these files ` + yellow('under') + ` ${modelPath} are used on your function code, you need to ${remoteNasDir} update these files path manully.
+If these files ` + yellow('under') + ` model directory are used on your function code, you need to ${remoteNasDir} update these files path manully.
 `);
 
   await promptForInputContinue('Please input enter to continue.');

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -447,10 +447,8 @@ You can add the following configuration to ` + yellow(`'nasMapping.${serviceName
 + `
 After adding, fun is going to automatically synchronize the ` + yellow(`local`) + ` directory ${modelPath} to ` + yellow(`remote`) + ` ${remoteNasDir}.
 
-If you access this path in your code, you need to manually update this path to ${remoteNasDir}
-If you do not want to do this or have already done so, please ignore.
-`
-  );
+If these files ` + yellow('under') + ` ${modelPath} are used on your function code, you need to ${remoteNasDir} update these files path manully.
+`);
 
   await promptForInputContinue('Please input enter to continue.');
 

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -22,7 +22,7 @@ const { getTpl, getBaseDir } = require('./tpl');
 const { green, red, yellow } = require('colors');
 const { getFcClient, getEcsPopClient, getNasPopClient } = require('./client');
 const { addEnv, resolveLibPathsFromLdConf, generateDefaultLibPath } = require('./install/env');
-const { readFileFromNasYml, mergeNasMappingsInNasYml } = require('./nas/support');
+const { readFileFromNasYml, mergeNasMappingsInNasYml, getNasMappingsFromNasYml } = require('./nas/support');
 
 const _ = require('lodash');
 
@@ -31,7 +31,8 @@ const {
   promptForMountTargets,
   promptForMountPoints,
   promptForFileSystems,
-  promptForSecurityGroup
+  promptForSecurityGroup,
+  promptForInput: promptForInputContinue
 } = require('./init/prompt');
 
 const FUN_GENERATED_SERVICE = 'fun-generated-default-service';
@@ -326,7 +327,8 @@ async function generateNasMappingsAndEnvs({
 
   return {
     envs,
-    nasMappings
+    nasMappings,
+    remoteNasDirPrefix: prefix
   };
 }
 
@@ -377,7 +379,7 @@ async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtim
 
   const nasConfig = (serviceRes.Properties || {}).NasConfig;
 
-  const { envs, nasMappings } = await generateNasMappingsAndEnvs({
+  const { envs, nasMappings, remoteNasDirPrefix } = await generateNasMappingsAndEnvs({
     baseDir,
     serviceName: nasServiceName,
     runtime,
@@ -399,8 +401,14 @@ async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtim
     functionName: nasFunctionName
   });
 
+  const serviceNasMappings = await processPythonModel({ baseDir, codeUri, runtime,
+    remoteNasDirPrefix,
+    serviceName: nasServiceName,
+    serviceNasMappings: nasMappingsObj
+  });
+
   // fun nas cp
-  await nasCpFromlocalNasDirToRemoteNasDir(tpl, tplPath, baseDir, nasServiceName, nasMappingsObj[nasServiceName]);
+  await nasCpFromlocalNasDirToRemoteNasDir(tpl, tplPath, baseDir, nasServiceName, serviceNasMappings[nasServiceName]);
 
   console.log(yellow(`\nFun has automatically uploaded your code dependency to NAS, then fun will use 'fun deploy ${nasServiceName}/${nasFunctionName}' to redeploy.`));
 
@@ -411,6 +419,42 @@ async function processNasAutomationConfiguration({ tpl, tplPath, baseDir, runtim
   if (partialDeploy.serviceName) {
     await require('./deploy/deploy-by-tpl').deployService(baseDir, partialDeploy.serviceName, partialDeploy.serviceRes, false, tplPath, true);
   }
+}
+
+async function processPythonModel({ baseDir, codeUri, runtime,
+  remoteNasDirPrefix,
+  serviceName,
+  serviceNasMappings
+}) {
+
+  if (!_.includes(['python2.7', 'python3'], runtime)) { return serviceNasMappings; }
+
+  const modelPath = path.resolve(codeUri, 'model');
+
+  if (!await fs.pathExists(modelPath)) { return serviceNasMappings; }
+
+  const remoteNasDir = `${remoteNasDirPrefix}model`;
+
+  console.log(`
+Fun has detected that there is a model folder. It is recommend to synchronize your model folder to NAS.
+You can add the following configuration to ` + yellow(`'nasMapping.${serviceName}'`) + ` in ` + yellow(`${path.resolve(baseDir, '.nas.yml')}
+`)
+
++ yellow(`
+  - localNasDir: ${modelPath}
+    remoteNasDir: ${remoteNasDir}
+    `)
++ `
+After adding, fun is going to automatically synchronize the ` + yellow(`local`) + ` directory ${modelPath} to ` + yellow(`remote`) + ` ${remoteNasDir}.
+
+If you access this path in your code, you need to manually update this path to ${remoteNasDir}
+If you do not want to do this or have already done so, please ignore.
+`
+  );
+
+  await promptForInputContinue('Please input enter to continue.');
+
+  return await getNasMappingsFromNasYml(baseDir);
 }
 
 async function backupTemplateFile(tplPath) {

--- a/lib/init/prompt.js
+++ b/lib/init/prompt.js
@@ -116,6 +116,17 @@ async function promptForConfirmContinue(message) {
   return false;
 }
 
+async function promptForInputContinue(message) {
+
+  const answers = await inquirer.prompt([{
+    type: 'input',
+    name: 'input',
+    message
+  }]);
+
+  return answers;
+}
+
 async function promptForDebugaHttptriggers(httpTriggers, message = 'select a function to debug?') {
   const choicesFuntions = httpTriggers.map(httpTrigger => {
     if (httpTrigger.path) {
@@ -226,5 +237,6 @@ module.exports = {
   promptForMountPoints,
   promptForMountTargets,
   promptForFileSystems,
-  promptForSecurityGroup
+  promptForSecurityGroup,
+  promptForInput: promptForInputContinue
 };

--- a/lib/nas/support.js
+++ b/lib/nas/support.js
@@ -167,9 +167,22 @@ async function readFileFromNasYml(baseDir) {
 
   if (!contentStr) { return {}; }
 
-  const contentObj = yaml.safeLoad(contentStr, {
-    schema: yaml.JSON_SCHEMA
-  });
+  let contentObj;
+
+  try {
+    contentObj = yaml.safeLoad(contentStr, {
+      schema: yaml.JSON_SCHEMA
+    });
+  } catch (e) {
+    throw new Error(`\nThere was a problem with parsing ${nasYmlPath}. Ensure it is valid YAML!
+${e}
+
+Please configure .nas.yml correctly. You may be able to continue by following two steps
+
+1. Execute 'fun nas sync' to upload local NAS resources to the cloud NAS service.
+2. Execute ‘fun deploy’ to deploy resources
+`);
+  }
 
   return contentObj || {};
 }

--- a/lib/nas/support.js
+++ b/lib/nas/support.js
@@ -177,7 +177,7 @@ async function readFileFromNasYml(baseDir) {
     throw new Error(`\nThere was a problem with parsing ${nasYmlPath}. Ensure it is valid YAML!
 ${e}
 
-After .nas.yml is configured correctly. You may be able to redeploy resources by following two steps
+After .nas.yml is configured correctly. You may be able to redeploy resources by following two steps:
 
 1. Execute 'fun nas sync' to upload local NAS resources to the NAS service.
 2. Execute ‘fun deploy’ to deploy resources to function computer.

--- a/lib/nas/support.js
+++ b/lib/nas/support.js
@@ -177,10 +177,10 @@ async function readFileFromNasYml(baseDir) {
     throw new Error(`\nThere was a problem with parsing ${nasYmlPath}. Ensure it is valid YAML!
 ${e}
 
-Please configure .nas.yml correctly. You may be able to continue by following two steps
+After .nas.yml is configured correctly. You may be able to redeploy resources by following two steps
 
-1. Execute 'fun nas sync' to upload local NAS resources to the cloud NAS service.
-2. Execute ‘fun deploy’ to deploy resources
+1. Execute 'fun nas sync' to upload local NAS resources to the NAS service.
+2. Execute ‘fun deploy’ to deploy resources to function computer.
 `);
   }
 


### PR DESCRIPTION
fix #635 
1. fun deploy 在大依赖向导中 python runtime 时检测 model 目录是否过大，提示如何配置 `.nas.yml`
2. 修改 fun deploy 时如果有 .nas.yml 文件的 tips。