### PR TITLE
ellison/automatic configuration for java8 runtime when fun deploy

### DIFF
--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -4,24 +4,27 @@ const path = require('path');
 const debug = require('debug')('fun:build');
 const fs = require('fs-extra');
 const yaml = require('js-yaml');
-const fcBuilders = require('@alicloud/fc-builders');
-const _ = require('lodash');
-const { green, red } = require('colors');
+const nas = require('../nas');
+const ncp = require('../utils/ncp');
+const util = require('util');
+const ncpAsync = util.promisify(ncp);
 const taskflow = require('./taskflow');
-const { showBuildNextTips, showInstallNextTips } = require('./tips');
-const { findFunctionsInTpl } = require('../definition');
 const template = require('./template');
 const artifact = require('./artifact');
 const docker = require('../docker');
 const uuid = require('uuid');
 const parser = require('./parser');
-const { yellow } = require('colors');
 const builder = require('./builder');
-const ncp = require('../utils/ncp');
-const nas = require('../nas');
-const util = require('util');
+const fcBuilders = require('@alicloud/fc-builders');
+
+const { recordMtimes } = require('../utils/file');
+
+const { yellow } = require('colors');
+const { green, red } = require('colors');
+const { findFunctionsInTpl } = require('../definition');
 const { DEFAULT_NAS_PATH_SUFFIX } = require('../tpl');
-const ncpAsync = util.promisify(ncp);
+
+const _ = require('lodash');
 
 async function convertFunYmlToFunfile(funymlPath, funfilePath) {
   const generatedFunfile = await parser.funymlToFunfile(funymlPath);
@@ -122,7 +125,17 @@ async function processFunfile(serviceName, serviceRes, codeUri, funfilePath, bas
   return imageTag;
 }
 
-async function buildFunction(buildName, tpl, baseDir, useDocker, stages, verbose) {
+async function recordMetaData(baseDir, functions, tplPath, metaPath, buildOps) {
+
+  const codeUris = functions.map(func => {
+    const { functionRes } = func;
+    return path.resolve(baseDir, functionRes.Properties.CodeUri);
+  });
+
+  await recordMtimes([...codeUris, ...[tplPath]], buildOps, metaPath);
+}
+
+async function buildFunction(buildName, tpl, baseDir, useDocker, stages, verbose, tplPath) {
   const buildStage = _.includes(stages, 'build');
 
   if (useDocker) {
@@ -204,13 +217,15 @@ async function buildFunction(buildName, tpl, baseDir, useDocker, stages, verbose
 
     console.log('Built artifacts: ' + path.relative(baseDir, rootArtifactsDir));
     console.log('Built template: ' + path.relative(baseDir, path.join(rootArtifactsDir, 'template.yml')));
-
-    showBuildNextTips();
   } else {
     console.log(green('\nInstall Success\n'));
-
-    showInstallNextTips();
   }
+  // save meta data
+  await recordMetaData(baseDir, buildFuncs, tplPath, path.resolve(rootArtifactsDir, 'meta.json'), {
+    'useDocker': useDocker,
+    'verbose': verbose,
+    'buildName': buildName
+  });
 }
 
 async function detectFunFile(baseDir, tpl) {

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -132,6 +132,12 @@ async function recordMetaData(baseDir, functions, tplPath, metaPath, buildOps) {
     return path.resolve(baseDir, functionRes.Properties.CodeUri);
   });
 
+  _.forEach(codeUris, codeUri => {
+    if (codeUri.endsWith('.zip') || codeUri.endsWith('.jar') || codeUri.endsWith('.war')) {
+      console.warn(red(`\nDeprecationWarning: your codeuri is ${path.resolve(baseDir, codeUri)}, and 'fun build' will not compiled your function dependencies. It is recommended that you change your codeuri to a directory.`));
+    }
+  });
+
   await recordMtimes([...codeUris, ...[tplPath]], buildOps, metaPath);
 }
 

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -1,10 +1,13 @@
 'use strict';
 
-const { detectTplPath, getTpl, validateYmlName } = require('../tpl');
-const validate = require('../validate/validate');
 const path = require('path');
+const validate = require('../validate/validate');
+
 const { red } = require('colors');
 const { buildFunction } = require('../build/build');
+const { showBuildNextTips } = require('../build/tips');
+const { detectTplPath, getTpl, validateYmlName } = require('../tpl');
+
 
 async function build(buildName, options) {
 
@@ -18,7 +21,7 @@ async function build(buildName, options) {
 
   if (!tplPath) {
     throw new Error(red('Current folder not a fun project\nThe folder must contains template.[yml|yaml] or faas.[yml|yaml] .'));
-  } 
+  }
 
   validateYmlName(tplPath);
 
@@ -28,7 +31,9 @@ async function build(buildName, options) {
 
   const baseDir = path.dirname(tplPath);
 
-  await buildFunction(buildName, tpl, baseDir, useDocker, ['install', 'build'], options.verbose);
+  await buildFunction(buildName, tpl, baseDir, useDocker, ['install', 'build'], options.verbose, tplPath);
+
+  showBuildNextTips();
 }
 
 module.exports = build;

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -1,7 +1,55 @@
 'use strict';
+const fs = require('fs-extra');
+const path = require('path');
 
-const { detectTplPath, validateYmlName } = require('../tpl');
 const { red } = require('colors');
+const { readJsonFromFile } = require('../utils/file');
+const { findFunctionsInTpl } = require('../definition');
+const { getTpl, getRootTplPath, detectTplPath, validateYmlName, DEFAULT_BUILD_ARTIFACTS_PATH_SUFFIX} = require('../tpl');
+
+const _ = require('lodash');
+
+function extractCodeUris(tpl) {
+  const functions = findFunctionsInTpl(tpl);
+  return functions.map(func => {
+    const { functionRes } = func;
+    return path.resolve(functionRes.Properties.CodeUri);
+  });
+}
+
+async function isMetaContentUpdate(tplPath) {
+  if (tplPath.indexOf(DEFAULT_BUILD_ARTIFACTS_PATH_SUFFIX) === -1) { return false; }
+
+  const rootTplPath = getRootTplPath(tplPath);
+  const rootTpl = await getTpl(rootTplPath);
+  const codeUris = extractCodeUris(rootTpl);
+
+  const metaPath = path.resolve(path.dirname(rootTplPath), DEFAULT_BUILD_ARTIFACTS_PATH_SUFFIX, 'meta.json');
+
+  if (!await fs.pathExists(metaPath)) { return false; }
+
+  const metaObj = await readJsonFromFile(metaPath);
+
+  if (_.isEmpty(metaObj)) {
+    return false;
+  }
+
+  for (const path of [...codeUris, ...[rootTplPath]]) {
+
+    const files = metaObj.modifiedTime || {};
+
+    if (!files[path]) {
+      return true;
+    }
+    const lstat = await fs.lstat(path);
+
+    if (files[path] !== lstat.mtime.getTime().toString()) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 async function deploy(context) {
 
@@ -16,6 +64,11 @@ async function deploy(context) {
   }
 
   validateYmlName(tplPath);
+
+  if (await isMetaContentUpdate(tplPath)) { // for fun build scene
+
+    console.warn(red(`Fun will you use ${path.relative(process.cwd(), tplPath)} to deploy the resource service and detect changes in the file. Please execute fun build to make sure the deployment is correct before that. If you have already done so, please ignore.`));
+  }
 
   await require('../deploy/deploy-by-tpl').deploy(tplPath, context);
 }

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -1,20 +1,23 @@
 'use strict';
 
-const debug = require('debug')('fun:install');
-const inquirer = require('inquirer');
 const fs = require('fs-extra');
 const path = require('path');
+const sbox = require('../install/sbox');
+const inquirer = require('inquirer');
+const validate = require('../validate/validate');
+const debug = require('debug')('fun:install');
+const getVisitor = require('../visitor').getVisitor;
+
 const { red, green, cyan } = require('colors');
 const { buildFunction, getOrConvertFunfile } = require('../build/build');
 const { resolveEnv } = require('../build/parser');
 const { FunModule } = require('../install/module');
 const { addEnv } = require('../install/env');
-const getVisitor = require('../visitor').getVisitor;
 const { getSupportedRuntimes } = require('../common/model/runtime');
-const sbox = require('../install/sbox');
 const { findFunctionInTpl } = require('../definition');
 const { detectTplPath, getTpl, validateYmlName } = require('../tpl');
-const validate = require('../validate/validate');
+const { showInstallNextTips } = require('../build/tips');
+
 const _ = require('lodash');
 
 async function installAll(funcPath, { verbose, useDocker }) {
@@ -32,6 +35,8 @@ async function installAll(funcPath, { verbose, useDocker }) {
   const baseDir = path.dirname(tplPath);
 
   await buildFunction(funcPath, tpl, baseDir, useDocker, ['install'], verbose);
+
+  showInstallNextTips();
 }
 
 async function getFunctionRes(funcPath) {

--- a/lib/commands/invoke.js
+++ b/lib/commands/invoke.js
@@ -10,7 +10,7 @@ const { getTpl, detectTplPath } = require('../tpl');
 const { getTriggerMetas } = require('../../lib/import/service');
 const { promptForFunctionSelection } = require('../init/prompt');
 const { findFunctionsInTpl, parseFunctionPath, findFirstFunctionName } = require('../definition');
-const { getEvent } = require('../utils/file');
+const { getEvent, readJsonFromFile } = require('../utils/file');
 const { red, yellow } = require('colors');
 
 const _ = require('lodash');
@@ -144,19 +144,6 @@ async function getHttpTrigger(serviceName, functionName) {
   return httpTrigger;
 }
 
-async function readFromRosTemplate(absRosTemplatePath) {
-  let rosTemplate;
-
-  const content = await fs.readFile(absRosTemplatePath, 'utf8');
-  try {
-
-    rosTemplate = JSON.parse(content);
-  } catch (err) {
-    throw new Error(`Unable to parse ROS json file: ${absRosTemplatePath}.\nError: ${err}`);
-  }
-  return rosTemplate;
-}
-
 async function findFunctionInRosTemplate(rosTemplate, serviceName, functionName) {
 
   const resourceName = serviceName + functionName;
@@ -179,7 +166,7 @@ async function invoke(invokeName, options) {
 
   if (await fs.pathExists(absRosTemplatePath)) {
 
-    const rosTemplate = await readFromRosTemplate(absRosTemplatePath);
+    const rosTemplate = await readJsonFromFile(absRosTemplatePath);
 
     const rosFuntion = await findFunctionInRosTemplate(rosTemplate, serviceName, functionName);
 

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -221,7 +221,7 @@ async function buildOnMeta(baseDir, tpl, tplPath) {
   const metaPath = path.resolve(baseDir, DEFAULT_BUILD_ARTIFACTS_PATH_SUFFIX, 'meta.json');
 
   if (!await fs.pathExists(metaPath)) {
-    console.warn(`warning: ${metaPath} does not exist.`);
+    console.warn(red(`\nwarning: ${metaPath} does not exist.`));
     return;
   }
 
@@ -277,7 +277,7 @@ async function updateInitializerAndEnvs({tplPath, tpl,
   return {
     packageName,
     codeUri: functionRes.Properties.CodeUri,
-    tplContent: updatedTplContent
+    updatedTplContent
   };
 }
 
@@ -292,7 +292,7 @@ async function processJavaIfNecessary({
 
   const { projectTpl, projectTplPath } = await getProjectTpl(tplPath);
 
-  const { packageName, codeUri } = await updateInitializerAndEnvs({
+  const { packageName, codeUri, updatedTplContent } = await updateInitializerAndEnvs({
     tplPath: projectTplPath,
     tpl: projectTpl,
     serviceName: serviceName,
@@ -302,9 +302,9 @@ async function processJavaIfNecessary({
   await copyEntryPoint(projectTplPath, codeUri, packageName);
 
   // fun build
-  await buildOnMeta(baseDir, projectTpl, projectTplPath);
+  await buildOnMeta(baseDir, updatedTplContent, projectTplPath);
 
-  return projectTpl;
+  return updatedTplContent;
 }
 
 function mergeEnvs(functionRes, envs) {

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -18,7 +18,9 @@ const nas = require('./nas');
 const nasCp = require('./nas/cp');
 
 const { sleep } = require('./time');
-const { getTpl, getBaseDir, getNasYmlPath } = require('./tpl');
+const { buildFunction } = require('./build/build');
+const { readJsonFromFile } = require('./utils/file');
+const { getTpl, getBaseDir, getNasYmlPath, DEFAULT_BUILD_ARTIFACTS_PATH_SUFFIX } = require('./tpl');
 const { green, red, yellow } = require('colors');
 const { getFcClient, getEcsPopClient, getNasPopClient } = require('./client');
 const { addEnv, resolveLibPathsFromLdConf, generateDefaultLibPath } = require('./install/env');
@@ -193,14 +195,116 @@ async function saveNasMappings(nasYmlPath, nasMappings) {
 
   return mergedNasMappings;
 }
+async function copyEntryPoint(tplPath, codeUri, packageName) {
+  const asbCodeUri = path.resolve(path.dirname(tplPath), codeUri);
+  const entryPointPath = path.join(asbCodeUri, 'src', 'main', 'java', packageName, 'Entrypoint.java');
 
-async function updateEnvironmentsInTpl({ tplPath, tpl, envs,
+  await fs.copy(path.resolve(__dirname, './utils/classLoader/Entrypoint.java'), entryPointPath);
+}
+
+// example.App::handleRequest -> example.App
+function extractPrefix(handler) {
+  const prefix = handler.substring(0, handler.length - '::handleRequest'.length).split('.');
+  const prefixArray = prefix.filter((ele, idx, arr) => {
+    return arr.length - 1 !== idx;
+  });
+  return prefixArray.join('.');
+}
+
+async function buildOnMeta(baseDir, tpl, tplPath) {
+
+  const metaPath = path.resolve(baseDir, DEFAULT_BUILD_ARTIFACTS_PATH_SUFFIX, 'meta.json');
+
+  if (!await fs.pathExists(metaPath)) {
+    console.warn(`warning: ${metaPath} does not exist.`);
+    return;
+  }
+
+  const metaObj = await readJsonFromFile(metaPath);
+
+  const { buildName, useDocker, verbose } = metaObj.buildOps || {};
+
+  console.log(yellow(`\nFun will execute 'fun build' to build dependencies.`));
+
+  // fun build
+  await buildFunction(buildName, tpl, baseDir, useDocker, ['install', 'build'], verbose, tplPath);
+}
+
+
+async function updateInitializerAndEnvs({tplPath, tpl,
   serviceName,
   functionName
 }) {
   const updatedTplContent = _.cloneDeep(tpl);
 
   const { functionRes } = definition.findFunctionByServiceAndFunctionName(updatedTplContent.Resources, serviceName, functionName);
+
+  const packageName = extractPrefix(functionRes.Properties.Handler);
+
+  const originHandler = functionRes.Properties.Handler;
+  const originInitializer = functionRes.Properties.Initializer;
+
+  functionRes.Properties.Handler = `${packageName}.Entrypoint::handleRequest`;
+
+  console.log(green(`Fun update Handler variables to ${tplPath}`));
+
+  const envs = {
+    'FUN_HANDLER': originHandler
+  };
+
+  console.log(green(`Fun add environment variables 'FUN_HANDLER' to ${tplPath}`));
+
+  if (originInitializer) {
+    functionRes.Properties.Initializer = `${packageName}.Entrypoint::initialize`;
+    console.log(green(`Fun update Initializer variables to ${tplPath}`));
+
+    Object.assign(envs, {
+      'FUN_INITIALIZER': originInitializer
+    });
+
+    console.log(green(`Fun add environment variables 'FUN_INITIALIZER' to ${tplPath}`));
+  }
+
+  functionRes.Properties.EnvironmentVariables = mergeEnvs(functionRes, envs);
+
+  util.outputTemplateFile(tplPath, updatedTplContent);
+
+  return {
+    packageName,
+    codeUri: functionRes.Properties.CodeUri,
+    tplContent: updatedTplContent
+  };
+}
+
+async function processJavaIfNecessary({
+  runtime, baseDir,
+  tplPath, tpl,
+  serviceName,
+  functionName
+}) {
+
+  if (runtime !== 'java8' || usingProjectTemplate(tplPath)) { return tpl; }
+
+  const { projectTpl, projectTplPath } = await getProjectTpl(tplPath);
+
+  const { packageName, codeUri } = await updateInitializerAndEnvs({
+    tplPath: projectTplPath,
+    tpl: projectTpl,
+    serviceName: serviceName,
+    functionName: functionName
+  });
+
+  await copyEntryPoint(projectTplPath, codeUri, packageName);
+
+  // fun build
+  await buildOnMeta(baseDir, projectTpl, projectTplPath);
+
+  return projectTpl;
+}
+
+function mergeEnvs(functionRes, envs) {
+  const functionProp = (functionRes.Properties || {});
+  const formerEnvs = (functionProp.EnvironmentVariables) || {};
 
   const customizer = (objValue, srcValue) => {
     if (objValue) {
@@ -210,10 +314,18 @@ async function updateEnvironmentsInTpl({ tplPath, tpl, envs,
     }
     return srcValue;
   };
+  return _.mergeWith(formerEnvs, envs, customizer);
+}
 
-  const functionProp = (functionRes.Properties || {});
-  const formerEnvs = (functionProp.EnvironmentVariables) || {};
-  const mergedEnvs = _.mergeWith(formerEnvs, envs, customizer);
+async function updateEnvironmentsInTpl({ tplPath, tpl, envs,
+  serviceName,
+  functionName
+}) {
+  const updatedTplContent = _.cloneDeep(tpl);
+
+  const { functionRes } = definition.findFunctionByServiceAndFunctionName(updatedTplContent.Resources, serviceName, functionName);
+
+  const mergedEnvs = mergeEnvs(functionRes, envs);
 
   if (_.isEmpty(functionRes['Properties'])) {
     functionRes.Properties = {
@@ -247,20 +359,10 @@ async function getProjectTpl(tplPath) {
   };
 }
 
-async function updateNasAutoConfigure(tplPath, tpl, nasServiceName) {
-  const updatedTplContent = updateNasAutoConfigureInTpl(tplPath, tpl, nasServiceName);
-
-  if (!usingProjectTemplate(tplPath)) {
-    const { projectTpl, projectTplPath } = await getProjectTpl(tplPath);
-    updateNasAutoConfigureInTpl(projectTplPath, projectTpl, nasServiceName);
-  }
-  return updatedTplContent;
-}
-
-function updateNasAutoConfigureInTpl(tplPath, tpl, nasServiceName) {
+function updateNasAutoConfigureInTpl(tplPath, tpl, serviceName) {
   const updatedTplContent = _.cloneDeep(tpl);
 
-  const { serviceRes } = definition.findServiceByServiceName(updatedTplContent.Resources, nasServiceName);
+  const { serviceRes } = definition.findServiceByServiceName(updatedTplContent.Resources, serviceName);
 
   if (_.isEmpty(serviceRes['Properties'])) {
     serviceRes.Properties = {
@@ -277,10 +379,17 @@ function updateNasAutoConfigureInTpl(tplPath, tpl, nasServiceName) {
   return updatedTplContent;
 }
 
-function updateNasAndVpcInTpl(tplPath, tpl, nasServiceName, nasAndVpcConfig) {
+async function updateNasAutoConfigure(tplPath, tpl, serviceName) {
+  const { projectTpl, projectTplPath } = await getTplInfo(tpl, tplPath);
+
+  const updatedTplContent = await updateNasAutoConfigureInTpl(projectTplPath, projectTpl, serviceName);
+  return updatedTplContent;
+}
+
+function updateNasAndVpcInTpl(tplPath, tpl, serviceName, nasAndVpcConfig) {
   const updatedTplContent = _.cloneDeep(tpl);
 
-  const { serviceRes } = definition.findServiceByServiceName(updatedTplContent.Resources, nasServiceName);
+  const { serviceRes } = definition.findServiceByServiceName(updatedTplContent.Resources, serviceName);
 
   if (_.isEmpty(serviceRes['Properties'])) {
     serviceRes.Properties = nasAndVpcConfig;
@@ -295,16 +404,30 @@ function updateNasAndVpcInTpl(tplPath, tpl, nasServiceName, nasAndVpcConfig) {
   return updatedTplContent;
 }
 
-async function updateNasAndVpc(tplPath, tpl, nasServiceName, nasAndVpcConfig) {
+async function getTplInfo(tpl, tplPath) {
+  let projectTpl;
+  let projectTplPath;
 
-  const updatedTplContent = updateNasAndVpcInTpl(tplPath, tpl, nasServiceName, nasAndVpcConfig);
+  if (usingProjectTemplate(tplPath)) {
 
-  if (!usingProjectTemplate(tplPath)) {
-
-    const { projectTpl, projectTplPath } = await getProjectTpl(tplPath);
-
-    updateNasAndVpcInTpl(projectTplPath, projectTpl, nasServiceName, nasAndVpcConfig);
+    projectTpl = tpl;
+    projectTplPath = tplPath;
+  } else {
+    const obj = await getProjectTpl(tplPath);
+    projectTpl = obj.projectTpl;
+    projectTplPath = obj.projectTplPath;
   }
+
+  return {
+    projectTpl,
+    projectTplPath
+  };
+}
+
+async function updateNasAndVpc(tplPath, tpl, serviceName, nasAndVpcConfig) {
+  const { projectTpl, projectTplPath } = await getTplInfo(tpl, tplPath);
+
+  const updatedTplContent = updateNasAndVpcInTpl(projectTplPath, projectTpl, serviceName, nasAndVpcConfig);
 
   return updatedTplContent;
 }
@@ -345,7 +468,7 @@ async function generateNasMappingsAndEnvs({
   const dependencyMappings = runtimeDependencyMappings[runtime];
 
   for (const mapping of dependencyMappings) {
-    // const localDir = path.join(codeUri, mapping.localDir);
+
     const localDir = resolveLocalNasDir(runtime, baseDir, codeUri, mapping.localDir, serviceName, functionName);
 
     if (await fs.pathExists(localDir)) { // language local dependencies dir exist
@@ -446,13 +569,20 @@ async function processNasAutomationConfiguration({ tpl, tplPath, runtime, codeUr
 
   const nasMappingsObj = await saveNasMappings(getNasYmlPath(tplPath), nasMappings);
 
-  const updatedTplContent = await updateEnvironments({
+  await updateEnvironments({
     tplPath, tpl, envs,
     serviceName: nasServiceName,
     functionName: nasFunctionName
   });
 
-  const serviceNasMappings = await processPythonModel({ nasYmlPath: getNasYmlPath(tplPath),
+  const updatedTplContent = await processJavaIfNecessary({
+    runtime, baseDir,
+    tplPath, tpl,
+    serviceName: nasServiceName,
+    functionName: nasFunctionName
+  });
+
+  const serviceNasMappings = await processPythonModelIfNecessary({ nasYmlPath: getNasYmlPath(tplPath),
     codeUri, runtime,
     remoteNasDirPrefix,
     serviceName: nasServiceName,
@@ -480,29 +610,20 @@ async function updateEnvironments({
   functionName
 }) {
 
+  const { projectTpl, projectTplPath } = await getTplInfo(tpl, tplPath);
+
   const updatedTplContent = await updateEnvironmentsInTpl({
-    tplPath, tpl, envs,
-    serviceName,
-    functionName
+    tplPath: projectTplPath,
+    tpl: projectTpl,
+    envs,
+    serviceName: serviceName,
+    functionName: functionName
   });
-
-  if (!usingProjectTemplate(tplPath)) {
-
-    const { projectTpl, projectTplPath } = await getProjectTpl(tplPath);
-
-    await updateEnvironmentsInTpl({
-      tplPath: projectTplPath,
-      tpl: projectTpl,
-      envs,
-      serviceName: serviceName,
-      functionName: functionName
-    });
-  }
 
   return updatedTplContent;
 }
 
-async function processPythonModel({ nasYmlPath, codeUri, runtime,
+async function processPythonModelIfNecessary({ nasYmlPath, codeUri, runtime,
   remoteNasDirPrefix,
   serviceName,
   serviceNasMappings
@@ -612,7 +733,7 @@ async function nasAutomationConfigurationIfNecessary({ tplPath, runtime, codeUri
 }) {
 
   let stop = false;
-  if (compressedSize > 963313 && _.includes(SUPPORT_RUNTIMES, runtime)) { // 50M
+  if (compressedSize > 52428800 && _.includes(SUPPORT_RUNTIMES, runtime)) { // 50M
     console.log(red(`\nFun detected that your function ${nasServiceName}/${nasFunctionName} sizes exceed 50M. It is recommended that using the nas service to manage your function dependencies.`));
 
     if (await promptForConfirmContinue(`Do you want to let fun to help you automate the configuration?`)) {

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -140,7 +140,12 @@ async function zipCode(baseDir, codeUri, runtime, functionName) {
     codeAbsPath = path.resolve(baseDir, codeUri);
 
     if (codeUri.endsWith('.zip') || codeUri.endsWith('.jar') || codeUri.endsWith('.war')) {
-      return { base64: Buffer.from(await fs.readFile(codeAbsPath)).toString('base64') };
+
+      const lstat = await fs.lstat(codeAbsPath);
+      return {
+        base64: Buffer.from(await fs.readFile(codeAbsPath)).toString('base64'),
+        compressedSize: lstat.size
+      };
     }
   } else {
     codeAbsPath = path.resolve(baseDir, './');
@@ -726,6 +731,17 @@ function replaceNasConfig(nasConfig, mountDir) {
   return cloneNasConfig;
 }
 
+async function ensureCodeUriForJava(codeUri) {
+
+  if (codeUri.endsWith('.zip') || codeUri.endsWith('.jar') || codeUri.endsWith('.war')) {
+    throw new Error(`
+You can follow these steps:
+    1. Modify codeuri to the directory where your 'src' is located.
+    2. Execute 'fun build' to build function dependencies.
+    3. Execute 'fun deploy' to deployment resources.`);
+  }
+}
+
 async function nasAutomationConfigurationIfNecessary({ tplPath, runtime, codeUri, nasConfig, vpcConfig,
   compressedSize,
   nasFunctionName,
@@ -734,7 +750,9 @@ async function nasAutomationConfigurationIfNecessary({ tplPath, runtime, codeUri
 
   let stop = false;
   if (compressedSize > 52428800 && _.includes(SUPPORT_RUNTIMES, runtime)) { // 50M
+
     console.log(red(`\nFun detected that your function ${nasServiceName}/${nasFunctionName} sizes exceed 50M. It is recommended that using the nas service to manage your function dependencies.`));
+    await ensureCodeUriForJava(codeUri);
 
     if (await promptForConfirmContinue(`Do you want to let fun to help you automate the configuration?`)) {
       const tpl = await getTpl(tplPath);

--- a/lib/tpl.js
+++ b/lib/tpl.js
@@ -85,6 +85,11 @@ function getRootBaseDir(baseDir) {
   return baseDir;
 }
 
+function getRootTplPath(tplPath) {
+  const baseDir = getBaseDir(tplPath);
+  return path.join(baseDir, path.basename(tplPath));
+}
+
 function getNasYmlPath(tplPath) {
   const baseDir = getBaseDir(tplPath);
   return path.join(baseDir, '.nas.yml');
@@ -106,5 +111,6 @@ function detectNasBaseDir(tplPath) {
 module.exports = {
   getTpl, detectTplPath, validateYmlName,
   detectNasBaseDir, DEFAULT_BUILD_ARTIFACTS_PATH_SUFFIX, DEFAULT_NAS_PATH_SUFFIX,
-  detectTmpDir, DEFAULT_LOCAL_TMP_PATH_SUFFIX, getBaseDir, getNasYmlPath, getRootBaseDir
+  detectTmpDir, DEFAULT_LOCAL_TMP_PATH_SUFFIX, getBaseDir, getNasYmlPath, getRootBaseDir,
+  getRootTplPath
 };

--- a/lib/utils/classLoader/Entrypoint.java
+++ b/lib/utils/classLoader/Entrypoint.java
@@ -1,0 +1,257 @@
+package example;
+
+import com.aliyun.fc.runtime.*;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class Entrypoint implements StreamRequestHandler, FunctionInitializer, HttpRequestHandler {
+
+    private ClassLoader nasLibClassloader;
+    private static final Map<String, Object> handlerObjectCache = new ConcurrentHashMap<>();
+
+    {
+        List<URL> classpathExt = Stream.of(System.getenv("JAVA_PATH"), "/code")
+                .map(p -> new File(p))
+                .flatMap(f -> Stream.concat(Stream.of(f), listJar(f)))
+                .map(f -> {
+                    try {
+                        return f.toURI().toURL();
+                    } catch (MalformedURLException e) {
+                        e.printStackTrace();
+                    }
+                    return null;
+                })
+                .collect(Collectors.toList());
+
+        nasLibClassloader = new ChildFirstURLClassLoader(classpathExt.toArray(new URL[0]), Thread.currentThread().getContextClassLoader());
+
+    }
+
+    private Stream<File> listJar(File dir) {
+        File[] jarFiles = dir.listFiles((_dir, name) ->
+                name.endsWith(".jar") || name.endsWith(".JAR") || name.endsWith(".zip") || name.endsWith(".ZIP"));
+
+        if (jarFiles == null) {
+            return Stream.empty();
+        } else {
+            return Stream.of(jarFiles);
+        }
+    }
+
+    private Class<?> loadClass(String className, Class<?> superClass) {
+        try {
+            Class customerClass = Class.forName(className, true, nasLibClassloader);
+            if (PojoRequestHandler.class.isAssignableFrom(customerClass)) {
+                throw new RuntimeException("interface com.aliyun.fc.runtime.PojoRequestHandler is not support, please use other com.aliyun.fc.runtime interfaces");
+            }
+            if (!superClass.isAssignableFrom(customerClass)) {
+                throw new RuntimeException(String.format("Handler class '%s' must implement one of the com.aliyun.fc.runtime interfaces", className));
+            }
+            return customerClass;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Object newObject(Class<?> clasz) {
+        try {
+            return clasz.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Object getHandlerObject(String className, Class<?> superClass) {
+        Object handler = handlerObjectCache.get(className);
+        if (handler == null) {
+            handler = newObject(loadClass(className, superClass));
+            handlerObjectCache.put(className, handler);
+        }
+        return handler;
+    }
+
+    private String[] splitHandlerName(String handlerName) {
+        String[] splittedNames = handlerName.split("::");
+
+        if (splittedNames.length != 2) {
+            throw new RuntimeException(String.format("Handler '%s' must contain one and only one \'::\'", handlerName));
+        }
+        return splittedNames;
+    }
+
+    private void invokeMethod(String envKey,Class<?> superClass, Class<?>[] parameterTypes, Object... args) {
+
+        String handlerName = System.getenv(envKey);
+
+        if (handlerName == null) {
+            throw new RuntimeException(String.format("ENV: '%s' is not set", envKey));
+        }
+
+
+        String[] splittedNames = splitHandlerName(handlerName);
+        String className = splittedNames[0];
+        String methodName = splittedNames[1];
+
+        Class<?> customClass = loadClass(className, FunctionInitializer.class);
+
+        try {
+            Method initialize = customClass.getDeclaredMethod(methodName, parameterTypes);
+            initialize.invoke(getHandlerObject(className, superClass), args);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Class<?>[] asClassList(Class<?>... classes) {
+        return classes;
+    }
+
+
+    public void initialize(Context context) throws IOException {
+
+        Thread.currentThread().setContextClassLoader(nasLibClassloader);
+
+
+        invokeMethod("FUN_INITIALIZER", FunctionInitializer.class, asClassList(Context.class), context);
+    }
+
+    @Override
+    public void handleRequest(
+            InputStream inputStream, OutputStream outputStream, Context context) throws IOException {
+
+        Thread.currentThread().setContextClassLoader(nasLibClassloader);
+
+        invokeMethod("FUN_HANDLER", StreamRequestHandler.class, asClassList(InputStream.class, OutputStream.class, Context.class), inputStream, outputStream, context);
+    }
+
+    @Override
+    public void handleRequest(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Context context) throws IOException, ServletException {
+        Thread.currentThread().setContextClassLoader(nasLibClassloader);
+
+        invokeMethod("FUN_HANDLER", HttpRequestHandler.class, asClassList(HttpServletRequest.class, HttpServletResponse.class, Context.class), httpServletRequest, httpServletResponse, context);
+    }
+}
+
+class ChildFirstURLClassLoader extends URLClassLoader {
+
+    private ClassLoader system;
+
+    public ChildFirstURLClassLoader(URL[] classpath, ClassLoader parent) {
+        super(classpath, parent);
+        system = getSystemClassLoader();
+    }
+
+    @Override
+    protected synchronized Class<?> loadClass(String name, boolean resolve)
+            throws ClassNotFoundException {
+        // First, check if the class has already been loaded
+        Class<?> c = findLoadedClass(name);
+        if (c == null) {
+            if (system != null) {
+                try {
+                    // checking system: jvm classes, endorsed, cmd classpath, etc.
+                    c = system.loadClass(name);
+                } catch (ClassNotFoundException ignored) {
+                }
+            }
+            if (c == null) {
+                try {
+                    // checking local
+                    c = findClass(name);
+                } catch (ClassNotFoundException e) {
+                    // checking parent
+                    // This call to loadClass may eventually call findClass again, in case the parent doesn't find anything.
+                    c = super.loadClass(name, resolve);
+                }
+            }
+        }
+        if (resolve) {
+            resolveClass(c);
+        }
+        return c;
+    }
+
+    @Override
+    public URL getResource(String name) {
+        URL url = null;
+        if (system != null) {
+            url = system.getResource(name);
+        }
+        if (url == null) {
+            url = findResource(name);
+            if (url == null) {
+                // This call to getResource may eventually call findResource again, in case the parent doesn't find anything.
+                url = super.getResource(name);
+            }
+        }
+        return url;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        /**
+         * Similar to super, but local resources are enumerated before parent resources
+         */
+        Enumeration<URL> systemUrls = null;
+        if (system != null) {
+            systemUrls = system.getResources(name);
+        }
+        Enumeration<URL> localUrls = findResources(name);
+        Enumeration<URL> parentUrls = null;
+        if (getParent() != null) {
+            parentUrls = getParent().getResources(name);
+        }
+        final List<URL> urls = new ArrayList<URL>();
+        if (systemUrls != null) {
+            while (systemUrls.hasMoreElements()) {
+                urls.add(systemUrls.nextElement());
+            }
+        }
+        if (localUrls != null) {
+            while (localUrls.hasMoreElements()) {
+                urls.add(localUrls.nextElement());
+            }
+        }
+        if (parentUrls != null) {
+            while (parentUrls.hasMoreElements()) {
+                urls.add(parentUrls.nextElement());
+            }
+        }
+        return new Enumeration<URL>() {
+            Iterator<URL> iter = urls.iterator();
+
+            public boolean hasMoreElements() {
+                return iter.hasNext();
+            }
+
+            public URL nextElement() {
+                return iter.next();
+            }
+        };
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String name) {
+        URL url = getResource(name);
+        try {
+            return url != null ? url.openStream() : null;
+        } catch (IOException e) {
+        }
+        return null;
+    }
+}

--- a/lib/utils/file.js
+++ b/lib/utils/file.js
@@ -86,5 +86,50 @@ async function getEvent(eventFile, ec = 'local invoke', dp = '/fun/local/invoke'
   });
 }
 
+async function assertFilesExsit(paths) {
+  for (const path of paths) {
+    if (!await fs.pathExists(path)) {
+      throw new Error(`${path} is not exsit`);
+    }
+  }
+}
+async function recordMtimes(filePaths, buildOps, recordedPath) {
 
-module.exports = { readLines, getEvent };
+  await assertFilesExsit(filePaths);
+
+  const fileMtimes = await filePaths.reduce(async (accPromise, cur) => {
+
+    const collection = await accPromise;
+    const lstat = await fs.lstat(cur);
+
+    const modifiedTimeObj = collection.modifiedTime || {};
+
+    Object.assign(collection, {
+      'modifiedTime': Object.assign(modifiedTimeObj, {
+        [cur]: lstat.mtime.getTime().toString()
+      })
+    });
+
+    return collection;
+  }, Promise.resolve({}));
+
+  // save build options
+  fileMtimes.buildOps = buildOps;
+
+  await fs.outputFile(recordedPath, JSON.stringify(fileMtimes, null, 4));
+}
+
+async function readJsonFromFile(absFilePath) {
+  let obj;
+
+  const str = await fs.readFile(absFilePath, 'utf8');
+  try {
+
+    obj = JSON.parse(str);
+  } catch (err) {
+    throw new Error(`Unable to parse json file: ${absFilePath}.\nError: ${err}`);
+  }
+  return obj;
+}
+
+module.exports = { readLines, getEvent, recordMtimes, readJsonFromFile };

--- a/test/fc.test.js
+++ b/test/fc.test.js
@@ -24,7 +24,8 @@ describe('test zipCode', () => {
     sandbox.stub(zip, 'pack').resolves({});
 
     sandbox.stub(fs, 'lstat').resolves({
-      isFile: function () { return false; }
+      isFile: function () { return false; },
+      size: '100'
     });
 
     sandbox.stub(fs, 'readFile').resolves('test');
@@ -75,7 +76,10 @@ describe('test zipCode', () => {
 
   it('test zipCode: relative codeUri for war', async () => {
     const content = await fc.zipCode('/a/b', './web.war');
-    expect(content).to.eql({ base64: Buffer.from('test').toString('base64') });
+    expect(content).to.eql({
+      base64: Buffer.from('test').toString('base64'),
+      compressedSize: '100'
+    });
 
     assert.calledWith(fs.readFile, path.resolve('/a/b/web.war'));
   });


### PR DESCRIPTION
1. 用户使用的旧的方案，也就是自己打包成 jar 上传的方式。如何一键帮助这种场景上传大依赖，还不确定，所以针对这个用户，我使用了在 mvn package 时，手动将依赖打包到 nas 目录的方法。如果针对这种场景，自动帮用户解决或者提示用户解决，让用户无痛用起来？
解决：检测到超过  50m，中断并提示正确的操作步骤。

2. 用户虽然使用了 .jar，但是也手动执行了 fun build，虽然混用， 不会导致报错，但是这里有个问题，如果用户的 CodeUri 填写的是 ./target/xxx.jar，是否应该告知用户正确的使用方法，避免后面的问题？
解决： 混用的场景下，会作出提示。

3. 用户使用了 .jar，执行了 fun build，然后后面更新了 yml，fun deploy 会使用 build 后的 yml，而不是用户更新的，这里如何自动触发更新，或者检测到有变更，报错或者等待用户确认，让用户知道如何更新？
解决：采用将元数据 mtime 保存到 meta.json 中，每次比较 mtime 是否有变更，有变更则提示。