### PR TITLE
ellison/grinding of auto configuration

### DIFF
--- a/lib/deploy/deploy-by-tpl.js
+++ b/lib/deploy/deploy-by-tpl.js
@@ -100,7 +100,7 @@ async function deployTriggers(serviceName, functionName, events) {
 async function deployFunction(baseDir, serviceName, functionName, functionRes, nasConfig, vpcConfig, onlyConfig, tplPath, skipTrigger = false) {
   const properties = functionRes.Properties || {};
 
-  await makeFunction(baseDir, {
+  const rs = await makeFunction(baseDir, {
     serviceName,
     functionName,
     description: properties.Description,
@@ -120,21 +120,51 @@ async function deployFunction(baseDir, serviceName, functionName, functionRes, n
   if (!skipTrigger) {
     await deployTriggers(serviceName, functionName, functionRes.Events);
   }
+
+  return rs;
+}
+
+async function reloadServiceRes(tplPath, name) {
+
+  const tpl = await getTpl(tplPath);
+
+  for (let { serviceName, serviceRes } of definition.findServices(tpl.Resources)) {
+    if (name === serviceName) {
+      return serviceRes;
+    }
+  }
+  return {};
 }
 
 async function deployFunctions(baseDir, serviceName, serviceRes, onlyConfig, tplPath, skipTrigger) {
   const serviceProps = serviceRes.Properties || {};
-  for (const [k, v] of Object.entries(serviceRes)) {
-    if ((v || {}).Type === 'Aliyun::Serverless::Function') {
 
-      const beforeDeployLog = onlyConfig ? 'config to be updated' : 'to be deployed';
-      const afterDeployLog = onlyConfig ? 'config update success' : 'deploy success';
+  let deployedFunctions = [];
+  let tplChanged;
 
-      console.log(`\tWaiting for function ${k} ${beforeDeployLog}...`);
-      await deployFunction(baseDir, serviceName, k, v, serviceProps.NasConfig, serviceProps.VpcConfig, onlyConfig, tplPath, skipTrigger);
-      console.log(green(`\tfunction ${k} ${afterDeployLog}`));
+  do {
+    tplChanged = false;
+
+    for (const [k, v] of Object.entries(serviceRes)) {
+      if ((v || {}).Type === 'Aliyun::Serverless::Function') {
+        if (_.includes(deployedFunctions, k)) { continue; }
+
+        const beforeDeployLog = onlyConfig ? 'config to be updated' : 'to be deployed';
+        const afterDeployLog = onlyConfig ? 'config update success' : 'deploy success';
+
+        console.log(`\tWaiting for function ${k} ${beforeDeployLog}...`);
+        const rs = await deployFunction(baseDir, serviceName, k, v, serviceProps.NasConfig, serviceProps.VpcConfig, onlyConfig, tplPath, skipTrigger);
+        deployedFunctions.push(k);
+        console.log(green(`\tfunction ${k} ${afterDeployLog}`));
+
+        if (rs.tplChanged) {
+          serviceRes = await reloadServiceRes(tplPath, serviceName);
+          tplChanged = true;
+          break;
+        }
+      }
     }
-  }
+  } while (tplChanged);
 }
 
 async function deployPolicy(resourceName, roleName, policy, curCount, product = 'Fc') {

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -140,7 +140,8 @@ async function zipCode(baseDir, codeUri, runtime, functionName) {
 const NODE_RUNTIME_MAPPING = {
   'localDir': 'node_modules',
   'remoteDir': 'node_modules',
-  'env': 'NODE_PATH'
+  'env': 'NODE_PATH',
+  'defaultEnv': '/usr/local/lib/node_modules'
 };
 
 const PYTHON_RUNTIME_MAPPING = {
@@ -466,7 +467,8 @@ async function generateNasMappingsAndEnvs({
     const localDir = resolveLocalNasDir(runtime, baseDir, codeUri, mapping.localDir, serviceName, functionName);
 
     if (await fs.pathExists(localDir)) { // language local dependencies dir exist
-      const remoteDir = `${prefix}${mapping.remoteDir}`;
+
+      const remoteDir = generateRemoteNasDir(mapping, prefix);
 
       nasMapping.push({
         localNasDir: localDir,
@@ -488,6 +490,17 @@ async function generateNasMappingsAndEnvs({
     nasMappings,
     remoteNasDirPrefix: prefix
   };
+}
+
+function generateRemoteNasDir(mapping, mountDirPrefix) {
+  let remoteDir;
+
+  if (mapping.defaultEnv) {
+    remoteDir = `${mapping.defaultEnv}:${mountDirPrefix}${mapping.remoteDir}`;
+  } else {
+    remoteDir = `${mountDirPrefix}${mapping.remoteDir}`;
+  }
+  return remoteDir;
 }
 
 function resolveLocalNasDir(runtime, baseDir, codeUri, localDirInNasMappings, serviceName, functionName) {

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -81,6 +81,8 @@ const runtimeTypeMapping = {
 };
 
 async function detectLibraryFolders(dirName, libraryFolders, wrap, functionName) {
+  if (_.isEmpty(libraryFolders)) { return; }
+
   for (const libraryFolder of libraryFolders) {
     const libraryPath = path.join(dirName, libraryFolder);
     if (await fs.pathExists(libraryPath)) {
@@ -562,7 +564,7 @@ async function processOtherFunctionsUnderServiceIfNecessary({
     return originFunctionName !== functionName;
   });
 
-  if (_.isEmpty(otherFunctions)) { return { tpl, tplChanged }; }
+  if (_.isEmpty(otherFunctions)) { return { updatedEnvsTpl: tpl, tplChanged }; }
 
   const pendingFuntions = otherFunctions.filter(m => {
     const functionProp = m.functionRes.Properties;
@@ -574,7 +576,7 @@ async function processOtherFunctionsUnderServiceIfNecessary({
     return (_.isEqual(runtimeDependencyMappings[runtime], runtimeDependencyMappings[otherRuntime]) && codeUri === otherAbsCodeUri);
   });
 
-  if (_.isEmpty(pendingFuntions)) { return { tpl, tplChanged }; }
+  if (_.isEmpty(pendingFuntions)) { return { updatedEnvsTpl: tpl, tplChanged }; }
 
   for (const pendingFuntion of pendingFuntions) {
 

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -56,7 +56,7 @@ const defaultNasConfig = {
   MountPoints: []
 };
 
-async function generateFunIngore(baseDir, codeUri) {
+async function generateFunIngore(baseDir, codeUri, runtime) {
   const absCodeUri = path.resolve(baseDir, codeUri);
   const absBaseDir = path.resolve(baseDir);
 
@@ -67,7 +67,7 @@ async function generateFunIngore(baseDir, codeUri) {
     return null;
   }
 
-  return await funignore(baseDir);
+  return await funignore(baseDir, runtime);
 }
 
 // TODO: python runtime .egg-info and .dist-info
@@ -130,7 +130,7 @@ async function zipCode(baseDir, codeUri, runtime, functionName) {
     codeAbsPath = path.resolve(baseDir, './');
   }
 
-  const ignore = await generateFunIngore(baseDir, codeAbsPath);
+  const ignore = await generateFunIngore(baseDir, codeAbsPath, runtime);
 
   await detectLibrary(codeAbsPath, runtime, baseDir, functionName, '\t\t');
 
@@ -331,7 +331,7 @@ async function updateEnvironmentsInTpl({ tplPath, tpl, envs,
 
   util.outputTemplateFile(tplPath, updatedTplContent);
 
-  console.log(green(`Fun add environment variables to ${tplPath}`));
+  console.log(green(`Fun add environment variables to '${serviceName}/${functionName}' with path ${tplPath}`));
 
   return updatedTplContent;
 }
@@ -538,6 +538,40 @@ async function nasCpFromlocalNasDirToRemoteNasDir(tpl, tplPath, baseDir, nasServ
   }
 }
 
+async function processOtherFunctionsUnderServiceIfNecessary({
+  baseDir, codeUri, runtime, envs, tpl, tplPath,
+  originServiceName, originFunctionName
+}) {
+
+  const otherFunctions = definition.findFunctionsInTpl(tpl, (functionName, functionRes) => {
+    return originFunctionName !== functionName;
+  });
+
+  if (_.isEmpty(otherFunctions)) { return tpl; }
+
+  const pendingFuntions = otherFunctions.filter(m => {
+    const functionProp = m.functionRes.Properties;
+
+    const otherCodeUri = (functionProp || {}).CodeUri;
+    const otherAbsCodeUri = path.resolve(baseDir, otherCodeUri);
+    const otherRuntime = (functionProp || {}).Runtime;
+
+    return (_.isEqual(runtimeDependencyMappings[runtime], runtimeDependencyMappings[otherRuntime]) && codeUri === otherAbsCodeUri);
+  });
+
+  if (_.isEmpty(pendingFuntions)) { return tpl; }
+
+  for (const pendingFuntion of pendingFuntions) {
+
+    tpl = await updateEnvironmentsInTpl({ tplPath, tpl, envs,
+      serviceName: originServiceName,
+      functionName: pendingFuntion.functionName
+    });
+  }
+
+  return tpl;
+}
+
 async function processNasAutomationConfiguration({ tpl, tplPath, runtime, codeUri, convertedNasConfig,
   nasServiceName,
   nasFunctionName
@@ -564,7 +598,7 @@ async function processNasAutomationConfiguration({ tpl, tplPath, runtime, codeUr
   const nasMappingsObj = await saveNasMappings(getNasYmlPath(tplPath), nasMappings);
 
   const updatedEnvsTpl = await updateEnvironments({
-    tplPath, tpl, envs,
+    tplPath, tpl, envs, baseDir, codeUri, runtime,
     serviceName: nasServiceName,
     functionName: nasFunctionName
   });
@@ -599,22 +633,25 @@ async function processNasAutomationConfiguration({ tpl, tplPath, runtime, codeUr
 }
 
 async function updateEnvironments({
-  tplPath, tpl, envs,
-  serviceName,
-  functionName
+  tplPath, tpl, envs, baseDir, codeUri, runtime,
+  serviceName, functionName
 }) {
 
   const { projectTpl, projectTplPath } = await getTplInfo(tpl, tplPath);
 
   const updatedTplContent = await updateEnvironmentsInTpl({
-    tplPath: projectTplPath,
-    tpl: projectTpl,
     envs,
-    serviceName: serviceName,
-    functionName: functionName
+    tpl: projectTpl,
+    tplPath: projectTplPath,
+    serviceName, functionName
   });
 
-  return updatedTplContent;
+  return await processOtherFunctionsUnderServiceIfNecessary({
+    tpl: updatedTplContent, tplPath,
+    baseDir, codeUri, runtime, envs,
+    originServiceName: serviceName,
+    originFunctionName: functionName
+  });
 }
 
 async function processPythonModelIfNecessary({ nasYmlPath, codeUri, runtime,

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -543,11 +543,13 @@ async function processOtherFunctionsUnderServiceIfNecessary({
   originServiceName, originFunctionName
 }) {
 
+  let tplChanged = false;
+
   const otherFunctions = definition.findFunctionsInTpl(tpl, (functionName, functionRes) => {
     return originFunctionName !== functionName;
   });
 
-  if (_.isEmpty(otherFunctions)) { return tpl; }
+  if (_.isEmpty(otherFunctions)) { return { tpl, tplChanged }; }
 
   const pendingFuntions = otherFunctions.filter(m => {
     const functionProp = m.functionRes.Properties;
@@ -559,7 +561,7 @@ async function processOtherFunctionsUnderServiceIfNecessary({
     return (_.isEqual(runtimeDependencyMappings[runtime], runtimeDependencyMappings[otherRuntime]) && codeUri === otherAbsCodeUri);
   });
 
-  if (_.isEmpty(pendingFuntions)) { return tpl; }
+  if (_.isEmpty(pendingFuntions)) { return { tpl, tplChanged }; }
 
   for (const pendingFuntion of pendingFuntions) {
 
@@ -569,7 +571,10 @@ async function processOtherFunctionsUnderServiceIfNecessary({
     });
   }
 
-  return tpl;
+  return {
+    updatedEnvsTpl: tpl,
+    tplChanged: true
+  };
 }
 
 async function processNasAutomationConfiguration({ tpl, tplPath, runtime, codeUri, convertedNasConfig,
@@ -597,7 +602,7 @@ async function processNasAutomationConfiguration({ tpl, tplPath, runtime, codeUr
 
   const nasMappingsObj = await saveNasMappings(getNasYmlPath(tplPath), nasMappings);
 
-  const updatedEnvsTpl = await updateEnvironments({
+  const { updatedEnvsTpl, tplChanged} = await updateEnvironments({
     tplPath, tpl, envs, baseDir, codeUri, runtime,
     serviceName: nasServiceName,
     functionName: nasFunctionName
@@ -630,6 +635,8 @@ async function processNasAutomationConfiguration({ tpl, tplPath, runtime, codeUr
     // can not use baseDir, should use tpl dirname
     await require('./deploy/deploy-by-tpl').deployService(path.dirname(tplPath), partialDeploy.serviceName, partialDeploy.serviceRes, false, tplPath, true);
   }
+
+  return tplChanged;
 }
 
 async function updateEnvironments({
@@ -775,6 +782,7 @@ async function nasAutomationConfigurationIfNecessary({ tplPath, runtime, codeUri
 }) {
 
   let stop = false;
+  let tplChanged = false;
   if (compressedSize > 52428800 && _.includes(SUPPORT_RUNTIMES, runtime)) { // 50M
 
     console.log(red(`\nFun detected that your function ${nasServiceName}/${nasFunctionName} sizes exceed 50M. It is recommended that using the nas service to manage your function dependencies.`));
@@ -788,7 +796,7 @@ async function nasAutomationConfigurationIfNecessary({ tplPath, runtime, codeUri
         const yes = await promptForConfirmContinue(`You have already configured 'NasConfig: Auto’. We want to use this configuration to store your function dependencies.`);
         if (yes) {
           await backupTemplateFile(tplPath); // backup tpl
-          await processNasAutomationConfiguration({
+          tplChanged = await processNasAutomationConfiguration({
             tpl, tplPath, runtime, codeUri,
             nasServiceName,
             nasFunctionName
@@ -806,7 +814,7 @@ async function nasAutomationConfigurationIfNecessary({ tplPath, runtime, codeUri
           const yes = await promptForConfirmContinue(`We have detected that you already have a NAS configuration. Do you directly use this NAS storage function dependencies.`);
           if (yes) {
             await backupTemplateFile(tplPath);
-            await processNasAutomationConfiguration({
+            tplChanged = await processNasAutomationConfiguration({
               tpl, tplPath, runtime, codeUri,
               nasServiceName,
               nasFunctionName
@@ -818,7 +826,7 @@ async function nasAutomationConfigurationIfNecessary({ tplPath, runtime, codeUri
           const answer = await promptForMountPoints(nasConfig.MountPoints);
           const convertedNasConfig = replaceNasConfig(nasConfig, answer.mountDir);
           await backupTemplateFile(tplPath);
-          await processNasAutomationConfiguration({
+          tplChanged = await processNasAutomationConfiguration({
             tpl, tplPath, runtime, codeUri, convertedNasConfig,
             nasServiceName,
             nasFunctionName
@@ -833,7 +841,7 @@ async function nasAutomationConfigurationIfNecessary({ tplPath, runtime, codeUri
           // write back to yml
           const updatedTpl = await updateNasAutoConfigure(tplPath, tpl, nasServiceName);
 
-          await processNasAutomationConfiguration({
+          tplChanged = await processNasAutomationConfiguration({
             tpl: updatedTpl, tplPath, runtime, codeUri,
             nasServiceName,
             nasFunctionName
@@ -847,7 +855,7 @@ async function nasAutomationConfigurationIfNecessary({ tplPath, runtime, codeUri
           const nasAndVpcConfig = generateNasAndVpcConfig(mountTarget, securityGroupId, nasServiceName);
           const updatedTpl = await updateNasAndVpc(tplPath, tpl, nasServiceName, nasAndVpcConfig);
 
-          await processNasAutomationConfiguration({
+          tplChanged = await processNasAutomationConfiguration({
             tpl: updatedTpl, tplPath, runtime, codeUri,
             nasServiceName,
             nasFunctionName
@@ -857,7 +865,10 @@ async function nasAutomationConfigurationIfNecessary({ tplPath, runtime, codeUri
       }
     }
   }
-  return stop;
+  return {
+    stop,
+    tplChanged
+  };
 }
 
 function usingProjectTemplate(tplPath) {
@@ -930,14 +941,14 @@ async function makeFunction(baseDir, {
       console.log(`\t\tWaiting for packaging function ${functionName} code...`);
       const { base64, count, compressedSize } = await zipCode(baseDir, codeUri, runtime, functionName);
 
-      const stop = await nasAutomationConfigurationIfNecessary({
+      const rs = await nasAutomationConfigurationIfNecessary({
         compressedSize, tplPath, runtime, nasConfig, vpcConfig,
         nasFunctionName: functionName,
         nasServiceName: serviceName,
         codeUri: path.resolve(baseDir, codeUri)
       });
 
-      if (stop) { return; }
+      if (rs.stop) { return { tplChanged: rs.tplChanged }; }
 
       const convertedSize = bytes(compressedSize, {
         unitSeparator: ' '
@@ -983,10 +994,10 @@ async function makeFunction(baseDir, {
     if (!fn) {
       // create
       params['functionName'] = functionName;
-      fn = await fc.createFunction(serviceName, params);
+      await fc.createFunction(serviceName, params);
     } else {
       // update
-      fn = await fc.updateFunction(serviceName, functionName, params);
+      await fc.updateFunction(serviceName, functionName, params);
     }
   } catch (ex) {
 
@@ -995,7 +1006,9 @@ async function makeFunction(baseDir, {
     }
     throw ex;
   }
-  return fn;
+  return {
+    tplChanged: false
+  };
 }
 
 async function makeService({

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -468,7 +468,7 @@ async function generateNasMappingsAndEnvs({
 
     if (await fs.pathExists(localDir)) { // language local dependencies dir exist
 
-      const remoteDir = generateRemoteNasDir(mapping, prefix);
+      const remoteDir = `${prefix}${mapping.remoteDir}`;
 
       nasMapping.push({
         localNasDir: localDir,
@@ -476,7 +476,7 @@ async function generateNasMappingsAndEnvs({
       });
 
       Object.assign(envs, {
-        [mapping.env]: remoteDir
+        [mapping.env]: generateNasEnv(mapping.defaultEnv, remoteDir)
       });
 
       outputNasMappingLog(baseDir, nasMappingPath, localDir);
@@ -492,15 +492,15 @@ async function generateNasMappingsAndEnvs({
   };
 }
 
-function generateRemoteNasDir(mapping, mountDirPrefix) {
-  let remoteDir;
+function generateNasEnv(defaultEnv, remoteNasDir) {
+  let nasEnv;
 
-  if (mapping.defaultEnv) {
-    remoteDir = `${mapping.defaultEnv}:${mountDirPrefix}${mapping.remoteDir}`;
+  if (defaultEnv) {
+    nasEnv = `${defaultEnv}:${remoteNasDir}`;
   } else {
-    remoteDir = `${mountDirPrefix}${mapping.remoteDir}`;
+    nasEnv = remoteNasDir;
   }
-  return remoteDir;
+  return nasEnv;
 }
 
 function resolveLocalNasDir(runtime, baseDir, codeUri, localDirInNasMappings, serviceName, functionName) {

--- a/lib/package/ignore.js
+++ b/lib/package/ignore.js
@@ -9,7 +9,26 @@ const { generateIgnoreFileFromNasYml } = require('../nas/support');
 
 const ignoredFile = ['.git', '.svn', '.env', '.fun/nas', '.fun/tmp', '.DS_Store', 'template.packaged.yml', '.nas.yml'];
 
-module.exports = async function (baseDir) {
+function selectIgnored(runtime) {
+  switch (runtime) {
+  case 'nodejs6':
+  case 'nodejs8':
+  case 'nodejs10':
+
+    return ['.fun/python', 'vendor'];
+  case 'python2.7':
+  case 'python3':
+
+    return ['node_modules', 'vendor'];
+  case 'php7.2':
+
+    return ['node_modules', '.fun/python'];
+  default:
+    return [];
+  }
+}
+
+module.exports = async function (baseDir, runtime) {
 
   const ignoreFilePath = `${baseDir}/.funignore`;
 
@@ -19,9 +38,11 @@ module.exports = async function (baseDir) {
     fileContent = fs.readFileSync(ignoreFilePath, 'utf8');
   }
 
+  const ignoreDependencies = selectIgnored(runtime);
+
   const ignoreList = await generateIgnoreFileFromNasYml(baseDir);
 
-  const ignoredPaths = parser(`${[...ignoredFile, ...ignoreList].join('\n')}\n${fileContent}`);
+  const ignoredPaths = parser(`${[...ignoredFile, ...ignoreList, ...ignoreDependencies].join('\n')}\n${fileContent}`);
 
   const ig = ignore().add(ignoredPaths);
   return function (f) {


### PR DESCRIPTION
背景：
用户的使用场景有些“特别”。用户有 3 个 node10 函数，3 个 python3 函数，由于每个函数都有大依赖，一共 6 个函数，都在同一个服务，而且放在了同一个目录里，只不过函数入口设置的不同。这就导致了 `node_modules` 包含了 3 个函数的所有依赖，`.fun/python` 包含了 3 个 python 的所有依赖。
1. 当部署执行 fun deploy 时，fun 开始一个函数一个函数。所以在 大依赖向导中 re-deploy 节点重新部署时依然会提示依赖过大，这是因为代码打包成 .zip 时，根据 .nas.yml 中的规则生成 ignore list，而 `.nas.yml `定义的最小单元是 service 级别的，所以在 re-deploy 时依然不会忽略其他 runtime 的大依赖。修正后的行为：打包代码时，在 ignore 规则中忽略其他 runtime 的依赖。例如 打包 node 时自动忽略 `.fun/python` 和` vendor`
2. 一个服务 A 下，存在两个函数 B, C， 并且 B, C 相同的 runtime 和 codeUri(绝对路径)。B, C 公用同一份依赖。此时在第一个函数 B 遇到大依赖向导时，会将 setvice 级别的规则写到 `.nas.yml `中。此时对函数 B 的处理无误，而处理 C 函数时，由于依赖已经上传到 nas 上，而此时虽然函数 C 部署成功，但是调用却因环境变量不对导致找不到依赖包，所以正确处理 B 函数的的同时，需要将 C 函数也更新，例如更新 C 的环境变量。
3. 用户大依赖向导完成后调用 node 函数失败，去看了 lambda 的 node Dockerfile，发现已经添加了一个 NODE_PATH，而我们的大依赖向导也添加一个 NODE_PATH，导致被覆盖了。方案：将 `NODE_PATH: /usr/local/lib/node_modules `内置到大依赖向导里面这个问题就解决了。
