### PR TITLE
perf(Fun Local): Reduce exit time after receiving ctrl-c

### DIFF
--- a/lib/commands/local/start.js
+++ b/lib/commands/local/start.js
@@ -17,7 +17,7 @@ const { getDebugPort, getDebugIde } = require('../../debug');
 const { detectTplPath, getTpl, validateYmlName, detectNasBaseDir } = require('../../tpl');
 
 const serverPort = 8000;
-const SERVER_CLOSE_TIMEOUT = 5000;
+const SERVER_CLOSE_TIMEOUT = 3000;
 
 function registerSigintForExpress(server) {
   var sockets = {}, nextSocketId = 0;
@@ -25,7 +25,7 @@ function registerSigintForExpress(server) {
   // close express server
   // https://stackoverflow.com/questions/14626636/how-do-i-shutdown-a-node-js-https-server-immediately/14636625#14636625
   server.on('connection', function (socket) {
-    let socketId = nextSocketId;
+    let socketId = nextSocketId++;
     sockets[socketId] = socket;
     socket.on('close', function () {
       delete sockets[socketId];
@@ -57,7 +57,6 @@ function registerSigintForExpress(server) {
 
     for (let socketId in sockets) {
       if (!{}.hasOwnProperty.call(sockets, socketId)) { continue; }
-
       sockets[socketId].destroy();
     }
   });

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -75,12 +75,9 @@ function waitingForContainerStopped() {
           container.destroy();
         } else {
           const c = docker.getContainer(container);
-
-          await c.inspect();
-
           console.log(`stopping container ${container}`);
 
-          jobs.push(c.stop());
+          jobs.push(c.kill().catch(ex => debug('kill container instance error, error is', ex)));
         }
       } catch (error) {
         debug('get container instance error, ignore container to stop, error is', error);

--- a/lib/local/http-invoke.js
+++ b/lib/local/http-invoke.js
@@ -214,8 +214,11 @@ class HttpInvoke extends Invoke {
           // for next invoke
           this.runner = null;
           this.containerName = docker.generateRamdomContainerName();
-
-          console.error(error);
+          if (error.indexOf('exited with code 137') > -1) { // receive signal SIGKILL http://tldp.org/LDP/abs/html/exitcodes.html
+            debug(error);
+          } else {
+            console.error(error);
+          }
           return;
         }
 

--- a/test/docker.test.js
+++ b/test/docker.test.js
@@ -317,6 +317,7 @@ describe('test docker run', async () => {
     sandbox.stub(DockerCli.prototype, 'run').resolves({});
     sandbox.stub(DockerCli.prototype, 'getContainer').returns({
       'stop': sandbox.stub(),
+      'kill': sandbox.stub(),
       'inspect': sandbox.stub().resolves({})
     });
 
@@ -445,8 +446,7 @@ describe('test docker run', async () => {
     await sleep(10);
 
     assert.calledWith(DockerCli.prototype.getContainer, 'containerId');
-    assert.calledOnce(DockerCli.prototype.getContainer().inspect);
-    assert.calledOnce(DockerCli.prototype.getContainer().stop);
+    assert.calledOnce(DockerCli.prototype.getContainer().kill);
   });
 });
 


### PR DESCRIPTION
优化收到 Ctrl-C 后，程序退出的时间，现在基本做到了秒级退出。目前退出程序前要做如下两件事：
1. 如果调用了 Local Start，启动了 Express Server，需要关闭 Server
2. 清理由 Fun 创建的 Container

针对 1：参考 [链接](https://stackoverflow.com/questions/14626636/how-do-i-shutdown-a-node-js-https-server-immediately/14636625#14636625) 清理，bug fix 之前 `let socketId = nextSocketId;` => `let socketId = nextSocketId++;`
针对 2：采用 docker kill 代替 docker stop，让退出信息对用户透明