### PR TITLE
feat(Permission Tip): Support aliyun cli permission tip

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,6 +13,11 @@ const Pop = require('@alicloud/pop-core');
 const getProfile = require('./profile').getProfile;
 const OSS = require('ali-oss');
 const debug = require('debug');
+const {
+  throwProcessedFCPermissionError,
+  throwProcessedPopPermissionError,
+  throwProcessedSLSPermissionError
+} = require('./error-message');
 
 const getRosClient = async () => {
   return await getPopClient('http://ros.aliyuncs.com', '2019-09-10');
@@ -62,6 +67,15 @@ const getFcClient = async (opts = {}) => {
       'user-agent': `${pkg.name}/v${pkg.version} ( Node.js ${process.version}; OS ${process.platform} ${process.arch}; language ${locale}; mid ${mid})`
     }
   });
+  const realRequest = fc.request.bind(fc);
+  fc.request = async (method, path, query, body, headers, opts = {}) => {
+    try {
+      return await realRequest(method, path, query, body, headers || {}, opts || {});
+    } catch (ex) {
+      await throwProcessedFCPermissionError(ex, ...path.split('/').filter(p => !!p));
+      throw ex;
+    }
+  };
 
   return fc;
 };
@@ -79,7 +93,7 @@ const getFnFClient = async () => {
 const getPopClient = async (endpoint, apiVersion) => {
   const profile = await getProfile();
 
-  return new Pop({
+  const pop = new Pop({
     endpoint: endpoint,
     apiVersion: apiVersion,
     accessKeyId: profile.accessKeyId,
@@ -88,6 +102,18 @@ const getPopClient = async (endpoint, apiVersion) => {
       timeout: profile.timeout * 1000
     }
   });
+
+  const realRequest = pop.request.bind(pop);
+  pop.request = async (action, params, options) => {
+    try {
+      return await realRequest(action, params, options);
+    } catch (ex) {
+      await throwProcessedPopPermissionError(ex, action);
+      throw ex;
+    }
+  };
+
+  return pop;
 };
 
 const getOtsPopClient = async () => {
@@ -153,11 +179,23 @@ const getCloudApiClient = async () => {
 const getSlsClient = async () => {
   const profile = await getProfile();
 
-  return new Log({
+  const log = new Log({
     region: profile.defaultRegion,
     accessKeyId: profile.accessKeyId,
     accessKeySecret: profile.accessKeySecret
   });
+
+  const realRequest = log._request.bind(log);
+  log._request = async (verb, projectName, path, queries, body, headers, options) => {
+    try {
+      return await realRequest(verb, projectName, path, queries, body, headers, options);
+    } catch (ex) {
+      await throwProcessedSLSPermissionError(ex);
+      throw ex;
+    }
+  };
+
+  return log;
 };
 
 module.exports = {

--- a/lib/deploy/deploy-support.js
+++ b/lib/deploy/deploy-support.js
@@ -92,6 +92,9 @@ async function makeLogstore({
           shardCount
         });
       } catch (ex) {
+        if (ex.code === 'Unauthorized') {
+          throw ex;
+        }
         debug('error when createLogStore, projectName is %s, logstoreName is %s, error is: \n%O', projectName, logstoreName, ex);
         console.log(red(`\t\tretry ${times} times`));
         retry(ex);
@@ -106,7 +109,9 @@ async function makeLogstore({
         });
       } catch (ex) {
         debug('error when updateLogStore, projectName is %s, logstoreName is %s, error is: \n%O', projectName, logstoreName, ex);
-
+        if (ex.code === 'Unauthorized') {
+          throw ex;
+        }
         if (ex.code !== 'ParameterInvalid' && ex.message !== 'no parameter changed') {
           console.log(red(`\t\tretry ${times} times`));
           retry(ex);
@@ -147,13 +152,14 @@ async function makeSlsProject(projectName, description) {
           description
         });
       } catch (ex) {
-        if (ex.code === 'ProjectAlreadyExist') {
+        if (ex.code === 'Unauthorized') {
+          throw ex;
+        } else if (ex.code === 'ProjectAlreadyExist') {
           throw new Error(red(`error: sls project ${projectName} already exist, it may be in other region or created by other users.`));
         } else if (ex.code === 'ProjectNotExist') {
           throw new Error(red(`Please go to https://sls.console.aliyun.com/ to open the LogServce.`));
         } else {
           debug('error when createProject, projectName is %s, error is: \n%O', projectName, ex);
-
           console.log(red(`\tretry ${times} times`));
           retry(ex);
         }

--- a/lib/error-message.js
+++ b/lib/error-message.js
@@ -1,5 +1,10 @@
 'use strict';
 
+const {
+  getProfile
+} = require('./profile');
+const { red } = require('colors');
+
 function throwProcessedException(ex, policyName) {
 
   if (ex.code === 'Forbidden.RAM') {
@@ -9,4 +14,96 @@ function throwProcessedException(ex, policyName) {
   throw ex;
 }
 
-module.exports = { throwProcessedException };
+async function throwProcessedPopPermissionError(ex, action) {
+  if (!ex.code || !ex.url || (ex.code !== 'NoPermission' && ex.code !== 'Forbidden.RAM' && !ex.code.includes('Forbbiden'))) { // NAS 返回的权限错误码是 Forbbiden.ram
+    throw ex;
+  }
+  const productRegex = new RegExp(/https?:\/\/([a-zA-Z]*).(.*)aliyuncs.com/);
+  const productRegexRes = productRegex.exec(ex.url);
+  if (!productRegexRes) {
+    throw ex;
+  }
+  const product = productRegexRes[1];
+  action = `${product}:${action}`;
+  let resource = '*';
+  if (ex.data && ex.data.Message) {
+    const regex = new RegExp(/Resource: (.*) Action: (.*)/);
+    const res = regex.exec(ex.data.Message);
+    if (res) {
+      resource = res[1];
+      action = res[2];
+    }
+  }
+  const policyName = generatePolicyName(action);
+  printPermissionTip(policyName, action, resource);
+  throw ex;
+}
+
+async function throwProcessedFCPermissionError(ex, ...resourceArr) {
+  if (!ex.code || ex.code !== 'AccessDenied' || !ex.message) {
+    throw ex;
+  }
+  const regex = new RegExp(/the caller is not authorized to perform '(.*)' on resource '(.*)'/);
+  const res = regex.exec(ex.message);
+  if (!res) {
+    throw ex;
+  }
+  const profile = await getProfile();
+  const action = res[1];
+  const resource = res[2];
+  const policyName = generatePolicyName(action, profile.defaultRegion, ...resourceArr);
+  printPermissionTip(policyName, action, resource);
+  throw ex;
+}
+
+async function throwProcessedSLSPermissionError(ex) {
+  if (!ex.code || ex.code !== 'Unauthorized' || !ex.message) {
+    throw ex;
+  }
+  const regex = new RegExp(/action: (.*), resource: (.*)/);
+  const res = regex.exec(ex.message);
+  if (!res) {
+    throw ex;
+  }
+  const action = res[1];
+  const resource = res[2];
+  const policyName = generatePolicyName(action);
+  printPermissionTip(policyName, action, resource);
+  throw ex;
+}
+
+function printPermissionTip(policyName, action, resource) {
+  const policy = {
+    'Version': '1',
+    'Statement': [
+      {
+        'Effect': 'Allow',
+        'Action': [
+          action
+        ],
+        'Resource': [
+          resource
+        ]
+      }
+    ]
+  };
+  console.error(red(`\nYou can run the following commands to grant permission '${action}' on '${resource}' `));
+  console.error(red('Via the link:  https://shell.aliyun.com/ or aliyun cli'));
+  console.error(red('(Note: aliyun cli tool needs to be configured with credentials that have related RAM permissions, such as primary account\'s AK)'));
+  console.error(red('\n1. Create Policy'));
+  console.error(red(`aliyun ram CreatePolicy --PolicyName ${policyName} --PolicyDocument "${JSON.stringify(policy).replace(/"/g, '\\"')}"`));
+  console.error(red('\n2. Attach Policy To User'));
+  console.error(red(`aliyun ram AttachPolicyToUser --PolicyName ${policyName} --PolicyType "Custom" --UserName "YOUR_USER_NAME"\n`));
+}
+
+function generatePolicyName(action, ...resourceArr) {
+  const resource = resourceArr && resourceArr.length ? resourceArr.join('-') : Math.random().toString(36).slice(-8);
+  return `fun-generated-${action.replace(/:/g, '-')}-${resource}`;
+}
+
+module.exports = {
+  throwProcessedException,
+  throwProcessedPopPermissionError,
+  throwProcessedFCPermissionError,
+  throwProcessedSLSPermissionError
+};

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -1055,11 +1055,7 @@ async function makeService({
 
       if (ex.code === 'AccessDenied' || !ex.code || ex.code === 'ENOTFOUND') {
 
-        if (ex.message.indexOf('the caller is not authorized to perform') !== -1) {
-
-          console.error(red(`\nMaybe you need grant AliyunRAMFullAccess policy to the subuser or use the primary account. You can refer to Chinese doc https://github.com/aliyun/fun/blob/master/docs/usage/faq-zh.md#nopermissionerror-you-are-not-authorized-to-do-this-action-resource-acsramxxxxxxxxxxrole-action-ramgetrole or English doc https://github.com/aliyun/fun/blob/master/docs/usage/faq.md#nopermissionerror-you-are-not-authorized-to-do-this-action-resource-acsramxxxxxxxxxxrole-action-ramgetrole for help.\n\nIf you don’t want use the AliyunRAMFullAccess policy or primary account, you can also specify the Role property for Service. You can refer to Chinese doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03-zh-cn.md#aliyunserverlessservice or English doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03.md#aliyunserverlessservice for help.\n`));
-
-        } else if (ex.message.indexOf('FC service is not enabled for current user') !== -1) {
+        if (ex.message.indexOf('FC service is not enabled for current user') !== -1) {
 
           console.error(red(`\nFC service is not enabled for current user. Please enable FC service before using fun.\nYou can enable FC service on this page https://www.aliyun.com/product/fc .\n`));
 
@@ -1134,6 +1130,9 @@ async function makeService({
         service = await fc.updateService(serviceName, options);
       }
     } catch (ex) {
+      if (ex.code === 'AccessDenied') {
+        throw ex;
+      }
       debug('error when createService or updateService, serviceName is %s, options is %j, error is: \n%O', serviceName, options, ex);
 
       console.log(red(`\tretry ${times} times`));

--- a/lib/ram.js
+++ b/lib/ram.js
@@ -6,6 +6,7 @@ const promiseRetry = require('./retry');
 const { red } = require('colors');
 const debug = require('debug')('fun:ram');
 const _ = require('lodash');
+const { throwProcessedPopPermissionError } = require('./error-message');
 
 const FNF_ASSUME_ROLE_POLICY = {
   'Statement': [
@@ -25,7 +26,7 @@ const FNF_ASSUME_ROLE_POLICY = {
 const getRamClient = async () => {
   const profile = await getProfile();
   
-  return new Ram({
+  const ram = new Ram({
     accessKeyId: profile.accessKeyId,
     accessKeySecret: profile.accessKeySecret,
     endpoint: 'https://ram.aliyuncs.com',
@@ -33,6 +34,17 @@ const getRamClient = async () => {
       timeout: profile.timeout * 1000
     }
   });
+
+  const realRequest = ram.request.bind(ram);
+  ram.request = async (action, params, options) => {
+    try {
+      return await realRequest(action, params, options);
+    } catch (ex) {
+      await throwProcessedPopPermissionError(ex, action);
+      throw ex;
+    }
+  };
+  return ram;
 };
 
 function normalizeRoleOrPoliceName(roleName) {
@@ -93,6 +105,9 @@ async function makePolicy(policyName, policyDocument) {
         });
       }
     } catch (ex) {
+      if (ex.code && ex.code === 'NoPermission') {
+        throw ex;
+      }
       console.log(red(`retry ${times} times`));
       retry(ex);
     }
@@ -118,6 +133,9 @@ async function attachPolicyToRole(policyName, roleName, policyType = 'System') {
         });
       }
     } catch (ex) {
+      if (ex.code && ex.code === 'NoPermission') {
+        throw ex;
+      }
       debug('error when attachPolicyToRole: %s, policyName %s, error is: \n%O', roleName, policyName, ex);
 
       console.log(red(`retry ${times} times`));
@@ -179,9 +197,6 @@ async function makeRole(roleName, createRoleIfNotExist, description = 'FunctionC
       if (ex.code && ex.code.startsWith('InvalidParameter')) {
         throw ex;
       } else if (ex.code && ex.code === 'NoPermission') {
-        console.error(red(`\n${ex.message}\n\nMaybe you need grant AliyunRAMFullAccess policy to the sub-account or use the primary account. You can refer to Chinese doc https://github.com/aliyun/fun/blob/master/docs/usage/faq-zh.md#nopermissionerror-you-are-not-authorized-to-do-this-action-resource-acsramxxxxxxxxxxrole-action-ramgetrole or English doc https://github.com/aliyun/fun/blob/master/docs/usage/faq.md#nopermissionerror-you-are-not-authorized-to-do-this-action-resource-acsramxxxxxxxxxxrole-action-ramgetrole for help.\n\n` +
-        `If you don’t want use the AliyunRAMFullAccess policy or primary account, you can also specify the Role property for Service. You can refer to Chinese doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03-zh-cn.md#aliyunserverlessservice or English doc https://github.com/aliyun/fun/blob/master/docs/specs/2018-04-03.md#aliyunserverlessservice for help.\n`));
-
         throw ex;
       } else {
         console.log(red(`retry ${times} times`));

--- a/lib/security-group.js
+++ b/lib/security-group.js
@@ -1,6 +1,4 @@
 'use strict';
-const { throwProcessedException } = require('./error-message');
-
 var requestOption = {
   method: 'POST'
 };
@@ -68,8 +66,7 @@ async function createSecurityGroup(ecsClient, region, vpcId, securityGroupName) 
     createRs = await ecsClient.request('CreateSecurityGroup', params, requestOption);
 
   } catch (ex) {
-    
-    throwProcessedException(ex, 'AliyunECSFullAccess');
+    throw ex;
   }
 
   return createRs.SecurityGroupId;

--- a/lib/vpc.js
+++ b/lib/vpc.js
@@ -7,7 +7,6 @@ const debug = require('debug')('fun:nas');
 
 const { green } = require('colors');
 const { sleep } = require('./time');
-const { throwProcessedException } = require('./error-message');
 const { getVpcPopClient, getEcsPopClient } = require('./client');
 
 const _ = require('lodash');
@@ -68,8 +67,7 @@ async function createVpc(vpcClient, region, vpcName) {
     createRs = await vpcClient.request('CreateVpc', createParams, requestOption);
     
   } catch (ex) {
-
-    throwProcessedException(ex, 'AliyunVpcFullAccess');
+    throw ex;
   }
 
   const vpcId = createRs.VpcId;
@@ -97,12 +95,14 @@ async function waitVpcUntilAvaliable(vpcClient, region, vpcId) {
     await sleep(800);
 
     const rs = await vpcClient.request('DescribeVpcs', params, requestOption);
+    const vpcs = rs.Vpcs.Vpc;
+    if (vpcs && vpcs.length) {
+      status = vpcs[0].Status;
 
-    status = rs.Vpcs.Vpc[0].Status;
-
-    debug('vpc status is: ' + status);
-
-    console.log(`\t\tvpc already created, waiting for status to be 'Available', now is ${status}`);
+      debug('vpc status is: ' + status);
+  
+      console.log(`\t\tVPC already created, waiting for status to be 'Available', the status is ${status} currently`);
+    }
 
   } while (count < 15 && status !== 'Available');
 

--- a/lib/vswitch.js
+++ b/lib/vswitch.js
@@ -8,7 +8,6 @@ const debug = require('debug')('fun:nas');
 
 const { red } = require('colors');
 const { getProfile } = require('./profile');
-const { throwProcessedException } = require('./error-message');
 
 var requestOption = {
   method: 'POST'
@@ -27,8 +26,7 @@ async function createDefaultVSwitch(vpcClient, region, vpcId, vswitchName) {
       vswitchName: vswitchName
     });
   } catch (ex) {
-
-    throwProcessedException(ex, 'AliyunVPCFullAccess');
+    throw ex;
   }
   return vswitchId;
 }


### PR DESCRIPTION
在遇到有关于权限问题的异常时，用户可以通过 fun 的提示创建出相关权限策略并授权给子账户，解决掉此次遇到的权限问题。

```
You can run the following commands to grant permission 'fc:UpdateService' on 'acs:fc:cn-hangzhou:xxxxxxx:services/xxxxxxx' 
Via the link:  https://shell.aliyun.com/ or aliyun cli
(Note: aliyun cli tool needs to be configured with credentials that have related RAM permissions)

1. Create Policy
aliyun ram CreatePolicy --PolicyName fun-generated-fc-UpdateService-cn-hangzhou-services-xxxxxxx --PolicyDocument "{\"Version\":\"1\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"fc:UpdateService\"],\"Resource\":[\"acs:fc:cn-hangzhou:xxxxxx:services/xxxxxxx\"]}]}"

2. Attach Policy To User
aliyun ram AttachPolicyToUser --PolicyName fun-generated-fc-UpdateService-cn-hangzhou-services-xxxxxxx --PolicyType "Custom" --UserName "YOUR_USER_NAME"
```