### PR TITLE
ellison/improve NasAuto select zone experience

### DIFF
--- a/lib/fc.js
+++ b/lib/fc.js
@@ -35,7 +35,7 @@ const {
   promptForMountPoints,
   promptForFileSystems,
   promptForSecurityGroup,
-  promptForInput: promptForInputContinue
+  promptForInputContinue
 } = require('./init/prompt');
 
 const FUN_GENERATED_SERVICE = 'fun-generated-default-service';
@@ -1430,16 +1430,9 @@ async function invokeFunction({
 }
 
 module.exports = {
-  invokeFcUtilsFunction,
-  makeFcUtilsFunctionNasDirChecker,
-  FUN_GENERATED_SERVICE,
-  makeService,
-  makeFunction,
-  zipCode,
-  detectLibrary,
-  getFcUtilsFunctionCode,
-  invokeFunction,
-  generateFunIngore,
-  parseMountDirPrefix,
-  nasAutoConfigurationIfNecessary
+  zipCode, makeService, makeFunction, invokeFunction,
+  detectLibrary, generateFunIngore, parseMountDirPrefix,
+  FUN_GENERATED_SERVICE, invokeFcUtilsFunction, getFcUtilsFunctionCode,
+  processNasMappingsAndEnvs, processNasAutoConfiguration, nasAutoConfigurationIfNecessary,
+  makeFcUtilsFunctionNasDirChecker
 };

--- a/lib/init/prompt.js
+++ b/lib/init/prompt.js
@@ -238,5 +238,5 @@ module.exports = {
   promptForMountTargets,
   promptForFileSystems,
   promptForSecurityGroup,
-  promptForInput: promptForInputContinue
+  promptForInputContinue
 };

--- a/lib/nas.js
+++ b/lib/nas.js
@@ -432,6 +432,12 @@ async function describeNasZones(nasClient, region) {
   return zones.Zones.Zone;
 }
 
+async function getNasAvailableZones(region) {
+  const nasClient = await getNasPopClient();
+  const zones = await describeNasZones(nasClient, region);
+  return zones.map(zone => { return zone.ZoneId; });
+}
+
 module.exports = {
   findNasFileSystem,
   findMountTarget,
@@ -445,5 +451,6 @@ module.exports = {
   getNasIdFromNasConfig,
   getDefaultNasDir,
   getAvailableNasFileSystems,
-  describeNasZones
+  describeNasZones,
+  getNasAvailableZones
 };

--- a/lib/nas.js
+++ b/lib/nas.js
@@ -7,7 +7,7 @@ const debug = require('debug')('fun:nas');
 const constants = require('./nas/constants');
 const definition = require('./definition');
 const getProfile = require('./profile').getProfile;
-const getFirstAvailableVSwitchId = require('./vswitch').getFirstAvailableVSwitchId;
+const getAvailableVSwitchId = require('./vswitch').getAvailableVSwitchId;
 
 const { green } = require('colors');
 const { sleep } = require('./time');
@@ -71,15 +71,20 @@ async function waitMountPointUntilAvaliable(nasClient, region, fileSystemId, mou
 
 async function createDefaultNasIfNotExist(vpcId, vswitchIds) {
   const nasClient = await getNasPopClient();
+  const vpcClient = await getVpcPopClient();
 
   const profile = await getProfile();
   const region = profile.defaultRegion;
 
-  const fileSystemId = await createNasFileSystemIfNotExist(nasClient, region);
+  const nasZones = await describeNasZones(nasClient, region);
+
+  const { zoneId, vswitchId, storageType } = await getAvailableVSwitchId(vpcClient, region, vswitchIds, nasZones);
+
+  const fileSystemId = await createNasFileSystemIfNotExist(nasClient, region, zoneId, storageType);
 
   debug('fileSystemId: %s', fileSystemId);
 
-  return await createMountTargetIfNotExist(nasClient, region, fileSystemId, vpcId, vswitchIds);
+  return await createMountTargetIfNotExist(nasClient, region, fileSystemId, vpcId, vswitchId);
 }
 
 async function findMountTarget(nasClient, region, fileSystemId, vpcId, vswitchId) {
@@ -109,10 +114,7 @@ async function findMountTarget(nasClient, region, fileSystemId, vpcId, vswitchId
   return null;
 }
 
-async function createMountTargetIfNotExist(nasClient, region, fileSystemId, vpcId, vswitchIds) {
-
-  const vpcClient = await getVpcPopClient();
-  const vswitchId = await getFirstAvailableVSwitchId(vpcClient, region, vswitchIds);
+async function createMountTargetIfNotExist(nasClient, region, fileSystemId, vpcId, vswitchId) {
 
   let mountTargetDomain = await findMountTarget(nasClient, region, fileSystemId, vpcId, vswitchId);
 
@@ -133,13 +135,13 @@ async function createMountTargetIfNotExist(nasClient, region, fileSystemId, vpcI
   return mountTargetDomain;
 }
 
-async function createNasFileSystemIfNotExist(nasClient, region) {
+async function createNasFileSystemIfNotExist(nasClient, region, zoneId, storageType) {
   let fileSystemId = await findNasFileSystem(nasClient, region, NAS_DEFAULT_DESCRIPTION);
 
   if (!fileSystemId) {
     console.log('\t\tcould not find default nas file system, ready to generate one');
 
-    fileSystemId = await createNasFileSystem(nasClient, region);
+    fileSystemId = await createNasFileSystem({ nasClient, region, zoneId, storageType });
 
     console.log(green('\t\tdefault nas file system has been generated, fileSystemId is: ' + fileSystemId));
   } else {
@@ -186,12 +188,18 @@ async function findNasFileSystem(nasClient, region, description) {
   return (fileSystem || {}).FileSystemId;
 }
 
-async function createNasFileSystem(nasClient, region) {
+async function createNasFileSystem({
+  nasClient,
+  region,
+  storageType,
+  zoneId
+}) {
   const params = {
     'RegionId': region,
     'ProtocolType': 'NFS',
-    'StorageType': 'Performance',
-    'Description': NAS_DEFAULT_DESCRIPTION
+    'StorageType': storageType,
+    'Description': NAS_DEFAULT_DESCRIPTION,
+    'ZoneId': zoneId
   };
 
   const rs = await nasClient.request('CreateFileSystem', params, requestOption);
@@ -415,6 +423,15 @@ async function getAvailableNasFileSystems(nasClient) {
     }, []);
 }
 
+async function describeNasZones(nasClient, region) {
+  const params = {
+    'RegionId': region
+  };
+
+  const zones = await nasClient.request('DescribeZones', params, requestOption);
+  return zones.Zones.Zone;
+}
+
 module.exports = {
   findNasFileSystem,
   findMountTarget,
@@ -427,5 +444,6 @@ module.exports = {
   convertTplToServiceNasIdMappings,
   getNasIdFromNasConfig,
   getDefaultNasDir,
-  getAvailableNasFileSystems
+  getAvailableNasFileSystems,
+  describeNasZones
 };

--- a/lib/nas.js
+++ b/lib/nas.js
@@ -432,12 +432,6 @@ async function describeNasZones(nasClient, region) {
   return zones.Zones.Zone;
 }
 
-async function getNasAvailableZones(region) {
-  const nasClient = await getNasPopClient();
-  const zones = await describeNasZones(nasClient, region);
-  return zones.map(zone => { return zone.ZoneId; });
-}
-
 module.exports = {
   findNasFileSystem,
   findMountTarget,
@@ -451,6 +445,5 @@ module.exports = {
   getNasIdFromNasConfig,
   getDefaultNasDir,
   getAvailableNasFileSystems,
-  describeNasZones,
-  getNasAvailableZones
+  describeNasZones
 };

--- a/lib/package/package.js
+++ b/lib/package/package.js
@@ -10,7 +10,7 @@ const { validateNasAndVpcConfig, SERVICE_RESOURCE, iterateResources, isNasAutoCo
 const fs = require('fs-extra');
 const {
   promptForConfirmContinue,
-  promptForInput
+  promptForInputContinue
 } = require('../init/prompt');
 const { getProfile } = require('../profile');
 
@@ -149,7 +149,7 @@ async function generateDefaultOSSBucket() {
     return bucketName;
   }
   if (!await promptForConfirmContinue('Auto generate OSS bucket for you:')) {
-    return (await promptForInput('Input OSS bucket name:')).input;
+    return (await promptForInputContinue('Input OSS bucket name:')).input;
   }
   await ossClient.putBucket(bucketName);
   return bucketName;

--- a/lib/utils/tpl.js
+++ b/lib/utils/tpl.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 
 const yaml = require('js-yaml');
 const _ = require('lodash');

--- a/lib/vpc.js
+++ b/lib/vpc.js
@@ -39,11 +39,11 @@ async function findVpc(vpcClient, region, vpcName) {
     totalCount = rs.TotalCount;
     pageNumber = rs.PageNumber;
     const vpcs = rs.Vpcs.Vpc;
-  
+
     debug('find vpc rs: %s', rs);
 
     vpc = _.find(vpcs, { VpcName: vpcName });
-  
+
     debug('find default vpc: %s', vpc);
 
   } while (!vpc && totalCount && pageNumber && pageNumber * pageSize < totalCount);
@@ -120,7 +120,6 @@ async function createDefaultVSwitchIfNotExist(vpcClient, region, vpcId, vswitchI
   } else {
     console.log(green('\t\tvswitch already generated, vswitchId is: ' + vswitchId));
   }
-
   return vswitchId;
 }
 
@@ -154,12 +153,10 @@ async function createDefaultSecurityGroupIfNotExist(ecsClient, region, vpcId) {
 }
 
 async function createDefaultVpcIfNotExist() {
-
   const profile = await getProfile();
   const region = profile.defaultRegion;
 
   const vpcClient = await getVpcPopClient();
-
   const ecsClient = await getEcsPopClient();
 
   const defaultVpcName = 'fc-fun-vpc';
@@ -176,11 +173,8 @@ async function createDefaultVpcIfNotExist() {
     console.log(green('\t\tvpc already generated, vpcId is: ' + vpcId));
   } else { // create
     console.log('\t\tcould not find default vpc, ready to generate one');
-
     vpcId = await createVpc(vpcClient, region, defaultVpcName);
-
     console.log(green('\t\tdefault vpc has been generated, vpcId is: ' + vpcId));
-
   }
 
   debug('vpcId is %s', vpcId);
@@ -188,9 +182,7 @@ async function createDefaultVpcIfNotExist() {
   const vswitchId = await createDefaultVSwitchIfNotExist(vpcClient, region, vpcId, vswitchIds);
 
   vswitchIds = [ vswitchId ];
-
   // create security
-
   const securityGroupId = await createDefaultSecurityGroupIfNotExist(ecsClient, region, vpcId);
 
   return {

--- a/lib/vswitch.js
+++ b/lib/vswitch.js
@@ -2,12 +2,12 @@
 
 const _ = require('lodash');
 
-const { getFcClient } = require('./client');
-
 const debug = require('debug')('fun:nas');
 
 const { red } = require('colors');
 const { getProfile } = require('./profile');
+const { getFcClient } = require('./client');
+const { promptForConfirmContinue } = require('./init/prompt');
 
 var requestOption = {
   method: 'POST'
@@ -120,11 +120,11 @@ async function getFcAllowedZones() {
 }
 
 async function selectAllowedVSwitchZone(vpcClient, region) {
-  const zones = await describeZones(vpcClient, region);
+  const vpcZones = await describeVpcZones(vpcClient, region);
 
   const fcAllowedZones = await getFcAllowedZones();
 
-  const usedZoneId = await selectVSwitchZoneId(fcAllowedZones, zones);
+  const usedZoneId = await selectVSwitchZoneId(fcAllowedZones, vpcZones);
 
   if (!usedZoneId) {
     throw new Error('no availiable zone for vswitch');
@@ -135,7 +135,7 @@ async function selectAllowedVSwitchZone(vpcClient, region) {
   return usedZoneId;
 }
 
-async function describeZones(vpcClient, region) {
+async function describeVpcZones(vpcClient, region) {
   const params = {
     'RegionId': region
   };
@@ -144,18 +144,63 @@ async function describeZones(vpcClient, region) {
   return zones.Zones.Zone;
 }
 
-async function getFirstAvailableVSwitchId(vpcClient, region, vswitchIds) {
+async function convertToFcAllowedZoneMap(vpcClient, region, vswitchIds) {
   const fcAllowedZones = await getFcAllowedZones();
+  const zoneMap = new Map();
+
   for (const vswitchId of vswitchIds) {
     const zoneId = await getVSwitchZoneId(vpcClient, region, vswitchId);
     if (_.includes(fcAllowedZones, zoneId)) {
-      debug('found first available vswitchId' + vswitchId);
-      return vswitchId;
+      zoneMap.set(zoneId, vswitchId);
     }
   }
-  throw new Error(`
+  if (_.isEmpty(zoneMap)) {
+    throw new Error(`
 Only zoneId ${fcAllowedZones} of vswitch is allowed by VpcConfig.
 Check your vswitch zoneId please.`);
+  }
+
+  return zoneMap;
+}
+
+function convertZones(zones, zoneMap, storageType = 'Performance') {
+  const zoneId = zones.ZoneId;
+  return {
+    zoneId,
+    vswitchId: zoneMap.get(zoneId),
+    storageType
+  };
+}
+
+async function getAvailableVSwitchId(vpcClient, region, vswitchIds, nasZones) {
+
+  const zoneMap = await convertToFcAllowedZoneMap(vpcClient, region, vswitchIds);
+
+  for (const zoneId of zoneMap.keys()) {
+    if (!_.includes(nasZones.map(m => { return m.ZoneId; }), zoneId)) {
+      zoneMap.delete(zoneId);
+    }
+  }
+  const performances = [];
+  const capacities = [];
+
+  _.forEach(nasZones, nasZone => {
+    if (_.includes([...zoneMap.keys()], nasZone.ZoneId)) {
+      if (!_.isEmpty(nasZone.Performance.Protocol)) { performances.push(nasZone); }
+      if (!_.isEmpty(nasZone.Capacity.Protocol)) { capacities.push(nasZone); }
+    }
+  });
+
+  if (!_.isEmpty(performances)) {
+    return convertZones(_.head(performances), zoneMap);
+  }
+
+  if (!_.isEmpty(capacities)) {
+    const yes = await promptForConfirmContinue(`Region ${region} only supports capacity NAS. Do you want to create it automatically?`);
+    if (yes) { return convertZones(_.head(capacities), zoneMap, 'Capacity'); }
+  }
+
+  throw new Error(`No NAS service available under region ${region}.`);
 }
 
 module.exports = {
@@ -163,5 +208,5 @@ module.exports = {
   selectVSwitchZoneId,
   createVSwitch,
   createDefaultVSwitch,
-  getFirstAvailableVSwitchId
+  getAvailableVSwitchId
 };

--- a/lib/vswitch.js
+++ b/lib/vswitch.js
@@ -6,7 +6,7 @@ const debug = require('debug')('fun:nas');
 
 const { red } = require('colors');
 const { getProfile } = require('./profile');
-const { getFcClient } = require('./client');
+const { getFcClient, getNasPopClient } = require('./client');
 const { promptForConfirmContinue } = require('./init/prompt');
 
 var requestOption = {
@@ -91,9 +91,11 @@ async function createVSwitch(vpcClient, {
   return createRs.VSwitchId;
 }
 
-async function selectVSwitchZoneId(fcAllowedZones, vpcZones, nasZoneIds) {
+async function selectVSwitchZoneId(fcAllowedZones, vpcZones, nasZones) {
 
-  const allowedZones = _.filter(vpcZones, z => _.includes(fcAllowedZones, z.ZoneId) && _.includes(nasZoneIds, z.ZoneId));
+  const allowedZones = _.filter(vpcZones, z => {
+    return _.includes(fcAllowedZones, z.ZoneId) && _.includes(nasZones.map(zone => { return zone.ZoneId; }), z.ZoneId);
+  });
 
   const sortedZones = _.sortBy(allowedZones, ['ZoneId']);
 
@@ -120,12 +122,13 @@ async function getFcAllowedZones() {
 }
 
 async function selectAllowedVSwitchZone(vpcClient, region) {
+  const nasClient = await getNasPopClient();
 
   const fcAllowedZones = await getFcAllowedZones();
-  const nasZoneIds = await require('./nas').getNasAvailableZones(region);
   const vpcZones = await describeVpcZones(vpcClient, region);
+  const nasZones = await await require('./nas').describeNasZones(nasClient, region);
 
-  const usedZoneId = await selectVSwitchZoneId(fcAllowedZones, vpcZones, nasZoneIds);
+  const usedZoneId = await selectVSwitchZoneId(fcAllowedZones, vpcZones, nasZones);
 
   if (!usedZoneId) {
     throw new Error('no availiable zone for vswitch');

--- a/lib/vswitch.js
+++ b/lib/vswitch.js
@@ -91,9 +91,9 @@ async function createVSwitch(vpcClient, {
   return createRs.VSwitchId;
 }
 
-async function selectVSwitchZoneId(fcAllowedZones, zones) {
+async function selectVSwitchZoneId(fcAllowedZones, vpcZones, nasZoneIds) {
 
-  const allowedZones = _.filter(zones, z => _.includes(fcAllowedZones, z.ZoneId));
+  const allowedZones = _.filter(vpcZones, z => _.includes(fcAllowedZones, z.ZoneId) && _.includes(nasZoneIds, z.ZoneId));
 
   const sortedZones = _.sortBy(allowedZones, ['ZoneId']);
 
@@ -120,11 +120,12 @@ async function getFcAllowedZones() {
 }
 
 async function selectAllowedVSwitchZone(vpcClient, region) {
-  const vpcZones = await describeVpcZones(vpcClient, region);
 
   const fcAllowedZones = await getFcAllowedZones();
+  const nasZoneIds = await require('./nas').getNasAvailableZones(region);
+  const vpcZones = await describeVpcZones(vpcClient, region);
 
-  const usedZoneId = await selectVSwitchZoneId(fcAllowedZones, vpcZones);
+  const usedZoneId = await selectVSwitchZoneId(fcAllowedZones, vpcZones, nasZoneIds);
 
   if (!usedZoneId) {
     throw new Error('no availiable zone for vswitch');

--- a/test/tpl-mock-data.js
+++ b/test/tpl-mock-data.js
@@ -23,6 +23,61 @@ const tpl = {
 };
 
 
+const tplWithNasAuto = {
+  'ROSTemplateFormatVersion': '2015-09-01',
+  'Transform': 'Aliyun::Serverless-2018-04-03',
+  'Resources': {
+    'localdemo': {
+      'Type': 'Aliyun::Serverless::Service',
+      'Properties': {
+        'Description': 'php local invoke demo',
+        'NasConfig': 'Auto'
+      },
+      'python3': {
+        'Type': 'Aliyun::Serverless::Function',
+        'Properties': {
+          'Handler': 'index.handler',
+          'CodeUri': 'python3',
+          'Description': 'Hello world with python3!',
+          'Runtime': 'python3'
+        }
+      }
+    }
+  }
+};
+
+const tplWithTheSameCodeUriAndRuntime = {
+  'ROSTemplateFormatVersion': '2015-09-01',
+  'Transform': 'Aliyun::Serverless-2018-04-03',
+  'Resources': {
+    'localdemo': {
+      'Type': 'Aliyun::Serverless::Service',
+      'Properties': {
+        'Description': 'php local invoke demo',
+        'NasConfig': 'Auto'
+      },
+      'fun1': {
+        'Type': 'Aliyun::Serverless::Function',
+        'Properties': {
+          'Handler': 'index.handler',
+          'CodeUri': './',
+          'Description': 'Hello world with nodejs6!',
+          'Runtime': 'nodejs6'
+        }
+      },
+      'fun2': {
+        'Type': 'Aliyun::Serverless::Function',
+        'Properties': {
+          'Handler': 'index.handler',
+          'CodeUri': './',
+          'Description': 'Hello world with nodejs6!',
+          'Runtime': 'nodejs6'
+        }
+      }
+    }
+  }
+};
+
 const tplWithDuplicatedFunctionsInService = {
   'ROSTemplateFormatVersion': '2015-09-01',
   'Transform': 'Aliyun::Serverless-2018-04-03',
@@ -137,4 +192,10 @@ const rosTemplate = {
   }
 };
 
-module.exports = { tpl, tplWithDuplicatedFunction, tplWithDuplicatedFunctionsInService, rosTemplate };
+module.exports = {
+  tpl, rosTemplate,
+  tplWithNasAuto,
+  tplWithDuplicatedFunction,
+  tplWithTheSameCodeUriAndRuntime,
+  tplWithDuplicatedFunctionsInService
+};

--- a/test/vswitch.test.js
+++ b/test/vswitch.test.js
@@ -56,7 +56,39 @@ describe('test selectVSwitchZoneId', async () => {
       }
     ];
 
-    const rs = await vswitch.selectVSwitchZoneId(fcAllowedzones, vpcZones);
+    const nasZones = [
+      {
+        'Performance': {
+          'Protocol': []
+        },
+        'Capacity': {
+          'Protocol': [
+            'nfs',
+            'smb',
+            'nasplus'
+          ]
+        },
+        'ZoneId': 'cn-hangzhou-b'
+      },
+      {
+        'Performance': {
+          'Protocol': [
+            'nfs',
+            'smb'
+          ]
+        },
+        'Capacity': {
+          'Protocol': [
+            'nfs',
+            'smb',
+            'nasplus'
+          ]
+        },
+        'ZoneId': 'cn-hangzhou-g'
+      }
+    ];
+
+    const rs = await vswitch.selectVSwitchZoneId(fcAllowedzones, vpcZones, nasZones);
     expect(rs).to.eql('cn-hangzhou-g');
   });
 });


### PR DESCRIPTION
Fun 工具默认创建的 Nas 是高吞吐和高 IOPS（适合高性能业务）的性能型 Nas。

问题：青岛 region 下性能型 Nas 服务不可用，仅支持容量型 Nas。导致 fun deploy 报错：`The specified AZone inventory is insufficient., URL: http://nas.cn-qingdao.aliyuncs.com/`

解决方案：
1. fun deploy 创建 vswitch 时可用区应为： fc，vswitch, nas 允许的可用区三者交集。
2. Fun 为用户创建文件系统时，检测到在可用区下无法创建性能型 Nas 时，尝试帮用户创建容量型 Nas，并以交互的方式提醒用户容量型 Nas 可能带来的问题，如延迟等... 如 region 的 可用区下性能型和容量型均不可提供服务，报错提示用户。