### PR TITLE
Coco/fix upload big file for http invoke

### DIFF
--- a/lib/deploy/deploy-by-tpl.js
+++ b/lib/deploy/deploy-by-tpl.js
@@ -241,9 +241,9 @@ async function deployService(baseDir, serviceName, serviceRes, onlyConfig, tplPa
   }
 
   if (!roleArn && policies) { // if roleArn exist, then ignore polices
-    console.log('\tattaching policies ' + policies + ' to role: ' + roleName);
+    console.log('\tattaching policies ' + JSON.stringify(policies) + ' to role: ' + roleName);
     await deployPolicies(serviceName, roleName, policies);
-    console.log(green('\tattached policies ' + policies + ' to role: ' + roleName));
+    console.log(green('\tattached policies ' + JSON.stringify(policies) + ' to role: ' + roleName));
   }
 
   if (!roleArn && (!_.isEmpty(vpcConfig) || !_.isEmpty(nasConfig))) {

--- a/lib/deploy/deploy-support.js
+++ b/lib/deploy/deploy-support.js
@@ -152,12 +152,10 @@ async function makeSlsProject(projectName, description) {
           description
         });
       } catch (ex) {
-        if (ex.code === 'Unauthorized') {
+        if (ex.code === 'Unauthorized' || ex.code === 'InvalidAccessKeyId') {
           throw ex;
         } else if (ex.code === 'ProjectAlreadyExist') {
           throw new Error(red(`error: sls project ${projectName} already exist, it may be in other region or created by other users.`));
-        } else if (ex.code === 'ProjectNotExist') {
-          throw new Error(red(`Please go to https://sls.console.aliyun.com/ to open the LogServce.`));
         } else {
           debug('error when createProject, projectName is %s, error is: \n%O', projectName, ex);
           console.log(red(`\tretry ${times} times`));

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -21,6 +21,8 @@ const { addEnv, addInstallTargetEnv, resolveLibPathsFromLdConf } = require('./in
 const { findPathsOutofSharedPaths } = require('./docker-support');
 const { processorTransformFactory } = require('./error-processor');
 
+var isWin = process.platform === 'win32';
+
 const _ = require('lodash');
 
 require('draftlog').into(console);
@@ -557,7 +559,6 @@ async function run(opts, event, outputStream, errorStream, context = {}) {
     errorStream: errorStream
   });
 
-  var isWin = process.platform === 'win32';
   if (!isWin) {
     container.modem.demuxStream(stream, outputStream, errorTransform);
   }
@@ -714,12 +715,12 @@ async function startContainer(opts, outputStream, errorStream, context = {}) {
       containers.delete(container.id);
     },
 
-    exec: async (cmd, { cwd = '', env = {}, outputStream, errorStream, verbose = false, context = {} } = {}) => {
+    exec: async (cmd, { cwd = '', env = {}, outputStream, errorStream, verbose = false, context = {}, event = null } = {}) => {
       const options = {
         Cmd: cmd,
         Env: dockerOpts.resolveDockerEnv(env),
         Tty: false,
-        AttachStdin: false,
+        AttachStdin: !isWin,
         AttachStdout: true,
         AttachStderr: true,
         WorkingDir: cwd
@@ -730,10 +731,14 @@ async function startContainer(opts, outputStream, errorStream, context = {}) {
 
       const exec = await container.exec(options);
 
-      const stream = await exec.start({ hijack: true, stdin: false });
+      const stream = await exec.start({ hijack: true, stdin: !isWin });
 
       // todo: have to wait, otherwise stdin may not be readable
       await new Promise(resolve => setTimeout(resolve, 30));
+
+      if (!isWin) {
+        writeEventToStreamAndClose(stream, event);
+      }
 
       if (!outputStream) {
         outputStream = process.stdout;
@@ -770,7 +775,7 @@ async function startInstallationContainer({ runtime, imageName, codeUri, targets
   }
 
   const codeMount = await resolveCodeUriToMount(codeUri, false);
-  
+
   const installMounts = conventInstallTargetsToMounts(targets);
   const passwdMount = await resolvePasswdMount();
   const mounts = _.compact([codeMount, ...installMounts, passwdMount]);

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -21,7 +21,7 @@ const { addEnv, addInstallTargetEnv, resolveLibPathsFromLdConf } = require('./in
 const { findPathsOutofSharedPaths } = require('./docker-support');
 const { processorTransformFactory } = require('./error-processor');
 
-var isWin = process.platform === 'win32';
+const isWin = process.platform === 'win32';
 
 const _ = require('lodash');
 
@@ -716,11 +716,13 @@ async function startContainer(opts, outputStream, errorStream, context = {}) {
     },
 
     exec: async (cmd, { cwd = '', env = {}, outputStream, errorStream, verbose = false, context = {}, event = null } = {}) => {
+      const stdin = event ? true : false;
+
       const options = {
         Cmd: cmd,
         Env: dockerOpts.resolveDockerEnv(env),
         Tty: false,
-        AttachStdin: !isWin,
+        AttachStdin: stdin,
         AttachStdout: true,
         AttachStderr: true,
         WorkingDir: cwd
@@ -731,12 +733,12 @@ async function startContainer(opts, outputStream, errorStream, context = {}) {
 
       const exec = await container.exec(options);
 
-      const stream = await exec.start({ hijack: true, stdin: !isWin });
+      const stream = await exec.start({ hijack: true, stdin });
 
       // todo: have to wait, otherwise stdin may not be readable
       await new Promise(resolve => setTimeout(resolve, 30));
 
-      if (!isWin) {
+      if (event !== null) {
         writeEventToStreamAndClose(stream, event);
       }
 

--- a/lib/error-processor.js
+++ b/lib/error-processor.js
@@ -117,7 +117,7 @@ class RosStackValidationErrorProcessor extends ErrorProcessor {
 
 class LogInactiveErrorProcessor extends ErrorProcessor {
   match(message, err) {
-    return (err && err.code === 'InvalidAccessKeyId' && _.includes(message, 'AccessKeyId') && _.includes(message, 'is inactive'));
+    return err && err.code === 'InvalidAccessKeyId' && _.includes(message, 'AccessKeyId') && _.includes(message, 'is inactive');
   }
 
   async process(message) {

--- a/lib/error-processor.js
+++ b/lib/error-processor.js
@@ -20,7 +20,9 @@ class FilterChain {
       new DockerNotStartedOrInstalledErrorProcessor(options),
       new FcServiceNotEnabledProcessor(options),
       new RamInactiveErrorProcessor(options),
-      new RosStackValidationErrorProcessor(options)
+      new RosStackValidationErrorProcessor(options),
+      new LogInactiveErrorProcessor(options)
+
     ];
   }
 
@@ -94,18 +96,14 @@ class FcServiceNotEnabledProcessor extends ErrorProcessor {
 
 class RamInactiveErrorProcessor extends ErrorProcessor {
   match(message, err) {
-    if (_.includes(message, 'Account is inactive to this service')
-      && _.includes(message, 'ram.aliyuncs.com')) {
-      return true;
-    }
-
-    return false;
+    return (_.includes(message, 'Account is inactive to this service') && _.includes(message, 'ram.aliyuncs.com'));
   }
 
   async process(message) {
     console.log(red('Ram service is not enabled for current user. Please enable Ram service before using fun.\nYou can enable Ram service on this page https://www.aliyun.com/product/ram .'));
   }
 }
+
 
 class RosStackValidationErrorProcessor extends ErrorProcessor {
   match(message, err) {
@@ -114,6 +112,16 @@ class RosStackValidationErrorProcessor extends ErrorProcessor {
 
   async process(message) {
     console.log(red('StackValidationFailed: template syntax mismatch with ROS support. You may be able to solve it by executing the command \'fun package\'.'));
+  }
+}
+
+class LogInactiveErrorProcessor extends ErrorProcessor {
+  match(message, err) {
+    return (err.code === 'InvalidAccessKeyId' && _.includes(message, 'AccessKeyId') && _.includes(message, 'is inactive'));
+  }
+
+  async process(message) {
+    console.log(red('\nPlease go to https://sls.console.aliyun.com/ to open the LogServce.'));
   }
 }
 
@@ -200,25 +208,25 @@ class DynamicLinkLibraryMissingProcessor extends ErrorProcessor {
     if (packageName) {
       process.nextTick(() => {
         console.log(red(`Tips: Fun has detected that you are missing ${lib} library, you can try to install it like this:
-  
+
   step1: fun install sbox -f ${this.serviceName}/${this.functionName} -i
   step2: fun-install apt-get install ${packageName}
   step3: type 'exit' to exit container and then reRun your function
 
-Also you can install dependencies through one command: 
+Also you can install dependencies through one command:
 
   fun install sbox -f ${this.serviceName}/${this.functionName} --cmd 'fun-install apt-get install ${packageName}'
 `));
       });
     } else {
       console.log(red(`Tips: Fun has detected that you are missing ${lib} library, you can try to install it like this:
-      
+
   step1: open this page ${this.debianPakcageUrlPrefix}${lib} to find your missing dependency
   step2: fun install sbox -f ${this.serviceName}/${this.functionName} -i
   step3: fun-install apt-get install YourPackageName
   step4: type 'exit' to exit container and then reRun your function
 
-Also you can install dependencies through one command: 
+Also you can install dependencies through one command:
 
   fun install sbox -f ${this.serviceName}/${this.functionName} --cmd 'fun-install apt-get install YourPackageName'
 `));

--- a/lib/error-processor.js
+++ b/lib/error-processor.js
@@ -117,7 +117,7 @@ class RosStackValidationErrorProcessor extends ErrorProcessor {
 
 class LogInactiveErrorProcessor extends ErrorProcessor {
   match(message, err) {
-    return (err.code === 'InvalidAccessKeyId' && _.includes(message, 'AccessKeyId') && _.includes(message, 'is inactive'));
+    return (err && err.code === 'InvalidAccessKeyId' && _.includes(message, 'AccessKeyId') && _.includes(message, 'is inactive'));
   }
 
   async process(message) {

--- a/lib/exception-handler.js
+++ b/lib/exception-handler.js
@@ -8,6 +8,7 @@ const { FilterChain } = require('./error-processor');
 const filterChain = new FilterChain();
 
 const handler = function (err) {
+  // err may be null when fun local || fun build || fun install
   filterChain.process(err.message, err).then(processed => {
     // If the verbose option is true, in addition to the message,
     // print the stack of the error.

--- a/lib/local/http-invoke.js
+++ b/lib/local/http-invoke.js
@@ -1,24 +1,24 @@
 'use strict';
 
-const { startContainer } = require('../docker');
-
 var AsyncLock = require('async-lock');
 var lock = new AsyncLock();
+var watch = require('node-watch');
 
-const dockerOpts = require('../docker-opts');
 const rimraf = require('rimraf');
 const ignore = require('../../lib/package/ignore');
-
+const Invoke = require('./invoke');
 const debug = require('debug')('fun:local');
 const streams = require('memory-streams');
-const FC_HTTP_PARAMS = 'x-fc-http-params';
-const { red } = require('colors');
-const { getHttpRawBody, generateHttpParams, parseHttpTriggerHeaders, validateHeader } = require('../local/http');
 const docker = require('../docker');
-const { validateSignature, parseOutputStream } = require('./http');
-const Invoke = require('./invoke');
+const dockerOpts = require('../docker-opts');
+const FC_HTTP_PARAMS = 'x-fc-http-params';
 
-var watch = require('node-watch');
+const { red } = require('colors');
+const { startContainer } = require('../docker');
+const { validateSignature, parseOutputStream } = require('./http');
+const { getHttpRawBody, generateHttpParams, parseHttpTriggerHeaders, validateHeader } = require('../local/http');
+
+const isWin = process.platform === 'win32';
 
 function is2xxStatusCode(statusCode) {
   return statusCode && statusCode.startsWith('2');
@@ -157,7 +157,7 @@ class HttpInvoke extends Invoke {
 
       if (this.debugPort && !this.runner) {
         // don't reuse container
-        const cmd = docker.generateDockerCmd(this.functionProps, true, event);
+        const cmd = docker.generateDockerCmd(this.functionProps, true);
 
         this.containerName = docker.generateRamdomContainerName();
 
@@ -169,7 +169,8 @@ class HttpInvoke extends Invoke {
           this.debugPort,
           envs,
           this.dockerUser,
-          this.debugIde);
+          this.debugIde
+        );
 
         await docker.run(opts,
           event,
@@ -178,7 +179,7 @@ class HttpInvoke extends Invoke {
         // reuse container
         debug('http doInvoke, acquire invoke lock');
 
-        const cmd = [dockerOpts.resolveMockScript(this.runtime), ...docker.generateDockerCmd(this.functionProps, true, this._invokeInitializer, event)];
+        const cmd = [dockerOpts.resolveMockScript(this.runtime), ...docker.generateDockerCmd(this.functionProps, true, this._invokeInitializer, isWin ? event : null)];
 
         debug(`http doInvoke, cmd is : ${cmd}`);
 
@@ -196,7 +197,8 @@ class HttpInvoke extends Invoke {
             context: {
               serviceName: this.serviceName,
               functionName: this.functionName
-            }
+            },
+            event
           });
 
           this._invokeInitializer = false;

--- a/lib/local/http-invoke.js
+++ b/lib/local/http-invoke.js
@@ -198,7 +198,7 @@ class HttpInvoke extends Invoke {
               serviceName: this.serviceName,
               functionName: this.functionName
             },
-            event
+            event: !isWin ? event : null
           });
 
           this._invokeInitializer = false;

--- a/lib/validate/schema/police.js
+++ b/lib/validate/schema/police.js
@@ -4,7 +4,7 @@ const policySchema = {
   '$id': '/Resources/Service/Role',
   'type': 'object',
   'properties': {
-    'Version': { 
+    'Version': {
       'type': 'string'
     },
     'Statement': {

--- a/lib/validate/schema/police.js
+++ b/lib/validate/schema/police.js
@@ -20,7 +20,10 @@ const policySchema = {
             'items': { 'type': 'string' }
           },
           'Resource': {
-            'type': 'string'
+            oneOf: [
+              { 'type': 'string' },
+              { 'type': 'array', 'items': { 'type': 'string' } }
+            ]
           }
         },
         'required': ['Effect', 'Action', 'Resource'],


### PR DESCRIPTION
问题 1：fun dpeloy 部署日志服务出现 AccessKeyId ... is inactive，反复排查 ak 信息正确，原因是日志服务未开通导致。
解决：捕捉错误特征并引导用户去日志服务首页开通服务。

问题 2: 修复 mac 上 http invoke 时表单过大的问题。

版本 1 ： windows 和 mac 都用 dockerode exec 的 stdin 传递事件。
发现的问题：dockerode exec 在 windows 上有问题，用 exec 的 stdin 传递事件，当调用 stream.end() 时，会直接导致 exec 退出，且 ExitCode 为 null。

版本 2：不使用 stdin 传递事件，而是自定义参数 --event 和 --decode 来处理 event。
发现的问题：表单过大时会出现报错：/var/fc/runtime/nodejs10/mock exited with code 126，目前此问题在 mac 和 windows 上均有发生。

版本3（此 pr）：windows 上行为和版本 2 保持一致，并修复 mac 表单限制。mac 上在 docker exec 时回退为 stdin。需要在 dockerode 提一个 issue，待 dockerode 修复后。fun 才真正解决此问题。

问题 3: 修复部署时 Policies 显示 [objec],[objec] 的问题以及配置 Policies 的 Resources 新增类型支持
