### PR TITLE
coco/support upload local resources to nas forcely

### DIFF
--- a/bin/fun-deploy.js
+++ b/bin/fun-deploy.js
@@ -30,10 +30,12 @@ program
 
   .option('-t, --template [template]', 'The path of fun template file.')
   .option('-c, --only-config', 'Update only configuration flags')
-  .option('-y, --assume-yes', 'Automatic yes to prompts. Assume "yes" as answer to all prompts and run non-interactively.\n')
-  .option('--use-ros', 'Deploy resources using ROS')
-  .option('--stack-name <stackName>', 'The name of the ROS stack')
   .option('-p, --parameter-override <parameter>', `A parameter structures that specify input parameters for your stack template.`, parsePairs)
+  .option('-y, --assume-yes', 'Automatic yes to prompts. Assume "yes" as answer to all prompts and run non-interactively.\n')
+
+  .option('--use-ros', 'Deploy resources using ROS')
+  .option('--use-nas', 'Automatically upload local resources to NAS.')
+  .option('--stack-name <stackName>', 'The name of the ROS stack')
   .parse(process.argv);
 
 if (program.args.length > 1) {
@@ -47,6 +49,7 @@ const context = {
   onlyConfig: program.onlyConfig || false,
   template: program.template,
   useRos: program.useRos,
+  useNas: program.useNas,
   stackName: program.stackName,
   assumeYes: program.assumeYes || false,
   parameterOverride: program.parameterOverride

--- a/bin/fun-package.js
+++ b/bin/fun-package.js
@@ -16,6 +16,7 @@ program
   .option('-t, --template <template>', 'The template file path')
   .option('-b, --oss-bucket <bucket>', 'The name of the oss bucket where Fun uploads local artifacts')
   .option('-o, --output-template-file <filename>', 'The output path of the packaged template file')
+  .option('--use-nas', 'Automatically upload local resources to NAS.')
   .parse(process.argv);
 
 if (program.args.length > 1) {

--- a/lib/build/tips.js
+++ b/lib/build/tips.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const _ = require('lodash');
+const path = require('path');
 const { yellow } = require('colors');
 
 function showBuildNextTips() {
@@ -42,6 +44,46 @@ Start with customDomain: \n* ${startTip}
 Debug with customDomain: \n* ${debugTip}\n`));
 }
 
+function showTipsForNasYml(baseDir, serviceNasMappings) {
+  if (_.isEmpty(serviceNasMappings)) { return; }
+
+  const localNasDir = [];
+  _.forEach(serviceNasMappings, (nasMappings, key) => {
+    for (const nasMapping of nasMappings) {
+      localNasDir.push(path.resolve(baseDir, nasMapping.localNasDir));
+    }
+  });
+  console.log(yellow(`
+===================================== Tips for nas resources ==================================================
+Fun has detected the .nas.yml file in your working directory, which contains the local directory:
+
+        ${localNasDir.join('\n\t')}
+  `));
+  console.log(yellow(`The above directories will be automatically ignored when 'fun deploy'.
+Any content of the above directories changes，you need to use 'fun nas sync' to sync local resources to remote.
+===============================================================================================================`));
+}
+
+function showPackageNextTips(packedYmlPath) {
+  const deployTip = 'fun deploy';
+
+  const relative = path.relative(process.cwd(), packedYmlPath);
+  const DEFAULT_PACKAGED_YAML_NAME = 'template.packaged.yml';
+
+  let templateParam = '';
+  if (relative !== DEFAULT_PACKAGED_YAML_NAME) {
+    templateParam = ` -t ${relative}`;
+  }
+
+  console.log(yellow(`\nTips for next step
+======================
+* Deploy Resources: ${deployTip}${templateParam}`));
+}
+
 module.exports = {
-  showBuildNextTips, showInstallNextTips, showLocalStartNextTips
+  showTipsForNasYml,
+  showBuildNextTips,
+  showInstallNextTips,
+  showPackageNextTips,
+  showLocalStartNextTips
 };

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -1,13 +1,14 @@
 'use strict';
 
+const fs = require('fs-extra');
+const path = require('path');
+const debug = require('debug')('fun:deploy');
+
+const { yellow, red, green } = require('colors');
 const { ensureFilesModified } = require('../utils/file');
 const { detectTplPath, validateTplName } = require('../tpl');
-const { detectFramework, generateTemplateContent, execFrameworkActions } = require('../frameworks/framework');
-const path = require('path');
-const { yellow, red, green } = require('colors');
-const fs = require('fs-extra');
 const { promptForConfirmContinue, promptForInputContinue } = require('../init/prompt');
-const debug = require('debug')('fun:deploy');
+const { detectFramework, generateTemplateContent, execFrameworkActions } = require('../frameworks/framework');
 
 async function deploy(context) {
   let tplPath = context.template;
@@ -43,7 +44,7 @@ async function deploy(context) {
       await fs.writeFile(tplPath, templateYmlContent);
 
       console.log(green('Generate Fun project successfully!'));
-      
+
       console.log(yellow('\n\n========= Fun will use \'fun deploy\' to deploy your application to Function Compute! ========='));
     } else {
       throw new Error(red('could not detect your project framework, please contact us on https://github.com/alibaba/funcraft/issues'));

--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -6,6 +6,7 @@ async function pack(options) {
 
   let tplPath = options.template;
   const bucket = options.ossBucket;
+  const useNas = options.useNas;
   const outputTemplateFile = options.outputTemplateFile;
 
   if (!tplPath) {
@@ -18,7 +19,7 @@ async function pack(options) {
 
   validateTplName(tplPath);
 
-  await require('../package/package').pack(tplPath, bucket, outputTemplateFile);
+  await require('../package/package').pack(tplPath, bucket, outputTemplateFile, useNas);
 }
 
 module.exports = pack;

--- a/lib/deploy/deploy-by-tpl.js
+++ b/lib/deploy/deploy-by-tpl.js
@@ -13,6 +13,7 @@ const date = require('date-and-time');
 const { deployByRos } = require('./deploy-support-ros');
 const { importService } = require('../import/service');
 const { getProfile, mark } = require('../profile');
+const { showTipsForNasYml } = require('../build/tips');
 const { green, yellow, red } = require('colors');
 const { displayTriggerInfo } = require('../../lib/trigger');
 const { showResourcesChanges } = require('./deploy-diffs');
@@ -895,7 +896,6 @@ async function deployByApi(baseDir, tpl, tplPath, context) {
 }
 
 async function deploy(tplPath, context) {
-
   if (!context.useRos) {
     await validate(tplPath);
   } else {
@@ -904,13 +904,10 @@ async function deploy(tplPath, context) {
   }
 
   const profile = await getProfile();
-
   console.log(`using region: ${profile.defaultRegion}`);
   console.log(`using accountId: ${mark(profile.accountId)}`);
   console.log(`using accessKeyId: ${mark(profile.accessKeyId)}`);
-  console.log(`using timeout: ${profile.timeout}`);
-
-  console.log('');
+  console.log(`using timeout: ${profile.timeout}\n`);
 
   const tpl = await getTpl(tplPath);
 
@@ -924,35 +921,14 @@ async function deploy(tplPath, context) {
     } else {
       console.log(yellow(`missing --stack-name parameter, using default stackName '${dirName}'`));
     }
-
     const stackName = context.stackName || DEFAULT_STACK_NAME;
-
     await deployByRos(baseDir, stackName, tpl, context.assumeYes, context.parameterOverride);
   } else {
+
     await deployByApi(baseDir, tpl, tplPath, context);
     const serviceNasMappings = await getNasMappingsFromNasYml(getNasYmlPath(tplPath));
     showTipsForNasYml(getRootBaseDir(baseDir), serviceNasMappings);
   }
-}
-
-function showTipsForNasYml(baseDir, serviceNasMappings) {
-  if (_.isEmpty(serviceNasMappings)) { return; }
-
-  const localNasDir = [];
-  _.forEach(serviceNasMappings, (nasMappings, key) => {
-    for (const nasMapping of nasMappings) {
-      localNasDir.push(path.resolve(baseDir, nasMapping.localNasDir));
-    }
-  });
-  console.log(yellow(`
-===================================== Tips for nas resources ==================================================
-Fun has detected the .nas.yml file in your working directory, which contains the local directory:
-
-        ${localNasDir.join('\n\t')}
-  `));
-  console.log(yellow(`The above directories will be automatically ignored when 'fun deploy'.
-Any content of the above directories changes，you need to use 'fun nas sync' to sync local resources to remote.
-===============================================================================================================`));
 }
 
 module.exports = {

--- a/lib/deploy/deploy-by-tpl.js
+++ b/lib/deploy/deploy-by-tpl.js
@@ -99,7 +99,10 @@ async function deployTriggers(serviceName, functionName, events) {
   }
 }
 
-async function deployFunction(baseDir, serviceName, functionName, functionRes, nasConfig, vpcConfig, onlyConfig, tplPath, skipTrigger = false) {
+async function deployFunction({ baseDir, nasConfig, vpcConfig, useNas,
+  serviceName, functionName, functionRes,
+  onlyConfig, tplPath, skipTrigger = false
+}) {
   const properties = functionRes.Properties || {};
 
   const rs = await makeFunction(baseDir, {
@@ -117,7 +120,7 @@ async function deployFunction(baseDir, serviceName, functionName, functionRes, n
     instanceConcurrency: properties.InstanceConcurrency,
     nasConfig,
     vpcConfig
-  }, onlyConfig, tplPath);
+  }, onlyConfig, tplPath, useNas);
 
   if (!skipTrigger) {
     await deployTriggers(serviceName, functionName, functionRes.Events);
@@ -138,7 +141,7 @@ async function reloadServiceRes(tplPath, name) {
   return {};
 }
 
-async function deployFunctions(baseDir, serviceName, serviceRes, onlyConfig, tplPath, skipTrigger) {
+async function deployFunctions({ baseDir, serviceName, serviceRes, onlyConfig, tplPath, skipTrigger, useNas }) {
   const serviceProps = serviceRes.Properties || {};
 
   let deployedFunctions = [];
@@ -155,7 +158,13 @@ async function deployFunctions(baseDir, serviceName, serviceRes, onlyConfig, tpl
         const afterDeployLog = onlyConfig ? 'config update success' : 'deploy success';
 
         console.log(`\tWaiting for function ${k} ${beforeDeployLog}...`);
-        const rs = await deployFunction(baseDir, serviceName, k, v, serviceProps.NasConfig, serviceProps.VpcConfig, onlyConfig, tplPath, skipTrigger);
+
+        const rs = await deployFunction({ baseDir, serviceName, onlyConfig, tplPath, skipTrigger, useNas,
+          functionName: k,
+          functionRes: v,
+          nasConfig: serviceProps.NasConfig,
+          vpcConfig: serviceProps.VpcConfig
+        });
         deployedFunctions.push(k);
         console.log(green(`\tfunction ${k} ${afterDeployLog}`));
 
@@ -270,7 +279,7 @@ async function generateServiceRole({ serviceName, vpcConfig, nasConfig,
   return ((role || {}).Role || {}).Arn || roleArn || '';
 }
 
-async function deployService(baseDir, serviceName, serviceRes, onlyConfig, tplPath, skipTrigger = false) {
+async function deployService({ baseDir, serviceName, serviceRes, onlyConfig, tplPath, skipTrigger = false, useNas }) {
   const properties = (serviceRes.Properties || {});
 
   const internetAccess = 'InternetAccess' in properties ? properties.InternetAccess : null;
@@ -296,7 +305,7 @@ async function deployService(baseDir, serviceName, serviceRes, onlyConfig, tplPa
     nasConfig: nasConfig
   });
 
-  await deployFunctions(baseDir, serviceName, serviceRes, onlyConfig, tplPath, skipTrigger);
+  await deployFunctions({ baseDir, serviceName, serviceRes, onlyConfig, tplPath, skipTrigger, useNas });
 }
 
 async function deployLogstoreDefaultIndex(projectName, logstoreName) {
@@ -713,13 +722,13 @@ async function partialDeployment(sourceName, tpl) {
   return {};
 }
 
-async function deployTplService(baseDir, serviceName, serviceRes, onlyConfig, tplPath) {
+async function deployTplService({ baseDir, serviceName, serviceRes, onlyConfig, tplPath, useNas }) {
 
   const beforeDeployLog = onlyConfig ? 'config to be updated' : 'to be deployed';
   const afterDeployLog = onlyConfig ? 'config update success' : 'deploy success';
 
   console.log(`Waiting for service ${serviceName} ${beforeDeployLog}...`);
-  await deployService(baseDir, serviceName, serviceRes, onlyConfig, tplPath);
+  await deployService({ baseDir, serviceName, serviceRes, onlyConfig, tplPath, useNas });
   console.log(green(`service ${serviceName} ${afterDeployLog}\n`));
 }
 
@@ -820,7 +829,12 @@ async function deployByApi(baseDir, tpl, tplPath, context) {
         return;
       }
 
-      await deployTplService(baseDir, resourceName, resourceRes, context.onlyConfig, tplPath);
+      await deployTplService({ baseDir, tplPath,
+        serviceName: resourceName,
+        serviceRes: resourceRes,
+        useNas: context.useNas,
+        onlyConfig: context.onlyConfig
+      });
     } else if (resourceType === definition.FLOW_RESOURCE) {
       await deployFlow(resourceName, resourceRes, tpl, context.parameterOverride, baseDir);
     } else {
@@ -841,7 +855,12 @@ async function deployByApi(baseDir, tpl, tplPath, context) {
   for (const [name, resource] of Object.entries(tpl.Resources)) {
     if (resource.Type === 'Aliyun::Serverless::Service') {
 
-      await deployTplService(baseDir, name, resource, context.onlyConfig, tplPath);
+      await deployTplService({ baseDir, tplPath,
+        serviceName: name,
+        serviceRes: resource,
+        useNas: context.useNas,
+        onlyConfig: context.onlyConfig
+      });
     } else if (resource.Type === 'Aliyun::Serverless::Api') {
       console.log(`Waiting for api gateway ${name} to be deployed...`);
       await deployApigateway(name, {
@@ -896,9 +915,7 @@ async function deploy(tplPath, context) {
   const tpl = await getTpl(tplPath);
 
   const baseDir = path.resolve(tplPath, '..');
-
   const dirName = path.basename(baseDir);
-
   const DEFAULT_STACK_NAME = `fun_default_stack_for_${dirName}`;
 
   if (context.useRos) {

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -612,7 +612,7 @@ async function processNasMappingsAndEnvs({ tpl, tplPath, runtime, codeUri, baseD
 
   const localDirs = _.map(runtimeDependencyMappings[runtime], mapping => path.join(codeUri, mapping.localDir));
 
-  if (_.isEmpty(nasMappings)) {
+  if (_.isEmpty(nasMappings[serviceName])) {
     throw new Error(red(`\nFun detects that your dependencies are not included in path ${localDirs} or ${path.resolve(codeUri, SYSTEM_DEPENDENCY_PATH)}`));
   }
 
@@ -811,7 +811,12 @@ async function processNasAutoConfiguration({ tpl, tplPath, runtime, codeUri, con
 
   if (partialDeploy.resourceName) {
     // can not use baseDir, should use tpl dirname
-    await require('./deploy/deploy-by-tpl').deployService(path.dirname(tplPath), partialDeploy.resourceName, partialDeploy.resourceRes, false, tplPath, true);
+    await require('./deploy/deploy-by-tpl').deployService({
+      baseDir: path.dirname(tplPath),
+      serviceName: partialDeploy.resourceName,
+      serviceRes: partialDeploy.resourceRes,
+      onlyConfig: false, tplPath, skipTrigger: true, useNas: false
+    });
   }
 
   return rs.tplChanged;
@@ -961,107 +966,105 @@ You can follow these steps:
   }
 }
 
-async function nasAutoConfigurationIfNecessary({ stage, tplPath, runtime, codeUri, nasConfig, vpcConfig,
-  compressedSize,
+async function nasAutoConfigurationIfNecessary({ stage, tplPath, runtime, codeUri, nasConfig, vpcConfig, useNas = false,
+  compressedSize = 0,
   nasFunctionName,
   nasServiceName
 }) {
 
   let stop = false;
   let tplChanged = false;
-  if (compressedSize > 52428800 && _.includes(SUPPORT_RUNTIMES, runtime)) { // 50M
 
-    console.log(red(`\nFun detected that your function ${nasServiceName}/${nasFunctionName} sizes is ${bytes(compressedSize, { unitSeparator: ' ' })} exceeding 50M. It is recommended that using the nas service to manage your function dependencies.`));
-    await ensureCodeUriForJava(codeUri, nasServiceName, nasFunctionName);
+  if (!_.includes(SUPPORT_RUNTIMES, runtime) || (!useNas && compressedSize < 52428800)) { return { stop, tplChanged }; }
 
-    if (await promptForConfirmContinue(`Do you want to let fun to help you automate the configuration?`)) {
+  if (compressedSize > 52428800) {
+    console.log(red(`\nFun detected that your function ${nasServiceName}/${nasFunctionName} sizes exceed 50M. It is recommended that using the nas service to manage your function dependencies.`));
+  }
 
-      const packageStage = (stage === 'package');
-      const tpl = await getTpl(tplPath);
+  await ensureCodeUriForJava(codeUri, nasServiceName, nasFunctionName);
 
-      if (definition.isNasAutoConfig(nasConfig)) {
-        const yes = await promptForConfirmContinue(`You have already configured 'NasConfig: Auto’. We want to use this configuration to store your function dependencies.`);
-        if (yes) {
+  if (await promptForConfirmContinue(`Do you want to let fun to help you automate the configuration?`)) {
 
-          if (packageStage && !_.isEmpty(vpcConfig)) {
-            throw new Error(`When 'NasConfig: Auto' is specified, 'VpcConfig' is not supported.`);
-          }
-          await backupTemplateFile(tplPath); // backup tpl
+    const packageStage = (stage === 'package');
+    const tpl = await getTpl(tplPath);
 
-          tplChanged = await processNasAutoConfiguration({
-            tpl, tplPath, runtime, codeUri, stage,
-            serviceName: nasServiceName,
-            functionName: nasFunctionName
-          });
+    if (definition.isNasAutoConfig(nasConfig)) {
+      const yes = await promptForConfirmContinue(`You have already configured 'NasConfig: Auto’. We want to use this configuration to store your function dependencies.`);
+      if (yes) {
 
-          stop = true;
-        } else {
-          throw new Error(red(`\nIf 'NasConfig: Auto' is configured, only the configuration store function dependency is currently supported.`));
+        if (packageStage && !_.isEmpty(vpcConfig)) {
+          throw new Error(`When 'NasConfig: Auto' is specified, 'VpcConfig' is not supported.`);
         }
-      } else if (!_.isEmpty(vpcConfig) && _.isEmpty(nasConfig)) {
+        await backupTemplateFile(tplPath); // backup tpl
 
-        throw new Error(red(`\nFun has detected that you only have VPC configuration. This scenario is not supported at this time. You also need to manually configure the NAS service. You can refer to: https://github.com/alibaba/funcraft/blob/master/docs/specs/2018-04-03-zh-cn.md#nas-%E9%85%8D%E7%BD%AE%E5%AF%B9%E8%B1%A1 and https://nas.console.aliyun.com/`));
-      } else if (!_.isEmpty(vpcConfig) && !_.isEmpty(nasConfig)) {
-
-        if (packageStage) {
-          throw new Error(`When 'NasConfig' is specified, 'VpcConfig' is not supported.`);
-        }
-        if (definition.onlyOneNASExists(nasConfig)) {
-          const yes = await promptForConfirmContinue(`We have detected that you already have a NAS configuration. Do you directly use this NAS storage function dependencies.`);
-          if (yes) {
-            await backupTemplateFile(tplPath);
-
-            tplChanged = await processNasAutoConfiguration({
-              tpl, tplPath, runtime, codeUri, stage,
-              serviceName: nasServiceName,
-              functionName: nasFunctionName
-            });
-          } else {
-            throw new Error(red(`If your yml has been already configured with 'NasConfig', fun only supports to use this 'NasConfig' to process your function dependencies. Otherwise you need to handle the dependencies by yourself.\n\nRefer to https://yq.aliyun.com/articles/712700 for more help.`));
-          }
-        } else {
-          const answer = await promptForMountPoints(nasConfig.MountPoints);
-          const convertedNasConfig = replaceNasConfig(nasConfig, answer.mountDir);
-          await backupTemplateFile(tplPath);
-
-          tplChanged = await processNasAutoConfiguration({
-            tpl, tplPath, runtime, codeUri, stage,
-            convertedNasConfig,
-            serviceName: nasServiceName,
-            functionName: nasFunctionName
-          });
-        }
+        tplChanged = await processNasAutoConfiguration({ tpl, tplPath, runtime, codeUri, stage,
+          serviceName: nasServiceName,
+          functionName: nasFunctionName
+        });
 
         stop = true;
-      } else if (_.isEmpty(vpcConfig) && _.isEmpty(nasConfig)) {
-        const yes = await promptForConfirmContinue(`We recommend using the 'NasConfig: Auto' configuration to manage your function dependencies.`);
-        if (yes) {
-          await backupTemplateFile(tplPath);
-          // write back to yml
-          const updatedTpl = await updateNasAutoConfigure(tplPath, tpl, nasServiceName);
-
-          tplChanged = await processNasAutoConfiguration({
-            tpl: updatedTpl, tplPath, runtime, codeUri, stage,
-            serviceName: nasServiceName,
-            functionName: nasFunctionName
-          });
-        } else {
-          // list available NAS
-          const { mountTarget, securityGroupId } = await processNasSelection();
-
-          await backupTemplateFile(tplPath); // backup tpl
-
-          const nasAndVpcConfig = generateNasAndVpcConfig(mountTarget, securityGroupId, nasServiceName);
-          const updatedTpl = await updateNasAndVpc(tplPath, tpl, nasServiceName, nasAndVpcConfig);
-
-          tplChanged = await processNasAutoConfiguration({
-            tpl: updatedTpl, tplPath, runtime, codeUri, stage,
-            serviceName: nasServiceName,
-            functionName: nasFunctionName
-          });
-        }
-        stop = true;
+      } else {
+        throw new Error(red(`\nIf 'NasConfig: Auto' is configured, only the configuration store function dependency is currently supported.`));
       }
+    } else if (!_.isEmpty(vpcConfig) && _.isEmpty(nasConfig)) {
+
+      throw new Error(red(`\nFun has detected that you only have VPC configuration. This scenario is not supported at this time. You also need to manually configure the NAS service. You can refer to: https://github.com/alibaba/funcraft/blob/master/docs/specs/2018-04-03-zh-cn.md#nas-%E9%85%8D%E7%BD%AE%E5%AF%B9%E8%B1%A1 and https://nas.console.aliyun.com/`));
+    } else if (!_.isEmpty(vpcConfig) && !_.isEmpty(nasConfig)) {
+
+      if (packageStage) {
+        throw new Error(`When 'NasConfig' is specified, 'VpcConfig' is not supported.`);
+      }
+      if (definition.onlyOneNASExists(nasConfig)) {
+        const yes = await promptForConfirmContinue(`We have detected that you already have a NAS configuration. Do you directly use this NAS storage function dependencies.`);
+        if (yes) {
+          await backupTemplateFile(tplPath);
+
+          tplChanged = await processNasAutoConfiguration({ tpl, tplPath, runtime, codeUri, stage,
+            serviceName: nasServiceName,
+            functionName: nasFunctionName
+          });
+        } else {
+          throw new Error(red(`If your yml has been already configured with 'NasConfig', fun only supports to use this 'NasConfig' to process your function dependencies. Otherwise you need to handle the dependencies by yourself.\n\nRefer to https://yq.aliyun.com/articles/712700 for more help.`));
+        }
+      } else {
+        const answer = await promptForMountPoints(nasConfig.MountPoints);
+        const convertedNasConfig = replaceNasConfig(nasConfig, answer.mountDir);
+        await backupTemplateFile(tplPath);
+
+        tplChanged = await processNasAutoConfiguration({ tpl, tplPath, runtime, codeUri, stage,
+          convertedNasConfig,
+          serviceName: nasServiceName,
+          functionName: nasFunctionName
+        });
+      }
+
+      stop = true;
+    } else if (_.isEmpty(vpcConfig) && _.isEmpty(nasConfig)) {
+      const yes = await promptForConfirmContinue(`We recommend using the 'NasConfig: Auto' configuration to manage your function dependencies.`);
+      if (yes) {
+        await backupTemplateFile(tplPath);
+        // write back to yml
+        const updatedTpl = await updateNasAutoConfigure(tplPath, tpl, nasServiceName);
+
+        tplChanged = await processNasAutoConfiguration({ tpl: updatedTpl, tplPath, runtime, codeUri, stage,
+          serviceName: nasServiceName,
+          functionName: nasFunctionName
+        });
+      } else {
+        // list available NAS
+        const { mountTarget, securityGroupId } = await processNasSelection();
+
+        await backupTemplateFile(tplPath); // backup tpl
+
+        const nasAndVpcConfig = generateNasAndVpcConfig(mountTarget, securityGroupId, nasServiceName);
+        const updatedTpl = await updateNasAndVpc(tplPath, tpl, nasServiceName, nasAndVpcConfig);
+
+        tplChanged = await processNasAutoConfiguration({ tpl: updatedTpl, tplPath, runtime, codeUri, stage,
+          serviceName: nasServiceName,
+          functionName: nasFunctionName
+        });
+      }
+      stop = true;
     }
   }
 
@@ -1115,7 +1118,7 @@ async function makeFunction(baseDir, {
   instanceConcurrency,
   nasConfig,
   vpcConfig
-}, onlyConfig, tplPath) {
+}, onlyConfig, tplPath, useNas = false) {
   const fc = await getFcClient();
 
   var fn;
@@ -1142,10 +1145,10 @@ async function makeFunction(baseDir, {
       const { base64, count, compressedSize } = await zipCode(baseDir, codeUri, runtime, functionName);
 
       const rs = await nasAutoConfigurationIfNecessary({
-        compressedSize, tplPath, runtime, nasConfig, vpcConfig,
         nasFunctionName: functionName,
         nasServiceName: serviceName,
-        codeUri: path.resolve(baseDir, codeUri)
+        codeUri: path.resolve(baseDir, codeUri),
+        compressedSize, tplPath, runtime, nasConfig, vpcConfig, useNas
       });
 
       if (rs.stop) { return { tplChanged: rs.tplChanged }; }

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -635,7 +635,7 @@ async function isSpringBootJar(jarfilePath) {
   try {
     const data = await zip.readZipFile(jarfilePath, 'META-INF/MANIFEST.MF');
     const content = data.toString();
-  
+
     return _.includes(content, 'Spring-Boot-Version');
   } catch (e) {
     return false;
@@ -666,7 +666,7 @@ async function detectJarfilePathFromBootstrap(bootstrapContent) {
   const matched = bootstrapContent.match(BOOTSTRAP_SPRING_BOOT_JAR_REGEX);
   let repackaged = false;
   let jarfilePath;
-  
+
   if (matched) {
     jarfilePath = matched[3];
   } else {

--- a/lib/fc.js
+++ b/lib/fc.js
@@ -184,7 +184,6 @@ const runtimeDependencyMappings = {
 };
 
 async function saveNasMappings(nasYmlPath, nasMappings) {
-
   if (_.isEmpty(nasMappings)) { return {}; }
 
   const contentObj = await readFileFromNasYml(nasYmlPath);

--- a/lib/nas/init.js
+++ b/lib/nas/init.js
@@ -76,7 +76,11 @@ async function deployNasService(baseDir, tpl, service, tplPath) {
       };
 
       console.log(`Waiting for service ${nasServiceName} to be deployed...`);
-      await require('../deploy/deploy-by-tpl').deployService(baseDir, nasServiceName, nasServiceRes, false, tplPath);
+      await require('../deploy/deploy-by-tpl').deployService({ baseDir, tplPath,
+        serviceName: nasServiceName,
+        serviceRes: nasServiceRes,
+        onlyConfig: false, skipTrigger: false, useNas: false
+      });
       console.log(green(`service ${nasServiceName} deploy success\n`));
 
       const nasMappings = await nas.convertNasConfigToNasMappings(nas.getDefaultNasDir(baseDir), nasConfig, serviceName);

--- a/lib/package/package.js
+++ b/lib/package/package.js
@@ -1,27 +1,24 @@
 'use strict';
 
-const { ensureFilesModified } = require('../utils/file');
-const { isEmptyDir } = require('../nas/cp/file');
-const { getOssClient } = require('../client');
-const { parseMountDirPrefix } = require('../fc');
-const { red, green, yellow } = require('colors');
-const { generateDefaultLogConfig } = require('../fc');
-const { getTpl, detectNasBaseDir, getNasYmlPath } = require('../tpl');
-const { validateNasAndVpcConfig, SERVICE_RESOURCE, iterateResources, isNasAutoConfig, isVpcAutoConfig, getUserIdAndGroupId } = require('../definition');
-
 const fs = require('fs-extra');
-const {
-  promptForConfirmContinue,
-  promptForInputContinue
-} = require('../init/prompt');
-const { getProfile } = require('../profile');
-
 const nas = require('../nas');
 const path = require('path');
 const util = require('../import/utils');
 const nasSupport = require('../nas/support');
 
 const _ = require('lodash');
+
+const { getProfile } = require('../profile');
+const { isEmptyDir } = require('../nas/cp/file');
+const { getOssClient } = require('../client');
+const { red, green, yellow } = require('colors');
+const { showPackageNextTips } = require('../build/tips');
+const { ensureFilesModified } = require('../utils/file');
+const { parseMountDirPrefix } = require('../fc');
+const { generateDefaultLogConfig } = require('../fc');
+const { getTpl, detectNasBaseDir, getNasYmlPath } = require('../tpl');
+const { promptForConfirmContinue, promptForInputContinue } = require('../init/prompt');
+const { validateNasAndVpcConfig, SERVICE_RESOURCE, iterateResources, isNasAutoConfig, isVpcAutoConfig, getUserIdAndGroupId } = require('../definition');
 
 const {
   zipToOss,
@@ -244,7 +241,7 @@ async function transformSlsAuto(tpl) {
   return cloneTpl;
 }
 
-async function pack(tplPath, bucket, outputTemplateFile) {
+async function pack(tplPath, bucket, outputTemplateFile, useNas) {
   const tpl = await getTpl(tplPath);
   validateNasAndVpcConfig(tpl.Resources);
 
@@ -262,7 +259,7 @@ async function pack(tplPath, bucket, outputTemplateFile) {
   const ossClient = await getOssClient(bucket);
 
   const updatedEnvTpl = await processNasPythonPaths(tpl, tplPath);
-  const updatedCodeTpl = await uploadAndUpdateFunctionCode({ tpl: updatedEnvTpl, tplPath, baseDir, ossClient });
+  const updatedCodeTpl = await uploadAndUpdateFunctionCode({ tpl: updatedEnvTpl, tplPath, baseDir, ossClient, useNas });
   const updatedSlsTpl = await transformSlsAuto(updatedCodeTpl);
   const updatedFlowTpl = await transformFlowDefinition(baseDir, transformCustomDomain(updatedSlsTpl));
   const updatedTpl = await processNasAutoToRosTemplate({ ossClient, baseDir, tplPath,
@@ -282,22 +279,6 @@ async function pack(tplPath, bucket, outputTemplateFile) {
 
   console.log(green('\nPackage success'));
   showPackageNextTips(packedYmlPath);
-}
-
-function showPackageNextTips(packedYmlPath) {
-  const deployTip = 'fun deploy';
-
-  const relative = path.relative(process.cwd(), packedYmlPath);
-  const DEFAULT_PACKAGED_YAML_NAME = 'template.packaged.yml';
-
-  let templateParam = '';
-  if (relative !== DEFAULT_PACKAGED_YAML_NAME) {
-    templateParam = ` -t ${relative}`;
-  }
-
-  console.log(yellow(`\nTips for next step
-======================
-* Deploy Resources: ${deployTip}${templateParam}`));
 }
 
 module.exports = {

--- a/lib/package/template.js
+++ b/lib/package/template.js
@@ -456,7 +456,8 @@ async function zipCode(srcPath, ignore, zipName = 'code.zip', prefix) {
 async function zipCodeToOss({ ossClient, codeUri, runtime, ignore, tplPath, nasConfig,
   serviceName, functionName,
   zipName = 'code.zip',
-  prefix = ''
+  prefix = '',
+  useNas = false
 }) {
 
   let objectName;
@@ -476,7 +477,7 @@ async function zipCodeToOss({ ossClient, codeUri, runtime, ignore, tplPath, nasC
 
   if (count === 0) { return { isEmpty: true, objectName }; }
 
-  const rs = await fc.nasAutoConfigurationIfNecessary({ stage: 'package', tplPath, compressedSize,
+  const rs = await fc.nasAutoConfigurationIfNecessary({ stage: 'package', tplPath, compressedSize, useNas,
     nasConfig, runtime, codeUri,
     nasServiceName: serviceName,
     nasFunctionName: functionName
@@ -555,10 +556,7 @@ async function processNasPythonPaths(tpl, tplPath) {
   return updatedTplContent;
 }
 
-async function uploadAndUpdateFunctionCode({
-  tpl, tplPath,
-  baseDir, ossClient
-}) {
+async function uploadAndUpdateFunctionCode({ tpl, tplPath, useNas, baseDir, ossClient }) {
   let updatedTplContent = _.cloneDeep(tpl);
 
   let processed;
@@ -588,7 +586,7 @@ async function uploadAndUpdateFunctionCode({
       const ignore = await fc.generateFunIngore(baseDir, codeUri);
 
       const rs = await zipCodeToOss({
-        ossClient, codeUri: absCodeUri, runtime, ignore, tplPath,
+        ossClient, codeUri: absCodeUri, runtime, ignore, tplPath, useNas,
         serviceName, functionName, nasConfig: (serviceRes.Properties || {}).NasConfig
       });
 
@@ -597,6 +595,7 @@ async function uploadAndUpdateFunctionCode({
       }
       if (rs.stop) {
         processed = true;
+        useNas = false;
         updatedTplContent = await getTpl(tplPath);
         break;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,7 +241,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -788,13 +788,13 @@
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -816,7 +816,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -861,7 +861,7 @@
     },
     "binary": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/binary/download/binary-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "requires": {
         "buffers": "~0.1.1",
@@ -977,7 +977,7 @@
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/boolbase/download/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bowser": {
@@ -1066,16 +1066,16 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-indexof-polyfill": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/buffer-indexof-polyfill/download/buffer-indexof-polyfill-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
       "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8="
     },
     "buffers": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/buffers/download/buffers-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
     },
     "builtin-status-codes": {
@@ -1190,7 +1190,7 @@
     },
     "chainsaw": {
       "version": "0.1.0",
-      "resolved": "https://registry.npm.taobao.org/chainsaw/download/chainsaw-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "requires": {
         "traverse": ">=0.3.0 <0.4"
@@ -1629,7 +1629,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/css-select/download/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -1871,7 +1871,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -1933,7 +1933,7 @@
     },
     "domutils": {
       "version": "1.5.1",
-      "resolved": "https://registry.npm.taobao.org/domutils/download/domutils-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
         "dom-serializer": "0",
@@ -1996,7 +1996,7 @@
     },
     "duplexer2": {
       "version": "0.1.4",
-      "resolved": "http://registry.npm.taobao.org/duplexer2/download/duplexer2-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "requires": {
         "readable-stream": "^2.0.2"
@@ -3300,7 +3300,7 @@
     },
     "int64-buffer": {
       "version": "0.1.9",
-      "resolved": "http://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.9.tgz",
       "integrity": "sha1-ngOdoEOyT3ixlrKD4EZT716ZD2E="
     },
     "into-stream": {
@@ -3761,7 +3761,7 @@
     },
     "listenercount": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/listenercount/download/listenercount-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
       "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
     },
     "locate-path": {
@@ -3930,7 +3930,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5490,7 +5490,7 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/setimmediate/download/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
@@ -6810,7 +6810,7 @@
     },
     "traverse": {
       "version": "0.3.9",
-      "resolved": "https://registry.npm.taobao.org/traverse/download/traverse-0.3.9.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftraverse%2Fdownload%2Ftraverse-0.3.9.tgz",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
     },
     "tree-kill": {

--- a/test/nas/init.test.js
+++ b/test/nas/init.test.js
@@ -60,21 +60,21 @@ describe('test fun nas init', () => {
     support.isNasServerStale.returns(true);
     fs.pathExists.returns(true);
     fs.readFile.returns(Buffer.from('123'));
-  }); 
+  });
 
   afterEach(() => {
     restoreProcess();
     sandbox.reset();
   });
-  
+
   it('function deployNasService without service', async () => {
-    
+
     const serviceName = 'fun-nas-test';
     const nasServiceName = constants.FUN_NAS_SERVICE_PREFIX + serviceName;
     const nasFunctionName = constants.FUN_NAS_FUNCTION;
-    
+
     const zipCodePath = path.resolve(__dirname, '../../lib/utils/fun-nas-server/dist/fun-nas-server.zip');
-    
+
     const nasServiceRes = {
       'Type': 'Aliyun::Serverless::Service',
       'Properties': {
@@ -105,13 +105,16 @@ describe('test fun nas init', () => {
         }
       }
     };
-    
+
     nas.convertNasConfigToNasMappings.returns([{localNasDir: baseDir, remoteNasDir: baseDir}]);
     await nasInitStub.deployNasService(baseDir, nasMockData.tpl, undefined, tplPath);
 
     assert.calledWith(fs.pathExists, zipCodePath);
-    assert.calledWith(deploy.deployService, baseDir, nasServiceName, nasServiceRes, false, tplPath);
-
+    assert.calledWith(deploy.deployService,
+      {
+        baseDir, tplPath,
+        serviceName: nasServiceName, serviceRes: nasServiceRes,
+        onlyConfig: false, useNas: false, skipTrigger: false
+      });
   });
-    
-}); 
+});

--- a/test/package/package.test.js
+++ b/test/package/package.test.js
@@ -61,7 +61,7 @@ describe('test package', () => {
   it('test outputTemplateFile', async () => {
     const packedYmlPath = path.resolve(process.cwd(), outputTemplateFile);
 
-    await pack.pack(tplPath, bucket, outputTemplateFile);
+    await pack.pack(tplPath, bucket, outputTemplateFile, false);
 
     assert.calledWith(tpl.getTpl, tplPath);
     assert.calledWith(client.getOssClient, bucket);
@@ -69,7 +69,8 @@ describe('test package', () => {
       tpl: mock.tpl,
       tplPath,
       baseDir: path.dirname(tplPath),
-      ossClient
+      ossClient,
+      useNas: false
     });
     assert.calledWith(util.outputTemplateFile, packedYmlPath, mock.tpl);
   });
@@ -77,7 +78,7 @@ describe('test package', () => {
   it('test default outputTemplateFile', async () => {
     const packedYmlPath = path.resolve(process.cwd(), 'template.packaged.yml');
 
-    await pack.pack(tplPath, bucket);
+    await pack.pack(tplPath, bucket, null, false);
 
     assert.calledWith(tpl.getTpl, tplPath);
     assert.calledWith(client.getOssClient, bucket);
@@ -85,14 +86,15 @@ describe('test package', () => {
       tpl: mock.tpl,
       tplPath,
       baseDir: path.dirname(tplPath),
-      ossClient
+      ossClient,
+      useNas: false
     });
     assert.calledWith(util.outputTemplateFile, packedYmlPath, mock.tpl);
   });
 
   it('test generate default oss bucket when bucket did not specified', async () => {
     const packedYmlPath = path.resolve(process.cwd(), 'template.packaged.yml');
-    await pack.pack(tplPath);
+    await pack.pack(tplPath, null, null, false);
 
     assert.calledWith(tpl.getTpl, tplPath);
     assert.calledWith(client.getOssClient, `fun-gen-${getProfileRes.defaultRegion}-${getProfileRes.accountId}`);
@@ -100,7 +102,8 @@ describe('test package', () => {
       tpl: mock.tpl,
       tplPath,
       baseDir: path.dirname(tplPath),
-      ossClient
+      ossClient,
+      useNas: false
     });
     assert.calledWith(util.outputTemplateFile, packedYmlPath, mock.tpl);
   });

--- a/test/package/template.test.js
+++ b/test/package/template.test.js
@@ -145,7 +145,7 @@ describe('test uploadAndUpdateFunctionCode', () => {
 
   beforeEach(() => {
     sandbox.stub(fs, 'ensureDir').resolves(true);
-    sandbox.stub(zip, 'packTo').resolves(true);
+    sandbox.stub(zip, 'packTo').resolves({count: 10, compressedSize: 10});
     sandbox.stub(util, 'md5').resolves('md5');
     sandbox.stub(fs, 'remove').resolves(true);
     sandbox.stub(fs, 'createReadStream').returns('zipcontent');


### PR DESCRIPTION
fix #772 

fun deploy 添加 --use-nas 强制分离依赖的开关。
默认是关闭状态。如果开启，则自动进入大依赖向导（复用原有大依赖处理逻辑）。