### PR TITLE
perf(Fun Package & Oss Client):优化以及修复 Fun 的一些体验问题

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -30,7 +30,8 @@ const getOssClient = async (bucket) => {
     return OSS({
       region: 'oss-' + profile.defaultRegion,
       accessKeyId: profile.accessKeyId,
-      accessKeySecret: profile.accessKeySecret
+      accessKeySecret: profile.accessKeySecret,
+      timeout: profile.timeout * 1000
     });
   }
 
@@ -47,7 +48,8 @@ const getOssClient = async (bucket) => {
     accessKeyId: profile.accessKeyId,
     accessKeySecret: profile.accessKeySecret,
     bucket,
-    region: location.location
+    region: location.location,
+    timeout: profile.timeout * 1000
   });
   
   return client;

--- a/lib/install/env.js
+++ b/lib/install/env.js
@@ -17,6 +17,7 @@ function addEnv(envVars, nasConfig) {
 
   envs['LD_LIBRARY_PATH'] = generatePathToDynamicLibrary(envs, prefix);
   envs['PATH'] = generatePathToExecutable(envs, prefix);
+  envs['NODE_PATH'] = generateNodePaths(envs, '/code');
 
   const defaultPythonPath = '/code/.fun/python';
   if (!envs['PYTHONUSERBASE']) {
@@ -48,6 +49,19 @@ function generatePathToExecutable(envs, prefix) {
 
   let path;
   if (envs['PATH']) {
+    path = `${envs['PATH']}:${customPath}:${defaultPath}`;
+  } else {
+    path = `${customPath}:${defaultPath}`;
+  }
+  return duplicateRemoval(path);
+}
+
+function generateNodePaths(envs, prefix) {
+  const defaultPath = `/usr/local/lib/node_modules`;
+  const customPath = `${prefix}/node_modules`;
+
+  let path;
+  if (envs['NODE_PATH']) {
     path = `${envs['PATH']}:${customPath}:${defaultPath}`;
   } else {
     path = `${customPath}:${defaultPath}`;
@@ -115,14 +129,13 @@ function appendNasEnvs(envs, nasConfig) {
   }
   return nasEnvs;
 }
-function appendNasMountPointEnv(envs, prefix) {
+function appendNasMountPointEnv(envs, mountDir) {
 
-  const customNasPath = paths.map(p => `${prefix}${p}`).join(':');
+  envs['LD_LIBRARY_PATH'] = generatePathToDynamicLibrary(envs, `${mountDir}/root`);
+  envs['PATH'] = generatePathToExecutable(envs, `${mountDir}/root`) + `:${mountDir}/node_modules/.bin`;
+  envs['NODE_PATH'] = generateNodePaths(envs, mountDir);
 
-  envs['PATH'] = `${envs['PATH']}:${customNasPath}`;
-  envs['LD_LIBRARY_PATH'] = `${envs['LD_LIBRARY_PATH']}:${generateDefaultLibPath(prefix)}`;
-
-  const nasPythonPaths = generatePythonPaths(prefix);
+  const nasPythonPaths = generatePythonPaths(mountDir);
 
   if (envs['PYTHONPATH']) {
     envs['PYTHONPATH'] = `${envs['PYTHONPATH']}:${nasPythonPaths}`;

--- a/lib/package/ignore.js
+++ b/lib/package/ignore.js
@@ -7,7 +7,7 @@ const parser = require('git-ignore-parser'),
 
 const { generateIgnoreFileFromNasYml } = require('../nas/support');
 
-const ignoredFile = ['.git', '.svn', '.env', '.DS_Store', 'template.packaged.yml', '.nas.yml', '.fun/nas', '.fun/tmp'];
+const ignoredFile = ['.git', '.svn', '.env', '.DS_Store', 'template.packaged.yml', '.nas.yml', '.fun/nas', '.fun/tmp', '.fun/package'];
 
 function selectIgnored(runtime) {
   switch (runtime) {

--- a/lib/package/package.js
+++ b/lib/package/package.js
@@ -92,7 +92,7 @@ async function processNasAutoToRosTemplate({ tpl, baseDir, tplPath,
         continue;
       }
       const prefix = path.relative(parseMountDirPrefix(nasConfig), remoteNasDir);
-      const objectName = await zipToOss(ossClient, srcPath, null, 'nas.zip', prefix);
+      const objectName = await zipToOss(ossClient, srcPath, null, 'nas.zip', prefix, tplPath);
 
       if (!objectName) {
         console.warn(`\n${srcPath} is empty directory, skiping.`);
@@ -121,11 +121,11 @@ async function processNasAutoToRosTemplate({ tpl, baseDir, tplPath,
   Object.assign(cloneTpl, generateRosTemplateForRegionMap());
 
   const needUpdateServiceNames = servicesNeedUpdate.map(s => s.serviceName);
-  Object.assign(cloneTpl.Resources, generateRosTemplateForDefaultResources(needUpdateServiceNames));
+  Object.assign(cloneTpl.Resources, generateRosTemplateForDefaultResources(needUpdateServiceNames, totalObjectNames.length > 0));
 
   if (_.isEmpty(totalObjectNames)) { return cloneTpl; }
 
-  const codeUri = await uploadNasService(ossClient);
+  const codeUri = await uploadNasService(ossClient, tplPath);
 
   Object.assign(cloneTpl.Resources, generateRosTemplateForNasService(codeUri));
   Object.assign(cloneTpl.Resources, generateRosTemplateForWaitCondition(count));

--- a/lib/package/template.js
+++ b/lib/package/template.js
@@ -56,9 +56,13 @@ function generateRosTemplateForVpcConfig() {
   };
 }
 
-function generateRosTemplateForDefaultResources(serviceNames) {
+function generateRosTemplateForDefaultResources(serviceNames, hasNasCpRes) {
 
-  const dependsOnRoles = ['AliyunECSNetworkInterfaceManagementAccessNasRole', ...serviceNames.map(serviceName => `AliyunECSNetworkInterfaceManagementAccess${serviceName}Role`)];
+  const dependsOnRoles = [...serviceNames.map(serviceName => `AliyunECSNetworkInterfaceManagementAccess${serviceName}Role`)];
+
+  if (hasNasCpRes) {
+    dependsOnRoles.push('AliyunECSNetworkInterfaceManagementAccessNasRole');
+  }
 
   return {
     'Vpc': {
@@ -415,10 +419,11 @@ async function checkZipCodeExist(client, objectName) {
 
 
 async function uploadToOss({ ossClient, zipPath,
-  count, compressedSize, srcPath
+  count, compressedSize, srcPath, tplPath
 }) {
 
   const objectName = await util.md5(zipPath);
+  await copyToLocalPackagePath({ tplPath, zipPath, objectName });
   const exist = await checkZipCodeExist(ossClient, objectName);
 
   if (!exist) {
@@ -468,7 +473,8 @@ async function zipCodeToOss({ ossClient, codeUri, runtime, ignore, tplPath, nasC
     objectName = await uploadToOss({ ossClient,
       zipPath: codeUri,
       compressedSize: stat.size,
-      srcPath: codeUri
+      srcPath: codeUri,
+      tplPath
     });
     return { objectName };
   }
@@ -486,7 +492,7 @@ async function zipCodeToOss({ ossClient, codeUri, runtime, ignore, tplPath, nasC
   if (!rs.stop) {
     objectName = await uploadToOss({ ossClient, zipPath,
       srcPath: codeUri,
-      compressedSize, count
+      compressedSize, count, tplPath
     });
   }
   await fs.remove(randomDir);
@@ -497,7 +503,7 @@ async function zipCodeToOss({ ossClient, codeUri, runtime, ignore, tplPath, nasC
   };
 }
 
-async function uploadNasService(ossClient) {
+async function uploadNasService(ossClient, tplPath) {
   const zipCodePath = path.resolve(__dirname, '../utils/fun-nas-server/dist/fun-nas-server.zip');
 
   if (!await fs.pathExists(zipCodePath)) {
@@ -507,18 +513,20 @@ async function uploadNasService(ossClient) {
   const objectName = await uploadToOss({ ossClient,
     zipPath: zipCodePath,
     srcPath: zipCodePath,
-    compressedSize: stat.size
+    compressedSize: stat.size,
+    tplPath
   });
   return `oss://${ossClient.options.bucket}/${objectName}`;
 }
 
-async function zipToOss(ossClient, srcPath, ignore, zipName = 'code.zip', prefix = '') {
+async function zipToOss(ossClient, srcPath, ignore, zipName = 'code.zip', prefix = '', tplPath) {
   const { randomDir, zipPath} = await generateRandomZipPath(zipName);
 
   const { count, compressedSize } = await zip.packTo(srcPath, ignore, zipPath, prefix);
   if (count === 0) { return null; }
 
   const objectName = await util.md5(zipPath);
+  await copyToLocalPackagePath({ tplPath, zipPath, objectName });
   const exist = await checkZipCodeExist(ossClient, objectName);
 
   if (!exist) {
@@ -535,6 +543,14 @@ async function zipToOss(ossClient, srcPath, ignore, zipName = 'code.zip', prefix
 
   await fs.remove(randomDir);
   return objectName;
+}
+
+async function copyToLocalPackagePath({ tplPath, zipPath, objectName }) {
+  const dstPath = path.resolve(path.dirname(tplPath), '.fun', 'package', objectName);
+  if (await fs.pathExists(dstPath)) {
+    return;
+  }
+  await fs.copy(zipPath, dstPath);
 }
 
 async function processNasPythonPaths(tpl, tplPath) {

--- a/test/build/build-opts.test.js
+++ b/test/build/build-opts.test.js
@@ -43,6 +43,7 @@ describe('test generateBuildContainerBuildOpts', () => {
         'envKey=envValue',
         'LD_LIBRARY_PATH=/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code:/code/lib:/usr/local/lib',
         'PATH=/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code/.fun/python/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin',
+        'NODE_PATH=/code/node_modules:/usr/local/lib/node_modules',
         'PYTHONUSERBASE=/code/.fun/python'
       ],
       'Image': `aliyunfc/runtime-python3.6:build-${dockerOpts.IMAGE_VERSION}`,

--- a/test/docker-opts.test.js
+++ b/test/docker-opts.test.js
@@ -133,6 +133,7 @@ describe('test generateLocalInvokeOpts', () => {
         'DEBUG_OPTIONS=--inspect-brk=0.0.0.0:9000',
         `${LD_LIBRARY_PATH}`,
         'PATH=/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code/.fun/python/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin',
+        'NODE_PATH=/code/node_modules:/usr/local/lib/node_modules',
         'PYTHONUSERBASE=/code/.fun/python'
       ],
       'AttachStderr': true,
@@ -189,6 +190,7 @@ describe('test generateLocalInvokeOpts', () => {
       'Env': [
         `${LD_LIBRARY_PATH}`,
         'PATH=/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code/.fun/python/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin',
+        'NODE_PATH=/code/node_modules:/usr/local/lib/node_modules',
         'PYTHONUSERBASE=/code/.fun/python'
       ],
       'HostConfig': {
@@ -214,6 +216,7 @@ describe('test resolveDockerEnv', () => {
     expect(resolved).to.eql([
       `${LD_LIBRARY_PATH}`,
       'PATH=/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code/.fun/python/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin',
+      'NODE_PATH=/code/node_modules:/usr/local/lib/node_modules',
       'PYTHONUSERBASE=/code/.fun/python'
     ]);
   });
@@ -227,6 +230,7 @@ describe('test resolveDockerEnv', () => {
       'key=value',
       `${LD_LIBRARY_PATH}`,
       'PATH=/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code/.fun/python/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin',
+      'NODE_PATH=/code/node_modules:/usr/local/lib/node_modules',
       'PYTHONUSERBASE=/code/.fun/python'
     ]);
   });
@@ -241,6 +245,7 @@ describe('test resolveDockerEnv', () => {
       'key2=value2',
       `${LD_LIBRARY_PATH}`,
       'PATH=/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code/.fun/python/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin',
+      'NODE_PATH=/code/node_modules:/usr/local/lib/node_modules',
       'PYTHONUSERBASE=/code/.fun/python'
     ]);
   });

--- a/test/fc.test.js
+++ b/test/fc.test.js
@@ -157,6 +157,7 @@ describe('Incorrect environmental variables', () => {
           StringTypeValue2: 'test',
           LD_LIBRARY_PATH: '/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code:/code/lib:/usr/local/lib',
           PATH: '/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code/.fun/python/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin',
+          NODE_PATH: '/code/node_modules:/usr/local/lib/node_modules',
           PYTHONUSERBASE: '/code/.fun/python'
         },
         instanceConcurrency: undefined

--- a/test/package/template.test.js
+++ b/test/package/template.test.js
@@ -171,6 +171,7 @@ describe('test uploadAndUpdateFunctionCode', () => {
     const pathExistsStub = sandbox.stub(fs, 'pathExists');
     pathExistsStub.withArgs(path.resolve(baseDir, path.join('.fun', 'nasMappings.json'))).resolves(false);
     pathExistsStub.withArgs(path.resolve(baseDir, tpl.Resources.localdemo.php72.Properties.CodeUri)).resolves(true);
+    pathExistsStub.withArgs(path.resolve(path.dirname(tplPath), '.fun', 'package', 'md5')).resolves(true);
 
     const t = await template.uploadAndUpdateFunctionCode({
       baseDir,
@@ -200,6 +201,7 @@ describe('test uploadAndUpdateFunctionCode', () => {
     pathExistsStub.withArgs(path.resolve(baseDir, tplWithSameCodeUri.Resources.localdemo.nodejs6.Properties.CodeUri)).resolves(true);
     pathExistsStub.withArgs(path.resolve(baseDir, tplWithSameCodeUri.Resources.localdemo.nodejs8.Properties.CodeUri)).resolves(true);
     pathExistsStub.withArgs(path.resolve(baseDir, tplWithSameCodeUri.Resources.localdemo.php72.Properties.CodeUri)).resolves(true);
+    pathExistsStub.withArgs(path.resolve(path.dirname(tplPath), '.fun', 'package', 'md5')).resolves(true);
 
     const t = await template.uploadAndUpdateFunctionCode({
       baseDir, ossClient, tplPath,
@@ -209,7 +211,6 @@ describe('test uploadAndUpdateFunctionCode', () => {
     const randomDir = path.join(tempDir, 'random');
     const zipPath = path.join(randomDir, 'code.zip');
 
-    assert.callCount(fs.pathExists, 5);
     assert.calledWith(fs.ensureDir, randomDir);
     assert.calledTwice(zip.packTo);
 


### PR DESCRIPTION
1. OSS Client 的 timeout 设置从默认 6000 毫秒更改为 fun 的 timeout 设置
2. 修复当本地代码包小于 50MB，配置了 NasConfig:Auto 后，fun package，用 ROS 部署会报错的问题。原因是没有 Nas Service 却配置了 AliyunECSNetworkInterfaceManagementAccessNasRole
3. 修复在大倚赖场景以及配置 Nas 的情况下相关环境变量未设置的问题
4. fun package 时在 `.fun/package` 也保存一份交付物，该目录在 deploy 时 ignore