### PR TITLE
perf(Package): perf fun package speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ install:
       cd $TRAVIS_REPO_SLUG;
     fi
   - npm install
-  - npm run build
+  - tsc -p ./
+  - copyfiles -a -u 1 -e "**/*.{js,ts}" "src/**/*" ./
   - bash -c 'cd ./lib/utils/fun-nas-server/; npm install'
 
 before_script: 

--- a/src/lib/package/package.js
+++ b/src/lib/package/package.js
@@ -93,7 +93,7 @@ async function processNasAutoToRosTemplate({ tpl, baseDir, tplPath,
         continue;
       }
       const prefix = path.relative(parseMountDirPrefix(nasConfig), remoteNasDir);
-      const objectName = await zipToOss(ossClient, srcPath, null, 'nas.zip', prefix, tplPath);
+      const objectName = await zipToOss(ossClient, srcPath, null, 'nas.zip', prefix, tplPath, { level: 1 });
 
       if (!objectName) {
         console.warn(`\n${srcPath} is empty directory, skiping.`);

--- a/src/lib/package/zip.js
+++ b/src/lib/package/zip.js
@@ -176,7 +176,7 @@ async function packFromJson(files) {
   return await generateAsync(zip);
 }
 
-async function packTo(file, funignore, targetPath, prefix = '') {
+async function packTo(file, funignore, targetPath, prefix = '', zlibOptions = {}) {
   if (!(await fs.pathExists(file))) {
     throw new Error(`zip file ${file} is not exist.`);
   }
@@ -195,9 +195,9 @@ async function packTo(file, funignore, targetPath, prefix = '') {
 
   const output = fs.createWriteStream(targetPath);
   const zipArchiver = archiver('zip', {
-    zlib: {
+    zlib: _.merge({
       level: 6
-    }
+    }, zlibOptions)
   }).on('progress', (progress) => {
     bar.total = progress.entries.total;
     bar.tick({


### PR DESCRIPTION
### 已存在 .nas.yml 的情况下

__原先的 fun package__
总流程耗时 45 s
代码 OSS 大小 2.28MB
依赖 OSS 大小 123.88 MB

__改进后的 fun package__
总流程耗时 30 s
代码 OSS 大小 2.28 MB
依赖 OSS 大小 137.21 MB

__提速 33%__

### 未存在 .nas.yml 的情况下

__原先的 fun package__
总流程耗时 75 s
代码 OSS 大小 2.28MB
依赖 OSS 大小 123.88 MB

__改进后的 fun package__
总流程耗时 60 s
代码 OSS 大小 2.74 MB
依赖 OSS 大小 137.21 MB

__提速 20%__

逻辑:
1. fun package 针对要迁移到 NAS 上的代码包, 以较低的压缩比进行压缩, 实际测试下来的效果很好, 375MB 的原文件, level 6 和 level 1 压缩出来的大小分别是 123 MB 和 137 MB, 差距并不大
2. fun package 首次压缩代码的时候, 仍旧使用过去的压缩方式, 避免一些临界情况导致触发大依赖向导; 在触发了大依赖向导后, 由于 .nas.yml 已生成, 依赖被声明在其中, 这时候以较低的压缩比压缩代码并不会再次触发大依赖, 所以在大依赖向导后, 针对代码以及依赖都以较低的压缩比进行压缩.
3. 之所以不考虑使用 level 0 的压缩比 (就是不压缩), 是因为 375 MB 的原文件, 在使用 level 0 后, 仍旧是 375 MB, 上传时间会较长, 不是很划算.
