### PR TITLE
修复 libreoffice 无法本地 invoke 的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ src/lib/utils/fun-nas-server/.fun/root/*
 !src/lib/utils/fun-nas-server/.fun/root/usr
 src/lib/utils/fun-nas-server/.fun/root/usr/*
 !src/lib/utils/fun-nas-server/.fun/root/usr/bin
+
+.fun

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ test-coveralls:
 
 clean: 
 	@rm -rf output
+	
+build:
+	tsc -p ./
+
+postbuild:
+	copyfiles -a -u 1 -e \"**/*.{js,ts}\" \"src/**/*\" ./
+	chmod +x bin/*.js
 
 binary: clean package-fun-nas-server
 	@script/binary.sh
@@ -40,4 +47,4 @@ package-fun-nas-server:
 upload: 
 	@script/upload.sh
 
-.PHONY: test clean binary
+.PHONY: test clean binary build

--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,4 @@ package-fun-nas-server:
 upload: 
 	@script/upload.sh
 
-.PHONY: test clean binary build
+.PHONY: test clean binary build postbuild

--- a/package-lock.json
+++ b/package-lock.json
@@ -1148,7 +1148,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-indexof-polyfill": {
       "version": "1.0.1",
@@ -3874,7 +3874,7 @@
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/json-stable-stringify-without-jsonify/download/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
@@ -4162,7 +4162,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -4285,7 +4285,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -4418,7 +4418,7 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/natural-compare/download/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
@@ -6961,7 +6961,7 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/text-table/download/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "lint": "eslint --fix src/lib src/bin test",
     "validate-lint": "eslint src/lib src/bin test",
     "prepack": "npm install && npm run build && chmod +x bin/* && make package-fun-nas-server",
-    "build": "tsc -p ./",
-    "postbuild": "copyfiles -a -u 1 -e \"**/*.{js,ts}\" \"src/**/*\" ./"
+    "build": "make build",
+    "postbuild": "make postbuild"
   },
   "author": "Jackson Tian",
   "maintainers": [

--- a/src/lib/commands/local/invoke.js
+++ b/src/lib/commands/local/invoke.js
@@ -69,7 +69,10 @@ async function invoke(invokeName, options) {
 
   debug(`found serviceName: ${serviceName}, functionName: ${functionName}, functionRes: ${functionRes}`);
 
-  const absTmpDir = await ensureTmpDir(options.tmpDir, tplPath, serviceName, functionName);
+  // env 'DISABLE_BIND_MOUNT_TMP_DIR' to disable bind mount of tmp dir.
+  // libreoffice will failed if /tmp directory is bind mount by docker.
+  const absTmpDir = process.env.DISABLE_BIND_MOUNT_TMP_DIR ? 
+    undefined : await ensureTmpDir(options.tmpDir, tplPath, serviceName, functionName);
 
   // Lazy loading to avoid stdin being taken over twice.
   const LocalInvoke = require('../../local/local-invoke');


### PR DESCRIPTION
调查发现 libreoffice 没有办法 local invoke 的原因是 docker container bind mount 了 /tmp 目录，由于 libreoffice 没有任何详细日志和报错，目前只能采用不挂载 /tmp 目录的方式 workaround。

DISABLE_BIND_MOUNT_TMP_DIR 环境变量存在就不会 bind mount /tmp 目录。