### PR TITLE
coco/fix parallel unzipping bug

### DIFF
--- a/src/lib/nas/cp/upload.js
+++ b/src/lib/nas/cp/upload.js
@@ -88,15 +88,13 @@ function unzipNasFileParallel(nasHttpTriggerPath, dstDir, nasZipFile, filesArrQu
         await sendUnzipRequest(nasHttpTriggerPath, dstDir, nasZipFile, unzipFiles, noClobber);
         bar.tick(unzipFiles.length);
       } catch (error) {
-        // 出现这样的错误是因为待解压文件列表不在上传的 NAS 端压缩文件
-        // 这种情况是压缩包上传出错
-        if ((error.message).contains('filename not matched')) {
+        // zip 中存在特殊文件名，例如 $data.js
+        if (error.message && error.message.includes('filename not matched')) {
           console.log(red(error));
-          console.log(red('Uploaded NAS zip file error, please re-sync.'));
           return;
         }
-        if ((error.message.toLowerCase()).contains('permission denied')) {
-          //TO DO : 权限问题更加详细的提示
+        if (error.message && error.message.toLowerCase().includes('permission denied')) {
+          //TODO : 权限问题更加详细的提示
           console.log(red(error));
           return;
         }

--- a/src/lib/nas/cp/upload.js
+++ b/src/lib/nas/cp/upload.js
@@ -83,7 +83,7 @@ async function uploadFile(resolvedSrc, actualDstPath, nasHttpTriggerPath) {
 function unzipNasFileParallel(nasHttpTriggerPath, dstDir, nasZipFile, filesArrQueue, unzipFilesCount, noClobber) {
   return new Promise((resolve, reject) => {
     const bar = createProgressBar(`${green(':unzipping')} :bar :current/:total :rate files/s, :percent :elapsed s`, { total: unzipFilesCount });
-    let unzipQueue = async.queue(async (unzipFiles, callback) => {
+    let unzipQueue = async.queue(async (unzipFiles, next) => {
       try {
         await sendUnzipRequest(nasHttpTriggerPath, dstDir, nasZipFile, unzipFiles, noClobber);
         bar.tick(unzipFiles.length);
@@ -114,7 +114,7 @@ function unzipNasFileParallel(nasHttpTriggerPath, dstDir, nasZipFile, filesArrQu
           return;
         }
       }
-      callback();
+      next();
     }, constants.FUN_NAS_UPLOAD_PARALLEL_COUNT);
 
     unzipQueue.drain = () => {

--- a/src/lib/nas/request.js
+++ b/src/lib/nas/request.js
@@ -96,7 +96,7 @@ async function sendUnzipRequest(nasHttpTriggerPath, dstDir, nasZipFile, unzipFil
   }
 
   for (let unzipFile of unzipFiles) {
-    cmd = cmd + ` "${unzipFile}"`;
+    cmd = cmd + ` '${unzipFile}'`;
   }
 
   return await sendCmdRequest(nasHttpTriggerPath, cmd);

--- a/src/lib/utils/file.js
+++ b/src/lib/utils/file.js
@@ -115,7 +115,7 @@ async function recordMtimes(filePaths, buildOps, recordedPath) {
 
   const fileMtimes = await filePaths.reduce(async (accPromise, cur) => {
     if (!await fs.pathExists(cur)) {
-      throw new Error(`${path} is not exsit`);
+      throw new Error(`${cur} is not exsit`);
     }
 
     const collection = await accPromise;

--- a/test/build/build.test.js
+++ b/test/build/build.test.js
@@ -45,6 +45,7 @@ describe('test buildFunction', () => {
   const runtime = functionRes.Properties.Runtime;
 
   const tplPath = path.join(baseDir, 'template.yml');
+  const packageJson = path.join(baseDir, 'package.json');
 
   let pathExistsStub;
 
@@ -54,6 +55,8 @@ describe('test buildFunction', () => {
 
     pathExistsStub.withArgs(path.resolve(baseDir)).resolves(true);
     pathExistsStub.withArgs(path.resolve(tplPath)).resolves(true);
+    pathExistsStub.withArgs(path.resolve(packageJson)).resolves(true);
+
     sandbox.stub(fs, 'lstat').resolves({
       'mtime': new Date('2019-12-16T09:30:55.325Z')
     });


### PR DESCRIPTION
fixes #865 
并行处理解压依赖时，某些文件名存在特殊字符，导致 shell 中 cmd 报错 `caution: filename not matched:  $data.js`。
应该防止 $ 被转义，将 "" 双引号，替换为 '' 单引号。
对比如下：
`unzip -q -o /mnt/auto/node_modules/.fun_nas_tmp/.fun-nas-generated-node_modules.zip -d /mnt/auto/node_modules/   '$data.js'`

`unzip -q -o /mnt/auto/node_modules/.fun_nas_tmp/.fun-nas-generated-node_modules.zip -d /mnt/auto/node_modules/  ”$data.js“`

如果文件名包含 \n 也会报错，暂时未做处理。因为没有发现任何文件名中包含换行。