### PR TITLE
coco/fix different zoneId issue

### DIFF
--- a/src/lib/commands/install.js
+++ b/src/lib/commands/install.js
@@ -123,7 +123,7 @@ function convertPackageToCmd(pkgType, pkg, {
   indexUrl, registry
 }) {
 
-  if (!_.includes(['pip', 'npm', 'apt'], pkgType)) {
+  if (!_.includes(['pip', 'npm', 'apt-get'], pkgType)) {
     throw new Error(`unknow package type %${pkgType}`);
   }
 

--- a/src/lib/vswitch.js
+++ b/src/lib/vswitch.js
@@ -151,20 +151,20 @@ async function describeVpcZones(vpcClient, region) {
 async function convertToFcAllowedZones(vpcClient, region, vswitchIds) {
   const fcAllowedZones = await getFcAllowedZones();
 
-  const zoneObj = [];
+  const fcZones = [];
   for (const vswitchId of vswitchIds) {
     const zoneId = await getVSwitchZoneId(vpcClient, region, vswitchId);
     if (_.includes(fcAllowedZones, zoneId)) {
-      zoneObj.push({ zoneId, vswitchId });
+      fcZones.push({ zoneId, vswitchId });
     }
   }
-  if (_.isEmpty(zoneObj)) {
+  if (_.isEmpty(fcZones)) {
     throw new Error(`
 Only zoneId ${fcAllowedZones} of vswitch is allowed by VpcConfig.
 Check your vswitch zoneId please.`);
   }
 
-  return zoneObj;
+  return fcZones;
 }
 
 function convertZones(nasZones, zones, storageType = 'Performance') {

--- a/src/lib/vswitch.js
+++ b/src/lib/vswitch.js
@@ -206,6 +206,8 @@ async function getAvailableVSwitchId(vpcClient, region, vswitchIds, nasZones) {
 
   const zoneMap = await convertToFcAllowedZoneMap(vpcClient, region, vswitchIds);
 
+  const FcAllowVswitchId = _.head([...zoneMap.values()]);
+
   for (const zoneId of zoneMap.keys()) {
     if (!_.includes(nasZones.map(m => { return m.ZoneId; }), zoneId)) {
       zoneMap.delete(zoneId);
@@ -232,7 +234,7 @@ async function getAvailableVSwitchId(vpcClient, region, vswitchIds, nasZones) {
     throw new Error(`No NAS service available under region ${region}.`);
   }
 
-  return processDifferentZones(nasZones, _.head([...zoneMap.values()]));
+  return processDifferentZones(nasZones, FcAllowVswitchId);
 }
 
 module.exports = {


### PR DESCRIPTION
修复了 NasAuto 场景可用区不同导致的 fun nas init 以及 fun dpeloy  失败的问题。例如 region ( 北京，香港)