### PR TITLE
ellison/add_LD_LIBRARY_PATH_env

### DIFF
--- a/src/lib/install/env.js
+++ b/src/lib/install/env.js
@@ -35,7 +35,9 @@ const sysLibs = [
   '/usr/lib/x86_64-linux-gnu',
   '/usr/lib64',
   '/lib',
-  '/lib/x86_64-linux-gnu'
+  '/lib/x86_64-linux-gnu',
+  '/python/lib/python2.7/site-packages',
+  '/python/lib/python3.6/site-packages'
 ];
 
 
@@ -57,13 +59,13 @@ function generateLibPath(envs, prefix) {
 
   if (envs['LD_LIBRARY_PATH']) {
     libPath = `${envs['LD_LIBRARY_PATH']}:${libPath}`;
-  } 
+  }
   return duplicateRemoval(libPath);
 }
 
 const sysPaths = [
-  '/usr/local/bin', 
-  '/usr/local/sbin', 
+  '/usr/local/bin',
+  '/usr/local/sbin',
   '/usr/bin',
   '/usr/sbin',
   '/sbin',

--- a/src/lib/package/package.js
+++ b/src/lib/package/package.js
@@ -252,7 +252,7 @@ async function generateOssBucket(bucketName) {
   console.log(yellow(`using oss-bucket: ${bucketName}`));
 
   if (process.stdin.isTTY && !await promptForConfirmContinue('Auto generate OSS bucket for you?')) {
-    return (await promptForInputContinue('Input OSS bucket name:')).input;
+    bucketName = (await promptForInputContinue('Input OSS bucket name:')).input;
   }
 
   await ossClient.putBucket(bucketName);

--- a/test/build/build-opts.test.js
+++ b/test/build/build-opts.test.js
@@ -41,7 +41,7 @@ describe('test generateBuildContainerBuildOpts', () => {
     expect(opts).to.eql({
       'Env': [
         'envKey=envValue',
-        'LD_LIBRARY_PATH=/code/.fun/root/usr/local/lib:/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code/.fun/root/lib:/code/.fun/root/lib/x86_64-linux-gnu:/code:/code/lib:/usr/local/lib',
+        'LD_LIBRARY_PATH=/code/.fun/root/usr/local/lib:/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code/.fun/root/lib:/code/.fun/root/lib/x86_64-linux-gnu:/code/.fun/root/python/lib/python2.7/site-packages:/code/.fun/root/python/lib/python3.6/site-packages:/code:/code/lib:/usr/local/lib',
         'PATH=/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code:/code/node_modules/.bin:/code/.fun/python/bin:/code/.fun/node_modules/.bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin',
         'NODE_PATH=/code/node_modules:/usr/local/lib/node_modules',
         'PYTHONUSERBASE=/code/.fun/python'

--- a/test/docker-opts.test.js
+++ b/test/docker-opts.test.js
@@ -75,7 +75,7 @@ describe('test resolveDockerRegistry', () => {
   });
 });
 
-const LD_LIBRARY_PATH = 'LD_LIBRARY_PATH=/code/.fun/root/usr/local/lib:/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code/.fun/root/lib:/code/.fun/root/lib/x86_64-linux-gnu:/code:/code/lib:/usr/local/lib';
+const LD_LIBRARY_PATH = 'LD_LIBRARY_PATH=/code/.fun/root/usr/local/lib:/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code/.fun/root/lib:/code/.fun/root/lib/x86_64-linux-gnu:/code/.fun/root/python/lib/python2.7/site-packages:/code/.fun/root/python/lib/python3.6/site-packages:/code:/code/lib:/usr/local/lib';
 const PATH = 'PATH=/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code:/code/node_modules/.bin:/code/.fun/python/bin:/code/.fun/node_modules/.bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin';
 
 describe('test generateLocalInvokeOpts', () => {

--- a/test/fc.test.js
+++ b/test/fc.test.js
@@ -164,7 +164,7 @@ describe('Incorrect environmental variables', () => {
       FC.prototype.updateFunction,
       'localdemo',
       'nodejs6',
-      {});
+      undefined);
   });
 
   it('invoke function sync', async () => {
@@ -326,7 +326,7 @@ describe('test processNasAutoConfiguration', ()=> {
 
     const functionProp = tplWithNasAuto.Resources.localdemo.python3.Properties;
     functionProp.EnvironmentVariables = {
-      'LD_LIBRARY_PATH': '/mnt/auto/root/usr/local/lib:/mnt/auto/root/usr/lib:/mnt/auto/root/usr/lib/x86_64-linux-gnu:/mnt/auto/root/usr/lib64:/mnt/auto/root/lib:/mnt/auto/root/lib/x86_64-linux-gnu',
+      'LD_LIBRARY_PATH': '/mnt/auto/root/usr/local/lib:/mnt/auto/root/usr/lib:/mnt/auto/root/usr/lib/x86_64-linux-gnu:/mnt/auto/root/usr/lib64:/mnt/auto/root/lib:/mnt/auto/root/lib/x86_64-linux-gnu:/mnt/auto/root/python/lib/python2.7/site-packages:/mnt/auto/root/python/lib/python3.6/site-packages',
       'PYTHONUSERBASE': '/mnt/auto/python'
     };
 
@@ -359,7 +359,7 @@ describe('test processNasAutoConfiguration', ()=> {
     });
 
     const envs = {
-      'LD_LIBRARY_PATH': '/mnt/auto/root/usr/local/lib:/mnt/auto/root/usr/lib:/mnt/auto/root/usr/lib/x86_64-linux-gnu:/mnt/auto/root/usr/lib64:/mnt/auto/root/lib:/mnt/auto/root/lib/x86_64-linux-gnu',
+      'LD_LIBRARY_PATH': '/mnt/auto/root/usr/local/lib:/mnt/auto/root/usr/lib:/mnt/auto/root/usr/lib/x86_64-linux-gnu:/mnt/auto/root/usr/lib64:/mnt/auto/root/lib:/mnt/auto/root/lib/x86_64-linux-gnu:/mnt/auto/root/python/lib/python2.7/site-packages:/mnt/auto/root/python/lib/python3.6/site-packages',
       'NODE_PATH': '/mnt/auto/node_modules:/usr/local/lib/node_modules'
     };
 

--- a/test/install/env.test.js
+++ b/test/install/env.test.js
@@ -18,7 +18,7 @@ describe('install_env', ()=>{
 
     expect(envs).to.have.property('PATH', '/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code:/code/node_modules/.bin:/code/.fun/python/bin:/code/.fun/node_modules/.bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin');
     expect(envs).to.have.property('PYTHONUSERBASE', '/code/.fun/python');
-    expect(envs).to.have.property('LD_LIBRARY_PATH', '/code/.fun/root/usr/local/lib:/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code/.fun/root/lib:/code/.fun/root/lib/x86_64-linux-gnu:/code:/code/lib:/usr/local/lib');
+    expect(envs).to.have.property('LD_LIBRARY_PATH', '/code/.fun/root/usr/local/lib:/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code/.fun/root/lib:/code/.fun/root/lib/x86_64-linux-gnu:/code/.fun/root/python/lib/python2.7/site-packages:/code/.fun/root/python/lib/python3.6/site-packages:/code:/code/lib:/usr/local/lib');
     expect(envs).to.have.property('NODE_PATH', '/code/node_modules:/usr/local/lib/node_modules');
   });
 
@@ -27,7 +27,7 @@ describe('install_env', ()=>{
       'LD_LIBRARY_PATH': '/usr/lib'
     });
 
-    expect(envs).to.have.property('LD_LIBRARY_PATH', '/usr/lib:/code/.fun/root/usr/local/lib:/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code/.fun/root/lib:/code/.fun/root/lib/x86_64-linux-gnu:/code:/code/lib:/usr/local/lib');
+    expect(envs).to.have.property('LD_LIBRARY_PATH', '/usr/lib:/code/.fun/root/usr/local/lib:/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code/.fun/root/lib:/code/.fun/root/lib/x86_64-linux-gnu:/code/.fun/root/python/lib/python2.7/site-packages:/code/.fun/root/python/lib/python3.6/site-packages:/code:/code/lib:/usr/local/lib');
   });
 
   it('with_PATH', () => {
@@ -58,8 +58,7 @@ describe('install_env', ()=>{
     const envs = addEnv({
       'LD_LIBRARY_PATH': '/usr/lib:/usr/lib:/usr/lib'
     });
-
-    expect(envs).to.have.property('LD_LIBRARY_PATH', '/usr/lib:/code/.fun/root/usr/local/lib:/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code/.fun/root/lib:/code/.fun/root/lib/x86_64-linux-gnu:/code:/code/lib:/usr/local/lib');
+    expect(envs).to.have.property('LD_LIBRARY_PATH', '/usr/lib:/code/.fun/root/usr/local/lib:/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code/.fun/root/usr/lib64:/code/.fun/root/lib:/code/.fun/root/lib/x86_64-linux-gnu:/code/.fun/root/python/lib/python2.7/site-packages:/code/.fun/root/python/lib/python3.6/site-packages:/code:/code/lib:/usr/local/lib');
   });
 
   it('with NODE_PATH', () => {


### PR DESCRIPTION
1. LD_LIBRARY_PATH 增加 python lib path， 比如 ujson 这种库， 是直接c 语言开发的， so 文件直接为 lib 目录，这个需要放置在  LD_LIBRARY_PATH
2. 修复 fun package 用户 input bucket 的 bug