### PR TITLE
fix: PHP Laravel character escaping

### DIFF
--- a/src/lib/frameworks/laravel.js
+++ b/src/lib/frameworks/laravel.js
@@ -72,7 +72,7 @@ server {
       proxy_read_timeout 180;
   }
 
-  location ~ /\.(?!well-known).* {
+  location ~ /\\.(?!well-known).* {
       deny all;
   }
 }


### PR DESCRIPTION
#961 