### PR TITLE
修正配置文件中 keepalive_timeout

### DIFF
--- a/src/lib/frameworks/laravel.js
+++ b/src/lib/frameworks/laravel.js
@@ -42,6 +42,7 @@ const laravel = {
           'mode': '0755',
           'backup': false,
           'content': `
+keepalive_timeout 1200s;
 server {
   listen 9000;
   server_name localhost;


### PR DESCRIPTION
修正配置文件中 keepalive_timeout，不添加此项有几率出现错误
`Process exited unexpectedly berfore completing request`