### PR TITLE
fix api invoke event pass fail bug

### DIFF
--- a/src/lib/docker.js
+++ b/src/lib/docker.js
@@ -492,7 +492,7 @@ async function generateDockerEnvs(baseDir, serviceName, serviceProps, functionNa
     'FC_MEMORY_SIZE': functionProps.MemorySize || 128,
     'FC_TIMEOUT': functionProps.Timeout || 3,
     'FC_INITIALIZER': functionProps.Initializer,
-    'FC_INITIALIZATION_TIMEOUT': functionProps.InitializationTimeout || 3,
+    'FC_INITIALIZATIONTIMEOUT': functionProps.InitializationTimeout || 3,
     'FC_SERVICE_NAME': serviceName,
     'FC_SERVICE_LOG_PROJECT': ((serviceProps || {}).LogConfig || {}).Project,
     'FC_SERVICE_LOG_STORE': ((serviceProps || {}).LogConfig || {}).Logstore

--- a/src/lib/local/api-invoke.js
+++ b/src/lib/local/api-invoke.js
@@ -19,18 +19,20 @@ class ApiInvoke extends Invoke {
 
   async init() {
     await super.init();
-
     this.envs = await docker.generateDockerEnvs(this.baseDir, this.serviceName, this.serviceRes.Properties, this.functionName, this.functionProps, this.debugPort, null, this.nasConfig, true, this.debugIde, this.debugArgs);
-    this.cmd = docker.generateDockerCmd(this.runtime, false, {
-      functionProps: this.functionProps,
-      httpMode: true
-    });
   }
 
   async doInvoke(req, res) {
-
     const containerName = docker.generateRamdomContainerName();
     const event = await getHttpRawBody(req);
+    var invokeInitializer = false;
+    if (this.functionProps.Initializer) { invokeInitializer = true; }
+    this.cmd = docker.generateDockerCmd(this.runtime, false, {
+      functionProps: this.functionProps,
+      httpMode: true,
+      invokeInitializer,
+      event
+    });
 
     const outputStream = new streams.WritableStream();
     const errorStream = new streams.WritableStream();

--- a/src/lib/local/http.js
+++ b/src/lib/local/http.js
@@ -241,7 +241,7 @@ function getFcReqHeaders(headers, reqeustId, envs) {
   fcHeaders['x-fc-function-name'] = headers['x-fc-function-name'] ? headers['x-fc-function-name'] : envs['FC_FUNCTION_NAME'] || 'fc-docker';
   fcHeaders['x-fc-function-memory'] = headers['x-fc-function-memory'] ? headers['x-fc-function-memory'] : envs['FC_MEMORY_SIZE'];
   fcHeaders['x-fc-function-timeout'] = headers['x-fc-function-timeout'] ? headers['x-fc-function-timeout'] : envs['FC_TIMEOUT'];
-  fcHeaders['x-fc-initialization-timeout'] = headers['x-fc-initialization-timeout'] ? headers['x-fc-initialization-timeout'] : envs['FC_INITIALIZATION_TIMEOUT'];
+  fcHeaders['x-fc-initialization-timeout'] = headers['x-fc-initialization-timeout'] ? headers['x-fc-initialization-timeout'] : envs['FC_INITIALIZATIONTIMEOUT'];
   fcHeaders['x-fc-function-initializer'] = headers['x-fc-function-initializer'] ? headers['x-fc-function-initializer'] : envs['FC_INITIALIZER'];
   fcHeaders['x-fc-function-handler'] = headers['x-fc-function-handler'] ? headers['x-fc-function-handler'] : envs['FC_HANDLER'];
   fcHeaders['x-fc-access-key-id'] = headers['x-fc-access-key-id'] ? headers['x-fc-access-key-id'] : envs['FC_ACCESS_KEY_ID'];


### PR DESCRIPTION
1. 修复 api-invoke 时 event 传输失败 bug
2. 将  FC_INITIALIZATION_TIMEOUT 环境变量名称修改回 FC_INITIALIZATIONTIMEOUT，适配 fc-docker 镜像版本 1.9.13