### PR TITLE
fix api invoke cmd args too long problem;add response when api invoke…

### DIFF
--- a/src/lib/docker.js
+++ b/src/lib/docker.js
@@ -257,6 +257,7 @@ function genDockerCmdOfCustomContainer(functionProps) {
   }
   return [];
 }
+// dockerode exec 在 windows 上有问题，用 exec 的 stdin 传递事件，当调用 stream.end() 时，会直接导致 exec 退出，且 ExitCode 为 null
 function genDockerCmdOfNonCustomContainer(functionProps, httpMode, invokeInitializer = true, event = null) {
   const cmd = ['-h', functionProps.Handler];
 
@@ -291,7 +292,6 @@ function genDockerCmdOfNonCustomContainer(functionProps, httpMode, invokeInitial
   return cmd;
 }
 
-// dockerode exec 在 windows 上有问题，用 exec 的 stdin 传递事件，当调用 stream.end() 时，会直接导致 exec 退出，且 ExitCode 为 null
 function generateDockerCmd(runtime, isLocalStartInit, { functionProps, httpMode, invokeInitializer = true, event = null }) {
   if (isCustomContainerRuntime(runtime)) {
     return genDockerCmdOfCustomContainer(functionProps);

--- a/src/lib/local/http-invoke.js
+++ b/src/lib/local/http-invoke.js
@@ -229,7 +229,6 @@ class HttpInvoke extends Invoke {
             });
 
             this._invokeInitializer = false;
-            this.response(outputStream, errorStream, res);
           } catch (error) {
             console.log(red('Fun Error: ', errorStream.toString()));
 
@@ -253,6 +252,7 @@ class HttpInvoke extends Invoke {
             }
             return;
           }
+          this.response(outputStream, errorStream, res);
         }
         debug('http doInvoke exec end, begin to response');
       }


### PR DESCRIPTION
新版本在 api-invoke 时未将 event 参数以 stdin 的形式传入，因此出现命令行过长的错误，目前已经修复；
增加了对 api-invoke 启动容器失败场景的处理，当 api-invoke 启动容器失败时，增加错误处理，使得程序不会意外退出。