### PR TITLE
fix: initializer not invoked in nodejs12 runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "fc-docker": {
-    "version": "1.9.13",
+    "version": "1.9.14",
     "registry_default": "registry.cn-beijing.aliyuncs.com",
     "registry_mirrors": [
       "registry.cn-beijing.aliyuncs.com",
@@ -32,6 +32,7 @@
     ]
   },
   "scripts": {
+    "help": "make -help",
     "test": "make test",
     "binary": "make binary",
     "postinstall": "node -e \"try { require('./src/lib/check-version'); } catch(e) { if (e.message && e.message.includes('Cannot find module')) { require('./lib/check-version'); } else { throw e; }}\"",

--- a/src/lib/docker-opts.js
+++ b/src/lib/docker-opts.js
@@ -70,7 +70,7 @@ async function resolveDockerRegistry() {
   return DOCKER_REGISTRY_CACHE;
 }
 
-const IMAGE_VERSION = process.env.FC_DOCKER_VERSION || pkg['fc-docker'].version || '1.9.13';
+const IMAGE_VERSION = process.env.FC_DOCKER_VERSION || pkg['fc-docker'].version || '1.9.14';
 
 async function resolveRuntimeToDockerImage(runtime, isBuild) {
   if (runtimeImageMap[runtime]) {


### PR DESCRIPTION
fix: initializer not invoked in nodejs12 runtime by update fc docker image versioin to 1.9.14

See: https://github.com/DevDengChao/aliyun-fc-nodejs12-runtime-initializer-not-invoked-sample-project